### PR TITLE
Use recommended config emoji in rules list header when no custom configs present

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,18 +85,20 @@ Generated rules table in `README.md`:
 
 <!-- begin rules list -->
 
-| Rule                                                           | Description                                       | 💼            | 🔧  | 💡  | 💭  |
-| -------------------------------------------------------------- | ------------------------------------------------- | ------------- | --- | --- | --- |
-| [max-nested-describe](docs/rules/max-nested-describe.md)       | Enforces a maximum depth to nested describe calls |               |     |     |     |
-| [no-alias-methods](docs/rules/no-alias-methods.md)             | Disallow alias methods                            | ✅ ![style][] | 🔧  |     |     |
-| [no-commented-out-tests](docs/rules/no-commented-out-tests.md) | Disallow commented out tests                      | ✅            |     |     |     |
+| Rule                                                           | Description                                       | ✅  | 🔧  | 💡  | 💭  |
+| -------------------------------------------------------------- | ------------------------------------------------- | --- | --- | --- | --- |
+| [max-nested-describe](docs/rules/max-nested-describe.md)       | Enforces a maximum depth to nested describe calls |     |     |     |     |
+| [no-alias-methods](docs/rules/no-alias-methods.md)             | Disallow alias methods                            | ✅  | 🔧  |     |     |
+| [no-commented-out-tests](docs/rules/no-commented-out-tests.md) | Disallow commented out tests                      | ✅  |     |     |     |
 
 <!-- end rules list -->
 
 ...
+```
 
-<!-- define the badge for any custom configs (besides `recommended`, `all`) here -->
+If you have any custom configs (besides `all`, `recommended`), you'll need to define a badge for them at the bottom of your `README.md`. Here's a badge for a custom `style` config that displays in blue:
 
+```md
 [style]: https://img.shields.io/badge/-style-blue.svg
 ```
 

--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -58,6 +58,13 @@ function buildRuleRow(
   return columns;
 }
 
+function hasCustomConfigs(plugin: Plugin) {
+  return Object.keys(plugin.configs || {}).some(
+    // Ignore the common configs.
+    (configName) => !['all', 'recommended'].includes(configName)
+  );
+}
+
 function generateRulesListMarkdown(
   details: RuleDetails[],
   plugin: Plugin,
@@ -70,7 +77,7 @@ function generateRulesListMarkdown(
   const listHeaderRow = [
     'Rule',
     'Description',
-    EMOJI_CONFIGS,
+    hasCustomConfigs(plugin) ? EMOJI_CONFIGS : EMOJI_CONFIG_RECOMMENDED, // If there are custom configs, use the general config emoji.
     EMOJI_FIXABLE,
     EMOJI_HAS_SUGGESTIONS,
   ];

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -3,7 +3,7 @@
 exports[`generator #generate adds extra column to rules table for TypeScript rules updates the documentation 1`] = `
 "<!-- begin rules list -->
 
-| Rule                           | Description            | 💼  | 🔧  | 💡  | 💭  |
+| Rule                           | Description            | ✅  | 🔧  | 💡  | 💭  |
 | ------------------------------ | ---------------------- | --- | --- | --- | --- |
 | [no-bar](docs/rules/no-bar.md) | Description of no-bar. |     |     |     | 💭  |
 | [no-foo](docs/rules/no-foo.md) | Description of no-foo. |     |     |     |     |
@@ -15,7 +15,7 @@ exports[`generator #generate adds extra column to rules table for TypeScript rul
 exports[`generator #generate deprecated rules updates the documentation 1`] = `
 "<!-- begin rules list -->
 
-| Rule                           | Description  | 💼  | 🔧  | 💡  |
+| Rule                           | Description  | ✅  | 🔧  | 💡  |
 | ------------------------------ | ------------ | --- | --- | --- |
 | [no-bar](docs/rules/no-bar.md) | Description. | ❌  |     |     |
 | [no-baz](docs/rules/no-baz.md) | Description. | ❌  |     |     |
@@ -125,7 +125,7 @@ details
 exports[`generator #generate uses prettier config from package.json updates the documentation 1`] = `
 "<!-- begin rules list -->
 
-| Rule                           | Description            | 💼  | 🔧  | 💡  |
+| Rule                           | Description            | ✅  | 🔧  | 💡  |
 | ------------------------------ | ---------------------- | --- | --- | --- |
 | [no-foo](docs/rules/no-foo.md) | Description of no-foo. |     |     |     |
 


### PR DESCRIPTION
The general configs emoji should only be used when multiple configs are present.