### PR TITLE
When rule doc is missing marker comment, remove old title before adding new one

### DIFF
--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -33,6 +33,11 @@ function replaceOrCreateHeader(
 ) {
   const markerLineIndex = lines.indexOf(marker);
 
+  if (markerLineIndex === -1 && lines.length > 0 && lines[0].startsWith('# ')) {
+    // No marker present so delete any existing title before we add the new one.
+    lines.splice(0, 1);
+  }
+
   // Replace header section (or create at top if missing).
   lines.splice(0, markerLineIndex + 1, ...newHeaderLines);
 }

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -78,6 +78,21 @@ exports[`generator #generate only a \`recommended\` config updates the documenta
 "
 `;
 
+exports[`generator #generate rule doc without header marker but pre-existing header updates the documentation 1`] = `
+"# Description. (\`no-foo\`)
+
+✅ This rule is enabled in the \`recommended\` config.
+
+<!-- end rule header -->
+
+Pre-existing notice about the rule being recommended.
+
+## Rule details
+
+Details.
+"
+`;
+
 exports[`generator #generate successful updates the documentation 1`] = `
 "# eslint-plugin-test
 


### PR DESCRIPTION
Fixes #9.