### PR TITLE
Improve section header detection

### DIFF
--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -46,7 +46,7 @@ export function findSectionHeader(
   str: string
 ): string | undefined {
   // Get all the matching strings.
-  const regexp = new RegExp(`##.* ${str}.*\n`, 'gi');
+  const regexp = new RegExp(`## .*${str}.*\n`, 'gi');
   const sectionPotentialMatches = [...markdown.matchAll(regexp)].map(
     (match) => match[0]
   );

--- a/test/lib/markdown-test.ts
+++ b/test/lib/markdown-test.ts
@@ -4,17 +4,23 @@ import { findSectionHeader } from '../../lib/markdown.js';
 describe('markdown', function () {
   describe('#findSectionHeader', function () {
     it('handles standard section title', function () {
-      expect(findSectionHeader('## Rules\n', 'rules')).toBe('## Rules\n');
+      const title = '## Rules\n';
+      expect(findSectionHeader(title, 'rules')).toBe(title);
     });
 
     it('handles section title with leading emoji', function () {
-      expect(findSectionHeader('## 🍟 Rules\n', 'rules')).toBe('## 🍟 Rules\n');
+      const title = '## 🍟 Rules\n';
+      expect(findSectionHeader(title, 'rules')).toBe(title);
+    });
+
+    it('handles section title with html', function () {
+      const title = "## <a name='Rules'></a>Rules\n";
+      expect(findSectionHeader(title, 'rules')).toBe(title);
     });
 
     it('handles sentential section title', function () {
-      expect(findSectionHeader('## List of supported rules\n', 'rules')).toBe(
-        '## List of supported rules\n'
-      );
+      const title = '## List of supported rules\n';
+      expect(findSectionHeader(title, 'rules')).toBe(title);
     });
 
     it('handles doc with multiple sections', function () {


### PR DESCRIPTION
Make sure we can detect the rules section in the README like this example from eslint-plugin-eslint-plugin:
```md
## <a name='Rules'></a>Rules
```