### PR TITLE
Handle when prettier is not installed

### DIFF
--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -159,16 +159,17 @@ export async function updateRulesList(
   const columns = getColumns(details, plugin, configsToRules);
 
   // New legend.
-  const legend = await format(
-    generateLegend(columns, urlConfigs),
-    pathToReadme
-  );
+  const legend = generateLegend(columns, urlConfigs);
 
   // New rule list.
-  const list = await format(
-    generateRulesListMarkdown(columns, details, configsToRules, pluginPrefix),
-    pathToReadme
+  const list = generateRulesListMarkdown(
+    columns,
+    details,
+    configsToRules,
+    pluginPrefix
   );
 
-  return `${preList}${BEGIN_RULE_LIST_MARKER}\n\n${legend}\n${list}\n${END_RULE_LIST_MARKER}${postList}`;
+  const newContent = await format(`${legend}\n\n${list}`, pathToReadme);
+
+  return `${preList}${BEGIN_RULE_LIST_MARKER}\n\n${newContent}\n\n${END_RULE_LIST_MARKER}${postList}`;
 }

--- a/lib/rule-notices.ts
+++ b/lib/rule-notices.ts
@@ -201,6 +201,7 @@ export function generateRuleHeaderLines(
       pluginPrefix,
       urlConfigs
     ),
+    '',
     END_RULE_HEADER_MARKER,
   ].join('\n');
 }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "typescript": "^4.8.4"
   },
   "peerDependencies": {
-    "eslint": ">= 7"
+    "eslint": ">= 7",
+    "prettier": ">= 2"
   },
   "engines": {
     "node": "^14.18.0 || ^16.0.0 || >=18.0.0"

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -3,7 +3,6 @@
 exports[`generator #generate CJS (non-ESM) generates the documentation 1`] = `
 "<!-- begin rules list -->
 
-
 | Rule                           | Description   |
 | ------------------------------ | ------------- |
 | [no-foo](docs/rules/no-foo.md) | disallow foo. |
@@ -24,7 +23,6 @@ exports[`generator #generate Missing plugin package.json throws an error 1`] = `
 
 exports[`generator #generate No configs found omits the config column 1`] = `
 "<!-- begin rules list -->
-
 
 | Rule                           | Description   |
 | ------------------------------ | ------------- |
@@ -51,7 +49,6 @@ Foo.
 
 ## Rules
 <!-- begin rules list -->
-
 
 | Rule                           | Description            |
 | ------------------------------ | ---------------------- |
@@ -344,7 +341,6 @@ exports[`generator #generate no rules with description generates the documentati
 "## Rules
 <!-- begin rules list -->
 
-
 | Rule                           |
 | ------------------------------ |
 | [no-foo](docs/rules/no-foo.md) |
@@ -363,7 +359,6 @@ exports[`generator #generate no rules with description generates the documentati
 exports[`generator #generate one rule missing description generates the documentation 1`] = `
 "## Rules
 <!-- begin rules list -->
-
 
 | Rule                           | Description             |
 | ------------------------------ | ----------------------- |

--- a/test/lib/generator-test.ts
+++ b/test/lib/generator-test.ts
@@ -5,7 +5,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readFileSync } from 'node:fs';
 import { jest } from '@jest/globals';
-import prettier from 'prettier'; // eslint-disable-line node/no-extraneous-import -- prettier is included by eslint-plugin-square
+import prettier from 'prettier';
 import * as sinon from 'sinon';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
I haven't figured out how to test avoid loading prettier from node_modules in our mock-fs tests: https://github.com/bmish/eslint-doc-generator/issues/88

I had to tweak newline handling to ensure the spacing would be correct even when prettier was not used to fix it.

Fixes #85.