### PR TITLE
Use `recommended` config emoji in rule doc when rule is only in that config

### DIFF
--- a/lib/configs.ts
+++ b/lib/configs.ts
@@ -1,0 +1,40 @@
+import type { Plugin } from './types.js';
+
+export function hasCustomConfigs(plugin: Plugin) {
+  return Object.keys(plugin.configs || {}).some(
+    // Ignore the common configs.
+    (configName) => !['all', 'recommended'].includes(configName)
+  );
+}
+
+/**
+ * Get config names that a given rule belongs to.
+ */
+export function getConfigsForRule(
+  ruleName: string,
+  plugin: Plugin,
+  pluginPrefix: string
+) {
+  const { configs } = plugin;
+  const configNames: Array<keyof typeof configs> = [];
+  let configName: keyof typeof configs;
+
+  for (configName in configs) {
+    const config = configs[configName];
+    const value = config.rules[`${pluginPrefix}/${ruleName}`];
+    const isEnabled = [2, 'error'].includes(value);
+
+    if (isEnabled) {
+      configNames.push(configName);
+    }
+  }
+
+  return configNames.sort();
+}
+
+/**
+ * Convert list of configs to string list of formatted names.
+ */
+export function configNamesToList(configNames: readonly string[]) {
+  return `\`${configNames.join('`, `')}\``;
+}

--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -7,6 +7,7 @@ import {
   EMOJI_REQUIRES_TYPE_CHECKING,
   EMOJI_CONFIGS,
 } from './emojis.js';
+import { hasCustomConfigs } from './configs.js';
 import type { Plugin, RuleDetails } from './types.js';
 
 function getConfigurationColumnValueForRule(
@@ -56,13 +57,6 @@ function buildRuleRow(
     columns.push(rule.requiresTypeChecking ? EMOJI_REQUIRES_TYPE_CHECKING : '');
   }
   return columns;
-}
-
-function hasCustomConfigs(plugin: Plugin) {
-  return Object.keys(plugin.configs || {}).some(
-    // Ignore the common configs.
-    (configName) => !['all', 'recommended'].includes(configName)
-  );
 }
 
 function generateRulesListMarkdown(

--- a/lib/rule-notices.ts
+++ b/lib/rule-notices.ts
@@ -4,11 +4,14 @@ import {
   EMOJI_FIXABLE,
   EMOJI_HAS_SUGGESTIONS,
   EMOJI_CONFIGS,
+  EMOJI_CONFIG_RECOMMENDED,
 } from './emojis.js';
+import { getConfigsForRule, configNamesToList } from './configs.js';
 import type { RuleModule, Plugin } from './types.js';
 
 enum MESSAGE_TYPE {
   CONFIGS = 'configs',
+  CONFIG_RECOMMENDED = 'configRecommended',
   DEPRECATED = 'deprecated',
   FIXABLE = 'fixable',
   HAS_SUGGESTIONS = 'hasSuggestions',
@@ -16,42 +19,11 @@ enum MESSAGE_TYPE {
 
 const MESSAGES = {
   [MESSAGE_TYPE.CONFIGS]: `${EMOJI_CONFIGS} This rule is enabled in the following configs:`, // TODO: include link to configs in the plugin's README.
+  [MESSAGE_TYPE.CONFIG_RECOMMENDED]: `${EMOJI_CONFIG_RECOMMENDED} This rule is enabled in the \`recommended\` config.`, // TODO: include link to configs in the plugin's README.
   [MESSAGE_TYPE.DEPRECATED]: `${EMOJI_DEPRECATED} This rule is deprecated.`,
   [MESSAGE_TYPE.FIXABLE]: `${EMOJI_FIXABLE} This rule is automatically fixable using the \`--fix\` [option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.`,
   [MESSAGE_TYPE.HAS_SUGGESTIONS]: `${EMOJI_HAS_SUGGESTIONS} This rule provides [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions) that can be applied manually.`,
 };
-
-/**
- * Get config names that a given rule belongs to.
- */
-function getConfigsForRule(
-  ruleName: string,
-  plugin: Plugin,
-  pluginPrefix: string
-) {
-  const { configs } = plugin;
-  const configNames: Array<keyof typeof configs> = [];
-  let configName: keyof typeof configs;
-
-  for (configName in configs) {
-    const config = configs[configName];
-    const value = config.rules[`${pluginPrefix}/${ruleName}`];
-    const isEnabled = [2, 'error'].includes(value);
-
-    if (isEnabled) {
-      configNames.push(configName);
-    }
-  }
-
-  return configNames.sort();
-}
-
-/**
- * Convert list of configs to string list of formatted names.
- */
-function configNamesToList(configNames: readonly string[]) {
-  return `\`${configNames.join('`, `')}\``;
-}
 
 /**
  * Convert list of rule names to string list of links.
@@ -65,11 +37,15 @@ function ruleNamesToList(ruleNames: readonly string[]) {
 /**
  * Determine which notices should and should not be included at the top of a rule doc.
  */
-function getNoticesForRule(rule: RuleModule) {
+function getNoticesForRule(rule: RuleModule, configsEnabled: string[]) {
   const notices: {
     [key in MESSAGE_TYPE]: boolean;
   } = {
-    [MESSAGE_TYPE.CONFIGS]: !rule.meta.deprecated,
+    [MESSAGE_TYPE.CONFIGS]:
+      configsEnabled.length > 1 ||
+      (configsEnabled.length === 1 && configsEnabled[0] !== 'recommended'),
+    [MESSAGE_TYPE.CONFIG_RECOMMENDED]:
+      configsEnabled.length === 1 && configsEnabled[0] === 'recommended',
     [MESSAGE_TYPE.DEPRECATED]: rule.meta.deprecated || false,
     [MESSAGE_TYPE.FIXABLE]: Boolean(rule.meta.fixable),
     [MESSAGE_TYPE.HAS_SUGGESTIONS]: rule.meta.hasSuggestions || false,
@@ -89,7 +65,8 @@ function getRuleNoticeLines(
   const lines: string[] = [];
 
   const rule = plugin.rules[ruleName];
-  const notices = getNoticesForRule(rule);
+  const configsEnabled = getConfigsForRule(ruleName, plugin, pluginPrefix);
+  const notices = getNoticesForRule(rule, configsEnabled);
   let messageType: keyof typeof notices;
 
   for (messageType in notices) {
@@ -104,14 +81,11 @@ function getRuleNoticeLines(
 
     if (messageType === MESSAGE_TYPE.CONFIGS) {
       // This notice should have a list of the rule's configs.
-      const configsEnabled = getConfigsForRule(ruleName, plugin, pluginPrefix);
-      if (configsEnabled.length > 0) {
-        const message = `${MESSAGES[MESSAGE_TYPE.CONFIGS]} ${configNamesToList(
-          configsEnabled
-        )}.`;
+      const message = `${MESSAGES[MESSAGE_TYPE.CONFIGS]} ${configNamesToList(
+        configsEnabled
+      )}.`;
 
-        lines.push(message);
-      }
+      lines.push(message);
     } else if (messageType === MESSAGE_TYPE.DEPRECATED) {
       // This notice should include links to the replacement rule(s) if available.
       const message =

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -52,6 +52,26 @@ exports[`generator #generate deprecated rules updates the documentation 4`] = `
 "
 `;
 
+exports[`generator #generate only a \`recommended\` config updates the documentation 1`] = `
+"<!-- begin rules list -->
+
+| Rule                           | Description  | ✅  | 🔧  | 💡  |
+| ------------------------------ | ------------ | --- | --- | --- |
+| [no-foo](docs/rules/no-foo.md) | Description. | ✅  |     |     |
+
+<!-- end rules list -->
+"
+`;
+
+exports[`generator #generate only a \`recommended\` config updates the documentation 2`] = `
+"# Description. (\`no-foo\`)
+
+✅ This rule is enabled in the \`recommended\` config.
+
+<!-- end rule header -->
+"
+`;
+
 exports[`generator #generate successful updates the documentation 1`] = `
 "# eslint-plugin-test
 

--- a/test/lib/generator-test.ts
+++ b/test/lib/generator-test.ts
@@ -158,6 +158,57 @@ describe('generator', function () {
       });
     });
 
+    describe('only a `recommended` config', function () {
+      beforeEach(function () {
+        mockFs({
+          'package.json': JSON.stringify({
+            name: 'eslint-plugin-test',
+            main: 'index.js',
+            type: 'module',
+          }),
+
+          'index.js': `
+            export default {
+              rules: {
+                'no-foo': {
+                  meta: { docs: { description: 'Description.' }, },
+                  create(context) {}
+                },
+              },
+              configs: {
+                recommended: {
+                  rules: {
+                    'test/no-foo': 'error',
+                  }
+                }
+              }
+            };`,
+
+          'README.md': '<!-- begin rules list --><!-- end rules list -->',
+
+          'docs/rules/no-foo.md': '',
+
+          // Needed for some of the test infrastructure to work.
+          node_modules: mockFs.load(
+            resolve(__dirname, '..', '..', 'node_modules')
+          ),
+        });
+      });
+
+      afterEach(function () {
+        mockFs.restore();
+        jest.resetModules();
+      });
+
+      it('updates the documentation', async function () {
+        await generate('.');
+
+        expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
+
+        expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
+      });
+    });
+
     describe('deprecated rules', function () {
       beforeEach(function () {
         mockFs({


### PR DESCRIPTION
Show:

✅ This rule is enabled in the \`recommended\` config.

Instead of:

💼 This rule is enabled in the following configs: \`recommended\`.
