### PR TITLE
Handle lowercase `readme.md`

### DIFF
--- a/lib/package-json.ts
+++ b/lib/package-json.ts
@@ -1,5 +1,5 @@
-import { join } from 'node:path';
-import { existsSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { importAbs } from './import.js';
 import type { Plugin } from './types.js';
 import type { PackageJson } from 'type-fest';
@@ -43,4 +43,23 @@ export function getPluginPrefix(path: string): string {
   return pluginPackageJson.name.endsWith('/eslint-plugin')
     ? pluginPackageJson.name.split('/')[0] // Scoped plugin name like @my-scope/eslint-plugin.
     : pluginPackageJson.name.replace('eslint-plugin-', ''); // Unscoped name like eslint-plugin-foo.
+}
+
+/**
+ * Resolve the path to a file but with the exact filename-casing present on disk.
+ */
+export function getPathWithExactFileNameCasing(
+  dir: string,
+  fileNameToSearch: string
+) {
+  const filenames = readdirSync(dir, { withFileTypes: true });
+  for (const dirent of filenames) {
+    if (
+      dirent.isFile() &&
+      dirent.name.toLowerCase() === fileNameToSearch.toLowerCase()
+    ) {
+      return resolve(dir, dirent.name);
+    }
+  }
+  return undefined; // eslint-disable-line unicorn/no-useless-undefined
 }

--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -9,7 +9,9 @@ import {
 import { getConfigsForRule, hasAnyConfigs } from './configs.js';
 import { COLUMN_TYPE, getColumns, COLUMN_HEADER } from './rule-list-columns.js';
 import { findSectionHeader, format } from './markdown.js';
+import { getPluginRoot } from './package-json.js';
 import { generateLegend } from './legend.js';
+import { relative } from 'node:path';
 import type { Plugin, RuleDetails, ConfigsToRules } from './types.js';
 
 function getConfigurationColumnValueForRule(
@@ -132,6 +134,7 @@ export async function updateRulesList(
   configsToRules: ConfigsToRules,
   pluginPrefix: string,
   pathToReadme: string,
+  pathToPlugin: string,
   ignoreConfig?: string[],
   urlConfigs?: string
 ): Promise<string> {
@@ -160,7 +163,10 @@ export async function updateRulesList(
 
   if (listStartIndex === -1 || listEndIndex === -1) {
     throw new Error(
-      `README.md is missing rules list markers: ${BEGIN_RULE_LIST_MARKER}${END_RULE_LIST_MARKER}`
+      `${relative(
+        getPluginRoot(pathToPlugin),
+        pathToReadme
+      )} is missing rules list markers: ${BEGIN_RULE_LIST_MARKER}${END_RULE_LIST_MARKER}`
     );
   }
 

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -240,6 +240,16 @@ exports[`generator #generate deprecated rules updates the documentation 4`] = `
 "
 `;
 
+exports[`generator #generate lowercase README file generates the documentation 1`] = `
+"<!-- begin rules list -->
+
+| Name                           |
+| :----------------------------- |
+| [no-foo](docs/rules/no-foo.md) |
+
+<!-- end rules list -->"
+`;
+
 exports[`generator #generate no existing comment markers - minimal doc content generates the documentation 1`] = `
 "## Rules
 <!-- begin rules list -->

--- a/test/lib/generator-test.ts
+++ b/test/lib/generator-test.ts
@@ -453,8 +453,45 @@ describe('generator', function () {
 
       it('throws an error', async function () {
         await expect(generate('.')).rejects.toThrow(
-          'Could not find README: README.md'
+          'Could not find README.md in ESLint plugin root.'
         );
+      });
+    });
+
+    describe('lowercase README file', function () {
+      beforeEach(function () {
+        mockFs({
+          'package.json': JSON.stringify({
+            name: 'eslint-plugin-test',
+            main: 'index.js',
+            type: 'module',
+          }),
+
+          'index.js': `
+            export default {
+              rules: {
+                'no-foo': { meta: { }, create(context) {} },
+              },
+            };`,
+
+          'readme.md': '<!-- begin rules list --><!-- end rules list -->',
+          'docs/rules/no-foo.md': '',
+
+          // Needed for some of the test infrastructure to work.
+          node_modules: mockFs.load(
+            resolve(__dirname, '..', '..', 'node_modules')
+          ),
+        });
+      });
+
+      afterEach(function () {
+        mockFs.restore();
+        jest.resetModules();
+      });
+
+      it('generates the documentation', async function () {
+        await generate('.');
+        expect(readFileSync('readme.md', 'utf8')).toMatchSnapshot();
       });
     });
 


### PR DESCRIPTION
Present in eslint-plugin-unicorn: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/readme.md

I missed this before because my Mac has a case-insensitive filesystem.