### PR TITLE
Hide empty columns from rules list

### DIFF
--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -60,7 +60,6 @@ export async function generate(path: string) {
 
   const pathTo = {
     readme: resolve(path, 'README.md'),
-    rules: resolve(path, 'src', 'rules'),
     docs: resolve(path, 'docs'),
   };
 

--- a/lib/legend.ts
+++ b/lib/legend.ts
@@ -17,13 +17,21 @@ const MESSAGES = {
   [COLUMN_TYPE.REQUIRES_TYPE_CHECKING]: `${EMOJI_REQUIRES_TYPE_CHECKING} Requires type information.`,
 };
 
-export function generateLegend(columns: COLUMN_TYPE[]) {
-  return columns
-    .flatMap((column) => {
-      if (column === COLUMN_TYPE.RULE || column === COLUMN_TYPE.DESCRIPTION) {
-        return []; // No need for a legend for these columns.
+export function generateLegend(columns: Record<COLUMN_TYPE, boolean>) {
+  return (Object.entries(columns) as [COLUMN_TYPE, boolean][])
+    .flatMap(([columnType, enabled]) => {
+      if (!enabled) {
+        // This column is turned off.
+        return [];
       }
-      return [MESSAGES[column]];
+      if (
+        columnType === COLUMN_TYPE.NAME ||
+        columnType === COLUMN_TYPE.DESCRIPTION
+      ) {
+        // No need for a legend for these columns.
+        return [];
+      }
+      return [MESSAGES[columnType]];
     })
     .join('\\\n'); // Back slash ensures these end up displayed on separate lines.
 }

--- a/lib/rule-list-columns.ts
+++ b/lib/rule-list-columns.ts
@@ -16,8 +16,8 @@ export enum COLUMN_TYPE {
   DESCRIPTION = 'description',
   FIXABLE = 'fixable',
   HAS_SUGGESTIONS = 'hasSuggestions',
+  NAME = 'rules',
   REQUIRES_TYPE_CHECKING = 'requiresTypeChecking',
-  RULE = 'rules',
 }
 
 export const COLUMN_HEADER = {
@@ -27,33 +27,37 @@ export const COLUMN_HEADER = {
   [COLUMN_TYPE.DESCRIPTION]: 'Description',
   [COLUMN_TYPE.FIXABLE]: EMOJI_FIXABLE,
   [COLUMN_TYPE.HAS_SUGGESTIONS]: EMOJI_HAS_SUGGESTIONS,
+  [COLUMN_TYPE.NAME]: 'Rule',
   [COLUMN_TYPE.REQUIRES_TYPE_CHECKING]: EMOJI_REQUIRES_TYPE_CHECKING,
-  [COLUMN_TYPE.RULE]: 'Rule',
 };
 
 /**
  * Decide what columns to display for the rules list.
+ * Only display columns for which there is at least one rule that has a value for that column.
  */
 export function getColumns(
   details: RuleDetails[],
   plugin: Plugin,
   configsToRules: ConfigsToRules
 ) {
-  const columns: COLUMN_TYPE[] = [];
-
-  columns.push(COLUMN_TYPE.RULE, COLUMN_TYPE.DESCRIPTION);
-  if (hasCustomConfigs(plugin)) {
-    columns.push(COLUMN_TYPE.CONFIGS); // If there are custom configs, use the general config emoji.
-  } else if (hasAnyConfigs(configsToRules)) {
-    columns.push(COLUMN_TYPE.CONFIG_RECOMMENDED); // If there are no custom configs, but there are configs, use the recommended config emoji.
-  }
-  columns.push(COLUMN_TYPE.FIXABLE, COLUMN_TYPE.HAS_SUGGESTIONS);
-  if (details.some((detail: RuleDetails) => detail.requiresTypeChecking)) {
-    columns.push(COLUMN_TYPE.REQUIRES_TYPE_CHECKING);
-  }
-  if (details.some((detail) => detail.deprecated)) {
-    columns.push(COLUMN_TYPE.DEPRECATED);
-  }
+  const columns: {
+    [key in COLUMN_TYPE]: boolean;
+  } = {
+    // Object keys in display order.
+    [COLUMN_TYPE.NAME]: true,
+    [COLUMN_TYPE.DESCRIPTION]: details.some((detail) => detail.description),
+    [COLUMN_TYPE.CONFIGS]: hasCustomConfigs(plugin), // If there are custom configs, use the general config emoji.
+    [COLUMN_TYPE.CONFIG_RECOMMENDED]:
+      !hasCustomConfigs(plugin) && hasAnyConfigs(configsToRules), // If there are no custom configs, but there are configs, use the recommended config emoji.
+    [COLUMN_TYPE.FIXABLE]: details.some((detail) => detail.fixable),
+    [COLUMN_TYPE.HAS_SUGGESTIONS]: details.some(
+      (detail) => detail.hasSuggestions
+    ),
+    [COLUMN_TYPE.REQUIRES_TYPE_CHECKING]: details.some(
+      (detail) => detail.requiresTypeChecking
+    ),
+    [COLUMN_TYPE.DEPRECATED]: details.some((detail) => detail.deprecated),
+  };
 
   return columns;
 }

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -3,12 +3,10 @@
 exports[`generator #generate CJS (non-ESM) generates the documentation 1`] = `
 "<!-- begin rules list -->
 
-🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).\\
-💡 Provides editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
-| Rule                           | Description   | 🔧  | 💡  |
-| ------------------------------ | ------------- | --- | --- |
-| [no-foo](docs/rules/no-foo.md) | disallow foo. |     |     |
+| Rule                           | Description   |
+| ------------------------------ | ------------- |
+| [no-foo](docs/rules/no-foo.md) | disallow foo. |
 
 <!-- end rules list -->"
 `;
@@ -27,12 +25,10 @@ exports[`generator #generate Missing plugin package.json throws an error 1`] = `
 exports[`generator #generate No configs found omits the config column 1`] = `
 "<!-- begin rules list -->
 
-🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).\\
-💡 Provides editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
-| Rule                           | Description   | 🔧  | 💡  |
-| ------------------------------ | ------------- | --- | --- |
-| [no-foo](docs/rules/no-foo.md) | disallow foo. |     |     |
+| Rule                           | Description   |
+| ------------------------------ | ------------- |
+| [no-foo](docs/rules/no-foo.md) | disallow foo. |
 
 <!-- end rules list -->"
 `;
@@ -56,12 +52,10 @@ Foo.
 ## Rules
 <!-- begin rules list -->
 
-🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).\\
-💡 Provides editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
-| Rule                           | Description            | 🔧  | 💡  |
-| ------------------------------ | ---------------------- | --- | --- |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. |     |     |
+| Rule                           | Description            |
+| ------------------------------ | ---------------------- |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. |
 
 <!-- end rules list -->
 
@@ -92,14 +86,12 @@ exports[`generator #generate adds extra column to rules table for TypeScript rul
 "<!-- begin rules list -->
 
 ✅ Enabled in the \`recommended\` configuration.\\
-🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).\\
-💡 Provides editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).\\
 💭 Requires type information.
 
-| Rule                           | Description            | ✅  | 🔧  | 💡  | 💭  |
-| ------------------------------ | ---------------------- | --- | --- | --- | --- |
-| [no-bar](docs/rules/no-bar.md) | Description of no-bar. |     |     |     | 💭  |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. |     |     |     |     |
+| Rule                           | Description            | ✅  | 💭  |
+| ------------------------------ | ---------------------- | --- | --- |
+| [no-bar](docs/rules/no-bar.md) | Description of no-bar. |     | 💭  |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. |     |     |
 
 <!-- end rules list -->"
 `;
@@ -108,16 +100,14 @@ exports[`generator #generate config that extends another config generates the do
 "## Rules
 <!-- begin rules list -->
 
-✅ Enabled in the \`recommended\` configuration.\\
-🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).\\
-💡 Provides editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+✅ Enabled in the \`recommended\` configuration.
 
-| Rule                           | Description            | ✅  | 🔧  | 💡  |
-| ------------------------------ | ---------------------- | --- | --- | --- |
-| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | ✅  |     |     |
-| [no-baz](docs/rules/no-baz.md) | Description of no-baz. | ✅  |     |     |
-| [no-biz](docs/rules/no-biz.md) | Description of no-biz. | ✅  |     |     |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅  |     |     |
+| Rule                           | Description            | ✅  |
+| ------------------------------ | ---------------------- | --- |
+| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | ✅  |
+| [no-baz](docs/rules/no-baz.md) | Description of no-baz. | ✅  |
+| [no-biz](docs/rules/no-biz.md) | Description of no-biz. | ✅  |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅  |
 
 <!-- end rules list -->
 "
@@ -163,13 +153,11 @@ exports[`generator #generate config with overrides generates the documentation 1
 "## Rules
 <!-- begin rules list -->
 
-✅ Enabled in the \`recommended\` configuration.\\
-🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).\\
-💡 Provides editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+✅ Enabled in the \`recommended\` configuration.
 
-| Rule                           | Description            | ✅  | 🔧  | 💡  |
-| ------------------------------ | ---------------------- | --- | --- | --- |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅  |     |     |
+| Rule                           | Description            | ✅  |
+| ------------------------------ | ---------------------- | --- |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅  |
 
 <!-- end rules list -->
 "
@@ -188,13 +176,11 @@ exports[`generator #generate deprecated function-style rule generates the docume
 "## Rules
 <!-- begin rules list -->
 
-✅ Enabled in the \`recommended\` configuration.\\
-🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).\\
-💡 Provides editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+✅ Enabled in the \`recommended\` configuration.
 
-| Rule                           | Description | ✅  | 🔧  | 💡  |
-| ------------------------------ | ----------- | --- | --- | --- |
-| [no-foo](docs/rules/no-foo.md) |             | ✅  |     |     |
+| Rule                           | ✅  |
+| ------------------------------ | --- |
+| [no-foo](docs/rules/no-foo.md) | ✅  |
 
 <!-- end rules list -->
 "
@@ -210,13 +196,11 @@ exports[`generator #generate deprecated function-style rule generates the docume
 exports[`generator #generate deprecated rule with no rule doc nor meta.docs updates the documentation 1`] = `
 "<!-- begin rules list -->
 
-🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).\\
-💡 Provides editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).\\
 ❌ Deprecated.
 
-| Rule                           | Description | 🔧  | 💡  | ❌  |
-| ------------------------------ | ----------- | --- | --- | --- |
-| [no-foo](docs/rules/no-foo.md) |             |     |     | ❌  |
+| Rule                           | ❌  |
+| ------------------------------ | --- |
+| [no-foo](docs/rules/no-foo.md) | ❌  |
 
 <!-- end rules list -->"
 `;
@@ -224,15 +208,13 @@ exports[`generator #generate deprecated rule with no rule doc nor meta.docs upda
 exports[`generator #generate deprecated rules updates the documentation 1`] = `
 "<!-- begin rules list -->
 
-🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).\\
-💡 Provides editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).\\
 ❌ Deprecated.
 
-| Rule                           | Description  | 🔧  | 💡  | ❌  |
-| ------------------------------ | ------------ | --- | --- | --- |
-| [no-bar](docs/rules/no-bar.md) | Description. |     |     | ❌  |
-| [no-baz](docs/rules/no-baz.md) | Description. |     |     | ❌  |
-| [no-foo](docs/rules/no-foo.md) | Description. |     |     | ❌  |
+| Rule                           | Description  | ❌  |
+| ------------------------------ | ------------ | --- |
+| [no-bar](docs/rules/no-bar.md) | Description. | ❌  |
+| [no-baz](docs/rules/no-baz.md) | Description. | ❌  |
+| [no-foo](docs/rules/no-foo.md) | Description. | ❌  |
 
 <!-- end rules list -->"
 `;
@@ -268,12 +250,11 @@ exports[`generator #generate no existing comment markers - minimal doc content g
 "## Rules
 <!-- begin rules list -->
 
-🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).\\
-💡 Provides editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).
 
-| Rule                           | Description            | 🔧  | 💡  |
-| ------------------------------ | ---------------------- | --- | --- |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧  |     |
+| Rule                           | Description            | 🔧  |
+| ------------------------------ | ---------------------- | --- |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧  |
 
 <!-- end rules list -->
 "
@@ -292,12 +273,11 @@ exports[`generator #generate no existing comment markers - with no blank lines i
 "## Rules
 <!-- begin rules list -->
 
-🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).\\
-💡 Provides editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).
 
-| Rule                           | Description            | 🔧  | 💡  |
-| ------------------------------ | ---------------------- | --- | --- |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧  |     |
+| Rule                           | Description            | 🔧  |
+| ------------------------------ | ---------------------- | --- |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧  |
 
 <!-- end rules list -->
 Existing rules section content."
@@ -316,12 +296,11 @@ exports[`generator #generate no existing comment markers - with one blank line a
 "## Rules
 <!-- begin rules list -->
 
-🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).\\
-💡 Provides editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).
 
-| Rule                           | Description            | 🔧  | 💡  |
-| ------------------------------ | ---------------------- | --- | --- |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧  |     |
+| Rule                           | Description            | 🔧  |
+| ------------------------------ | ---------------------- | --- |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧  |
 
 <!-- end rules list -->
 
@@ -341,12 +320,11 @@ Existing rule doc content."
 exports[`generator #generate no prettier config generates the documentation 1`] = `
 "<!-- begin rules list -->
 
-🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).\\
-💡 Provides editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).
 
-| Rule                           | Description            | 🔧  | 💡  |
-| ------------------------------ | ---------------------- | --- | --- |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧  |     |
+| Rule                           | Description            | 🔧  |
+| ------------------------------ | ---------------------- | --- |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧  |
 
 <!-- end rules list -->"
 `;
@@ -362,16 +340,62 @@ details
 Long line that SHOULD NOT get wrapped by prettier since it's outside the header. Long line that SHOULD NOT get wrapped by prettier since it's outside the header.""
 `;
 
+exports[`generator #generate no rules with description generates the documentation 1`] = `
+"## Rules
+<!-- begin rules list -->
+
+
+| Rule                           |
+| ------------------------------ |
+| [no-foo](docs/rules/no-foo.md) |
+
+<!-- end rules list -->
+"
+`;
+
+exports[`generator #generate no rules with description generates the documentation 2`] = `
+"# \`test/no-foo\`
+
+<!-- end rule header -->
+"
+`;
+
+exports[`generator #generate one rule missing description generates the documentation 1`] = `
+"## Rules
+<!-- begin rules list -->
+
+
+| Rule                           | Description             |
+| ------------------------------ | ----------------------- |
+| [no-bar](docs/rules/no-bar.md) |                         |
+| [no-foo](docs/rules/no-foo.md) | Description for no-foo. |
+
+<!-- end rules list -->
+"
+`;
+
+exports[`generator #generate one rule missing description generates the documentation 2`] = `
+"# Description for no-foo (\`test/no-foo\`)
+
+<!-- end rule header -->
+"
+`;
+
+exports[`generator #generate one rule missing description generates the documentation 3`] = `
+"# \`test/no-bar\`
+
+<!-- end rule header -->
+"
+`;
+
 exports[`generator #generate only a \`recommended\` config updates the documentation 1`] = `
 "<!-- begin rules list -->
 
-✅ Enabled in the \`recommended\` configuration.\\
-🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).\\
-💡 Provides editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+✅ Enabled in the \`recommended\` configuration.
 
-| Rule                           | Description  | ✅  | 🔧  | 💡  |
-| ------------------------------ | ------------ | --- | --- | --- |
-| [no-foo](docs/rules/no-foo.md) | Description. | ✅  |     |     |
+| Rule                           | Description  | ✅  |
+| ------------------------------ | ------------ | --- |
+| [no-foo](docs/rules/no-foo.md) | Description. | ✅  |
 
 <!-- end rules list -->"
 `;
@@ -389,13 +413,11 @@ exports[`generator #generate rule config with options generates the documentatio
 "## Rules
 <!-- begin rules list -->
 
-✅ Enabled in the \`recommended\` configuration.\\
-🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).\\
-💡 Provides editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+✅ Enabled in the \`recommended\` configuration.
 
-| Rule                           | Description            | ✅  | 🔧  | 💡  |
-| ------------------------------ | ---------------------- | --- | --- | --- |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅  |     |     |
+| Rule                           | Description            | ✅  |
+| ------------------------------ | ---------------------- | --- |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅  |
 
 <!-- end rules list -->
 "
@@ -421,40 +443,16 @@ Pre-existing notice about the rule being recommended.
 Details."
 `;
 
-exports[`generator #generate rule without a description generates the documentation 1`] = `
-"## Rules
-<!-- begin rules list -->
-
-🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).\\
-💡 Provides editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
-
-| Rule                           | Description | 🔧  | 💡  |
-| ------------------------------ | ----------- | --- | --- |
-| [no-foo](docs/rules/no-foo.md) |             |     |     |
-
-<!-- end rules list -->
-"
-`;
-
-exports[`generator #generate rule without a description generates the documentation 2`] = `
-"# \`test/no-foo\`
-
-<!-- end rule header -->
-"
-`;
-
 exports[`generator #generate rules that are disabled generates the documentation 1`] = `
 "## Rules
 <!-- begin rules list -->
 
-✅ Enabled in the \`recommended\` configuration.\\
-🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).\\
-💡 Provides editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+✅ Enabled in the \`recommended\` configuration.
 
-| Rule                           | Description            | ✅  | 🔧  | 💡  |
-| ------------------------------ | ---------------------- | --- | --- | --- |
-| [no-bar](docs/rules/no-bar.md) | Description of no-bar. |     |     |     |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. |     |     |     |
+| Rule                           | Description            | ✅  |
+| ------------------------------ | ---------------------- | --- |
+| [no-bar](docs/rules/no-bar.md) | Description of no-bar. |     |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. |     |
 
 <!-- end rules list -->
 "
@@ -536,14 +534,11 @@ exports[`generator #generate uses prettier config from package.json should wrap 
 
 ✅ Enabled in the
 \`recommended\`
-configuration.\\
-🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).\\
-💡 Provides editor
-[suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+configuration.
 
-| Rule                           | Description            | ✅  | 🔧  | 💡  |
-| ------------------------------ | ---------------------- | --- | --- | --- |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. |     |     |     |
+| Rule                           | Description            | ✅  |
+| ------------------------------ | ---------------------- | --- |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. |     |
 
 <!-- end rules list -->"
 `;
@@ -568,12 +563,11 @@ exports[`generator #generate with no blank lines around comment markers generate
 No blank line after this.
 <!-- begin rules list -->
 
-🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).\\
-💡 Provides editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).
 
-| Rule                           | Description            | 🔧  | 💡  |
-| ------------------------------ | ---------------------- | --- | --- |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧  |     |
+| Rule                           | Description            | 🔧  |
+| ------------------------------ | ---------------------- | --- |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧  |
 
 <!-- end rules list -->
 No blank line before this."
@@ -595,12 +589,11 @@ One blank line after this.
 
 <!-- begin rules list -->
 
-🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).\\
-💡 Provides editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).
 
-| Rule                           | Description            | 🔧  | 💡  |
-| ------------------------------ | ---------------------- | --- | --- |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧  |     |
+| Rule                           | Description            | 🔧  |
+| ------------------------------ | ---------------------- | --- |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧  |
 
 <!-- end rules list -->
 

--- a/test/lib/generator-test.ts
+++ b/test/lib/generator-test.ts
@@ -1588,7 +1588,7 @@ describe('generator', function () {
       });
     });
 
-    describe('rule without a description', function () {
+    describe('no rules with description', function () {
       beforeEach(function () {
         mockFs({
           'package.json': JSON.stringify({
@@ -1627,6 +1627,54 @@ describe('generator', function () {
         await generate('.');
         expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
         expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
+      });
+    });
+
+    describe('one rule missing description', function () {
+      beforeEach(function () {
+        mockFs({
+          'package.json': JSON.stringify({
+            name: 'eslint-plugin-test',
+            main: 'index.js',
+            type: 'module',
+          }),
+
+          'index.js': `
+            export default {
+              rules: {
+                'no-foo': {
+                  meta: { docs: { description: 'Description for no-foo.'} },
+                  create(context) {},
+                },
+                'no-bar': {
+                  meta: { },
+                  create(context) {},
+                },
+              },
+            };`,
+
+          'README.md': '## Rules\n',
+
+          'docs/rules/no-foo.md': '',
+          'docs/rules/no-bar.md': '',
+
+          // Needed for some of the test infrastructure to work.
+          node_modules: mockFs.load(
+            resolve(__dirname, '..', '..', 'node_modules')
+          ),
+        });
+      });
+
+      afterEach(function () {
+        mockFs.restore();
+        jest.resetModules();
+      });
+
+      it('generates the documentation', async function () {
+        await generate('.');
+        expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
+        expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
+        expect(readFileSync('docs/rules/no-bar.md', 'utf8')).toMatchSnapshot();
       });
     });
 


### PR DESCRIPTION
Hide the description, fixable, or suggestions columns from the README rules list if no rules have content for these.