### PR TITLE
Allow deprecated rules to forgo a doc file or description

### DIFF
--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -41,6 +41,17 @@ exports[`generator #generate adds extra column to rules table for TypeScript rul
 "
 `;
 
+exports[`generator #generate deprecated rule with no rule doc nor meta.docs updates the documentation 1`] = `
+"<!-- begin rules list -->
+
+| Rule                           | Description | ✅  | 🔧  | 💡  |
+| ------------------------------ | ----------- | --- | --- | --- |
+| [no-foo](docs/rules/no-foo.md) |             | ❌  |     |     |
+
+<!-- end rules list -->
+"
+`;
+
 exports[`generator #generate deprecated rules updates the documentation 1`] = `
 "<!-- begin rules list -->
 

--- a/test/lib/generator-test.ts
+++ b/test/lib/generator-test.ts
@@ -331,6 +331,47 @@ describe('generator', function () {
       });
     });
 
+    describe('deprecated rule with no rule doc nor meta.docs', function () {
+      beforeEach(function () {
+        mockFs({
+          'package.json': JSON.stringify({
+            name: 'eslint-plugin-test',
+            main: 'index.js',
+            type: 'module',
+          }),
+
+          'index.js': `
+            export default {
+              rules: {
+                'no-foo': {
+                  meta: { deprecated: true, }, // No docs specified.
+                  create(context) {}
+                },
+              },
+              configs: {}
+            };`,
+
+          'README.md': '<!-- begin rules list --><!-- end rules list -->',
+
+          // Needed for some of the test infrastructure to work.
+          node_modules: mockFs.load(
+            resolve(__dirname, '..', '..', 'node_modules')
+          ),
+        });
+      });
+
+      afterEach(function () {
+        mockFs.restore();
+        jest.resetModules();
+      });
+
+      it('updates the documentation', async function () {
+        await generate('.');
+
+        expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
+      });
+    });
+
     describe('uses prettier config from package.json', function () {
       beforeEach(function () {
         mockFs({


### PR DESCRIPTION
Support use case for eslint-plugin-unicorn.

Fixes #15.