### PR TITLE
Throw exception when plugin does not export a `rules` object

### DIFF
--- a/lib/package-json.ts
+++ b/lib/package-json.ts
@@ -29,6 +29,9 @@ export async function loadPlugin(path: string): Promise<Plugin> {
     pluginPackageJson.main?.endsWith('/') ? 'index.js' : ''
   );
   const { default: plugin } = await import(pluginEntryPoint);
+  if (!plugin.rules) {
+    throw new Error('Could not find exported `rules` object in ESLint plugin.');
+  }
   return plugin;
 }
 

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -22,6 +22,8 @@ exports[`generator #generate No configs found does not crash 2`] = `
 "
 `;
 
+exports[`generator #generate No exported rules object found throws an error 1`] = `"Could not find exported \`rules\` object in ESLint plugin."`;
+
 exports[`generator #generate README missing rule list markers and no rules section throws an error 1`] = `"README.md is missing rules list markers: <!-- begin rules list --><!-- end rules list -->"`;
 
 exports[`generator #generate README missing rule list markers but with rules section adds rule list markers to rule section 1`] = `

--- a/test/lib/generator-test.ts
+++ b/test/lib/generator-test.ts
@@ -830,7 +830,7 @@ describe('generator', function () {
             main: 'index.js',
           }),
 
-          'index.js': '',
+          'index.js': 'export default { rules: {} }',
 
           // Needed for some of the test infrastructure to work.
           node_modules: mockFs.load(
@@ -926,6 +926,36 @@ describe('generator', function () {
         await generate('.');
         expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
         expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
+      });
+    });
+
+    describe('No exported rules object found', function () {
+      beforeEach(function () {
+        mockFs({
+          'package.json': JSON.stringify({
+            name: 'eslint-plugin-test',
+            main: 'index.js',
+            type: 'module',
+          }),
+
+          'index.js': 'export default {};',
+
+          'README.md': '<!-- begin rules list --><!-- end rules list -->',
+
+          'docs/rules/no-foo.md': '',
+
+          // Needed for some of the test infrastructure to work.
+          node_modules: mockFs.load(
+            resolve(__dirname, '..', '..', 'node_modules')
+          ),
+        });
+      });
+      afterEach(function () {
+        mockFs.restore();
+        jest.resetModules();
+      });
+      it('throws an error', async function () {
+        await expect(generate('.')).rejects.toThrowErrorMatchingSnapshot();
       });
     });
   });


### PR DESCRIPTION
Fixes #13.