### PR TITLE
Add `--ignore-config` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ If you have any custom configs (besides `all`, `recommended`), you'll need to de
 
 | Name | Description |
 | --- | --- |
+| `--ignore-config` | (optional) Config to ignore from being displayed (often used for an `all` config) (option can be repeated). |
 | `--ignore-deprecated-rules` | (optional) Whether to ignore deprecated rules from being checked, displayed, or updated (default: `false`). |
 | `--rule-doc-section-include` | (optional) Required section in each rule doc (option can be repeated). |
 | `--rule-doc-section-exclude` | (optional) Disallowed section in each rule doc (option can be repeated). |

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -36,6 +36,12 @@ export function run() {
       new Argument('[path]', 'path to ESLint plugin root').default('.')
     )
     .option(
+      '--ignore-config',
+      '(optional) Config to ignore from being displayed (often used for an `all` config) (option can be repeated).',
+      collect,
+      []
+    )
+    .option(
       '--ignore-deprecated-rules',
       '(optional) Whether to ignore deprecated rules from being checked, displayed, or updated.',
       false
@@ -67,6 +73,7 @@ export function run() {
     .action(async function (
       path,
       options: {
+        ignoreConfig: string[];
         ignoreDeprecatedRules?: boolean;
         ruleDocSectionInclude: string[];
         ruleDocSectionExclude: string[];
@@ -75,6 +82,7 @@ export function run() {
       }
     ) {
       await generate(path, {
+        ignoreConfig: options.ignoreConfig,
         ignoreDeprecatedRules: options.ignoreDeprecatedRules,
         ruleDocSectionInclude: options.ruleDocSectionInclude,
         ruleDocSectionExclude: options.ruleDocSectionExclude,

--- a/lib/configs.ts
+++ b/lib/configs.ts
@@ -1,9 +1,10 @@
 import type { Plugin, ConfigsToRules } from './types.js';
 
-export function hasCustomConfigs(plugin: Plugin) {
+export function hasCustomConfigs(plugin: Plugin, ignoreConfig?: string[]) {
   return Object.keys(plugin.configs || {}).some(
-    // Ignore the common configs.
-    (configName) => !['all', 'recommended'].includes(configName)
+    // Consider a config custom if not-recommended and not ignored.
+    (configName) =>
+      configName !== 'recommended' && !ignoreConfig?.includes(configName)
   );
 }
 

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -68,6 +68,7 @@ function expectSectionHeader(
 export async function generate(
   path: string,
   options?: {
+    ignoreConfig?: string[];
     ignoreDeprecatedRules?: boolean;
     ruleDocSectionInclude?: string[];
     ruleDocSectionExclude?: string[];
@@ -137,6 +138,7 @@ export async function generate(
       plugin,
       configsToRules,
       pluginPrefix,
+      options?.ignoreConfig,
       options?.ruleDocTitleFormat,
       options?.urlConfigs
     );
@@ -189,6 +191,7 @@ export async function generate(
     configsToRules,
     pluginPrefix,
     pathTo.readme,
+    options?.ignoreConfig,
     options?.urlConfigs
   );
   writeFileSync(pathTo.readme, readme, 'utf8');

--- a/lib/rule-list-columns.ts
+++ b/lib/rule-list-columns.ts
@@ -40,7 +40,8 @@ export const COLUMN_HEADER: {
 export function getColumns(
   details: RuleDetails[],
   plugin: Plugin,
-  configsToRules: ConfigsToRules
+  configsToRules: ConfigsToRules,
+  ignoreConfig?: string[]
 ) {
   const columns: {
     [key in COLUMN_TYPE]: boolean;
@@ -48,9 +49,9 @@ export function getColumns(
     // Object keys in display order.
     [COLUMN_TYPE.NAME]: true,
     [COLUMN_TYPE.DESCRIPTION]: details.some((detail) => detail.description),
-    [COLUMN_TYPE.CONFIGS]: hasCustomConfigs(plugin), // If there are custom configs, use the general config emoji.
+    [COLUMN_TYPE.CONFIGS]: hasCustomConfigs(plugin, ignoreConfig), // If there are custom configs, use the general config emoji.
     [COLUMN_TYPE.CONFIG_RECOMMENDED]:
-      !hasCustomConfigs(plugin) && hasAnyConfigs(configsToRules), // If there are no custom configs, but there are configs, use the recommended config emoji.
+      !hasCustomConfigs(plugin, ignoreConfig) && hasAnyConfigs(configsToRules), // If there are no custom configs, but there are configs, use the recommended config emoji.
     [COLUMN_TYPE.FIXABLE]: details.some((detail) => detail.fixable),
     [COLUMN_TYPE.HAS_SUGGESTIONS]: details.some(
       (detail) => detail.hasSuggestions

--- a/lib/rule-notices.ts
+++ b/lib/rule-notices.ts
@@ -73,6 +73,7 @@ function getRuleNoticeLines(
   plugin: Plugin,
   configsToRules: ConfigsToRules,
   pluginPrefix: string,
+  ignoreConfig?: string[],
   urlConfigs?: string
 ) {
   const lines: string[] = [];
@@ -94,7 +95,7 @@ function getRuleNoticeLines(
     ruleName,
     configsToRules,
     pluginPrefix
-  );
+  ).filter((config) => !ignoreConfig?.includes(config));
   const notices = getNoticesForRule(rule, configsEnabled);
   let messageType: keyof typeof notices;
 
@@ -189,6 +190,7 @@ export function generateRuleHeaderLines(
   plugin: Plugin,
   configsToRules: ConfigsToRules,
   pluginPrefix: string,
+  ignoreConfig?: string[],
   ruleDocTitleFormat?: RuleDocTitleFormat,
   urlConfigs?: string
 ): string {
@@ -199,6 +201,7 @@ export function generateRuleHeaderLines(
       plugin,
       configsToRules,
       pluginPrefix,
+      ignoreConfig,
       urlConfigs
     ),
     '',

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -82,13 +82,13 @@ exports[`generator #generate Scoped plugin name determines the correct plugin pr
 exports[`generator #generate adds extra column to rules table for TypeScript rules updates the documentation 1`] = `
 "<!-- begin rules list -->
 
-✅ Enabled in the \`recommended\` configuration.\\
+💼 Configurations enabled in.\\
 💭 Requires type information.
 
-| Rule                           | Description            | ✅  | 💭  |
-| ------------------------------ | ---------------------- | --- | --- |
-| [no-bar](docs/rules/no-bar.md) | Description of no-bar. |     | 💭  |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. |     |     |
+| Rule                           | Description            | 💼       | 💭  |
+| ------------------------------ | ---------------------- | -------- | --- |
+| [no-bar](docs/rules/no-bar.md) | Description of no-bar. |          | 💭  |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ![all][] |     |
 
 <!-- end rules list -->"
 `;
@@ -474,11 +474,11 @@ Description.
 🔧 Fixable with [\`eslint --fix\`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).\\
 💡 Provides editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
-| Rule                           | Description            | 💼         | 🔧  | 💡  |
-| ------------------------------ | ---------------------- | ---------- | --- | --- |
-| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | ![style][] | 🔧  |     |
-| [no-baz](docs/rules/no-baz.md) | Description of no-boz. |            |     |     |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅         | 🔧  | 💡  |
+| Rule                           | Description            | 💼                  | 🔧  | 💡  |
+| ------------------------------ | ---------------------- | ------------------- | --- | --- |
+| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | ![all][] ![style][] | 🔧  |     |
+| [no-baz](docs/rules/no-baz.md) | Description of no-boz. |                     |     |     |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ![all][] ✅         | 🔧  | 💡  |
 
 <!-- end rules list -->
 more content."
@@ -524,13 +524,12 @@ details"
 exports[`generator #generate uses prettier config from package.json should wrap prose in rule doc header to just 20 chars 1`] = `
 "<!-- begin rules list -->
 
-✅ Enabled in the
-\`recommended\`
-configuration.
+💼 Configurations
+enabled in.
 
-| Rule                           | Description            | ✅  |
-| ------------------------------ | ---------------------- | --- |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. |     |
+| Rule                           | Description            | 💼       |
+| ------------------------------ | ---------------------- | -------- |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ![all][] |
 
 <!-- end rules list -->"
 `;
@@ -635,6 +634,29 @@ exports[`generator #generate with \`--url-configs\` option with only recommended
 "# Description for no-foo (\`test/no-foo\`)
 
 ✅ This rule is enabled in the \`recommended\` [config](http://example.com/configs).
+
+<!-- end rule header -->
+"
+`;
+
+exports[`generator #generate with --ignore-config hides the ignored config 1`] = `
+"## Rules
+<!-- begin rules list -->
+
+✅ Enabled in the \`recommended\` configuration.
+
+| Rule                           | Description             | ✅  |
+| ------------------------------ | ----------------------- | --- |
+| [no-foo](docs/rules/no-foo.md) | Description for no-foo. | ✅  |
+
+<!-- end rules list -->
+"
+`;
+
+exports[`generator #generate with --ignore-config hides the ignored config 2`] = `
+"# Description for no-foo (\`test/no-foo\`)
+
+✅ This rule is enabled in the \`recommended\` config.
 
 <!-- end rule header -->
 "


### PR DESCRIPTION
Fixes #89.

Not defaulting to `all` because there would be no way to un-ignore it and it may be safer to display all configs by default.
