### PR TITLE
Add missing Node shebang to binary

### DIFF
--- a/bin/eslint-doc-generator.ts
+++ b/bin/eslint-doc-generator.ts
@@ -1,3 +1,6 @@
+#!/usr/bin/env node
+/* eslint node/shebang:"off" -- shebang needed so compiled code gets interpreted as JS */
+
 import { run } from '../lib/cli.js';
 
 try {


### PR DESCRIPTION
Otherwise `yarn eslint-doc-generator` or `npm exec eslint-doc-generator` might print out garbage when attempting to run this binary.