### PR TITLE
Handle string `extends` from ESLint config, deprecated/function-style rules, missing rule descriptions (and use actual ESLint types to detect issues like these)

### DIFF
--- a/lib/config-resolution.ts
+++ b/lib/config-resolution.ts
@@ -32,9 +32,13 @@ async function resolveConfigRules(config: Config): Promise<Rules> {
   return rules;
 }
 
-async function resolveConfigExtends(extendItems: string[]): Promise<Rules> {
+async function resolveConfigExtends(
+  extendItems: string[] | string
+): Promise<Rules> {
   const rules: Rules = {};
-  for (const extend of extendItems) {
+  for (const extend of Array.isArray(extendItems)
+    ? extendItems
+    : [extendItems]) {
     if (
       ['plugin:', 'eslint:'].some((prefix) => extend.startsWith(prefix)) ||
       !existsSync(extend)

--- a/lib/package-json.ts
+++ b/lib/package-json.ts
@@ -30,9 +30,6 @@ export async function loadPlugin(path: string): Promise<Plugin> {
     pluginPackageJson.main?.endsWith('/') ? 'index.js' : ''
   );
   const { default: plugin } = await importAbs(pluginEntryPoint);
-  if (!plugin.rules) {
-    throw new Error('Could not find exported `rules` object in ESLint plugin.');
-  }
   return plugin;
 }
 

--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -48,7 +48,7 @@ function buildRuleRow(
 ): string[] {
   const columns = [
     `[${rule.name}](docs/rules/${rule.name}.md)`,
-    rule.description,
+    rule.description || '',
     getConfigurationColumnValueForRule(rule, configsToRules, pluginPrefix),
     rule.fixable ? EMOJI_FIXABLE : '',
     rule.hasSuggestions ? EMOJI_HAS_SUGGESTIONS : '',

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,29 +1,22 @@
 import type { TSESLint, JSONSchema } from '@typescript-eslint/utils';
 
-export type RuleModule = TSESLint.RuleModule<string, unknown[]> & {
-  meta: Required<Pick<TSESLint.RuleMetaData<string>, 'docs'>>;
-};
+// Standard ESLint types.
 
-type RuleSeverity = 'off' | 'error' | 'warn' | 0 | 1 | 2;
+export type RuleModule = TSESLint.RuleModule<string, unknown[]>;
 
-export type Rules = Record<string, RuleSeverity | [RuleSeverity, unknown]>;
+export type Rules = TSESLint.Linter.RulesRecord;
 
-export type Config = {
-  extends?: string[];
-  rules?: Rules;
-  overrides?: { rules?: Rules; extends?: [] }[];
-};
+export type Config = TSESLint.Linter.Config;
+
+export type Plugin = TSESLint.Linter.Plugin;
+
+// Custom types.
 
 export type ConfigsToRules = Record<string, Rules>;
 
-export type Plugin = {
-  rules: Record<string, RuleModule>;
-  configs?: Record<string, Config>;
-};
-
 export interface RuleDetails {
   name: string;
-  description: string;
+  description?: string; // Rule might not have a description.
   fixable: boolean;
   hasSuggestions: boolean;
   requiresTypeChecking: boolean;

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -162,6 +162,25 @@ exports[`generator #generate config with overrides generates the documentation 2
 "
 `;
 
+exports[`generator #generate deprecated function-style rule generates the documentation 1`] = `
+"## Rules
+<!-- begin rules list -->
+
+| Rule                           | Description | ✅  | 🔧  | 💡  |
+| ------------------------------ | ----------- | --- | --- | --- |
+| [no-foo](docs/rules/no-foo.md) |             | ✅  |     |     |
+
+<!-- end rules list -->
+"
+`;
+
+exports[`generator #generate deprecated function-style rule generates the documentation 2`] = `
+"# \`test/no-foo\`
+
+<!-- end rule header -->
+"
+`;
+
 exports[`generator #generate deprecated rule with no rule doc nor meta.docs updates the documentation 1`] = `
 "<!-- begin rules list -->
 
@@ -346,6 +365,25 @@ exports[`generator #generate rule doc without header marker but pre-existing hea
 Pre-existing notice about the rule being recommended.
 ## Rule details
 Details."
+`;
+
+exports[`generator #generate rule without a description generates the documentation 1`] = `
+"## Rules
+<!-- begin rules list -->
+
+| Rule                           | Description | ✅  | 🔧  | 💡  |
+| ------------------------------ | ----------- | --- | --- | --- |
+| [no-foo](docs/rules/no-foo.md) |             |     |     |     |
+
+<!-- end rules list -->
+"
+`;
+
+exports[`generator #generate rule without a description generates the documentation 2`] = `
+"# \`test/no-foo\`
+
+<!-- end rule header -->
+"
 `;
 
 exports[`generator #generate rules that are disabled generates the documentation 1`] = `


### PR DESCRIPTION
Fixes #69.