### PR TITLE
Add `--config-emoji` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Generated content in a rule doc (everything above the marker comment):
 ```md
 # Disallow use of `foo` (`test/no-foo`)
 
-💼 This rule is enabled in the following configs: `all`, `recommended`.
+💼 This rule is enabled in the following configs: `all`, ✅ `recommended`.
 
 🔧 This rule is automatically fixable by the `--fix` [CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
@@ -107,25 +107,36 @@ Generated rules table in `README.md` (everything between the marker comments):
 
 The table will hide columns that don't apply to any rules, and the legend will include only the symbols that are used in the table.
 
-If you have any custom configs (besides `all`, `recommended`), you'll need to define a badge for them at the bottom of your `README.md`. Here's a badge for a custom `style` config that displays in blue:
+## Badge
+
+If you have any custom configs (besides `recommended`), you'll need to either define emojis for them with `--config-emoji`, or define badges for them at the bottom of your `README.md`.
+
+Here's a badge for a custom `style` config that displays in blue:
 
 ```md
 [style]: https://img.shields.io/badge/-style-blue.svg
 ```
 
-Custom config emojis will also be an option soon ([#34](https://github.com/bmish/eslint-doc-generator/issues/34)).
+And how it looks:
+
+![style][]
+
+[style]: https://img.shields.io/badge/-style-blue.svg
 
 ## Configuration options
 
 | Name | Description |
 | :-- | :-- |
 | `--check` | Whether to check for and fail if there is a diff. No output will be written. Typically used during CI. |
-| `--ignore-config` | (optional) Config to ignore from being displayed. Often used for an `all` config. Option can be repeated. |
-| `--ignore-deprecated-rules` | (optional) Whether to ignore deprecated rules from being checked, displayed, or updated (default: `false`). |
-| `--rule-doc-section-exclude` | (optional) Disallowed section in each rule doc. Exit with failure if present. Option can be repeated. |
-| `--rule-doc-section-include` | (optional) Required section in each rule doc. Exit with failure if missing. Option can be repeated. |
-| `--rule-doc-title-format` | (optional) The format to use for rule doc titles. Defaults to `desc-parens-prefix-name`. See choices in below table. |
-| `--url-configs` | (optional) Link to documentation about the ESLint configurations exported by the plugin. |
+| `--config-emoji` | Custom emoji to use for a config. Defaults to `recommended,✅`. Configs for which no emoji is specified will expect a corresponding [badge](#badge) to be specified in `README.md` instead. Option can be repeated. |
+| `--ignore-config` | Config to ignore from being displayed. Often used for an `all` config. Option can be repeated. |
+| `--ignore-deprecated-rules` | Whether to ignore deprecated rules from being checked, displayed, or updated (default: `false`). |
+| `--rule-doc-section-exclude` | Disallowed section in each rule doc. Exit with failure if present. Option can be repeated. |
+| `--rule-doc-section-include` | Required section in each rule doc. Exit with failure if missing. Option can be repeated. |
+| `--rule-doc-title-format` | The format to use for rule doc titles. Defaults to `desc-parens-prefix-name`. See choices in below [table](#--rule-doc-title-format). |
+| `--url-configs` | Link to documentation about the ESLint configurations exported by the plugin. |
+
+All options are optional.
 
 ### `--rule-doc-title-format`
 

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -41,6 +41,12 @@ export function run() {
       false
     )
     .option(
+      '--config-emoji <config-emoji>',
+      '(optional) Custom emoji to use for a config. Defaults to `recommended,✅`. Configs for which no emoji is specified will expect a corresponding badge to be specified in `README.md` instead. Option can be repeated.',
+      collect,
+      []
+    )
+    .option(
       '--ignore-config <config>',
       '(optional) Config to ignore from being displayed (often used for an `all` config) (option can be repeated).',
       collect,
@@ -79,6 +85,7 @@ export function run() {
       path,
       options: {
         check?: boolean;
+        configEmoji?: string[];
         ignoreConfig: string[];
         ignoreDeprecatedRules?: boolean;
         ruleDocSectionExclude: string[];
@@ -89,6 +96,7 @@ export function run() {
     ) {
       await generate(path, {
         check: options.check,
+        configEmoji: options.configEmoji,
         ignoreConfig: options.ignoreConfig,
         ignoreDeprecatedRules: options.ignoreDeprecatedRules,
         ruleDocSectionExclude: options.ruleDocSectionExclude,

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -13,6 +13,7 @@ import { END_RULE_HEADER_MARKER } from './markers.js';
 import { findSectionHeader, replaceOrCreateHeader } from './markdown.js';
 import { resolveConfigsToRules } from './config-resolution.js';
 import { RuleDocTitleFormat } from './rule-doc-title-format.js';
+import { parseConfigEmojiOptions } from './configs.js';
 import type { RuleDetails } from './types.js';
 
 /**
@@ -74,6 +75,7 @@ export async function generate(
   path: string,
   options?: {
     check?: boolean;
+    configEmoji?: string[];
     ignoreConfig?: string[];
     ignoreDeprecatedRules?: boolean;
     ruleDocSectionExclude?: string[];
@@ -122,6 +124,10 @@ export async function generate(
       (details) => !options?.ignoreDeprecatedRules || !details.deprecated
     );
 
+  // Options.
+  const configEmojis = parseConfigEmojiOptions(plugin, options?.configEmoji);
+  const ignoreConfig = options?.ignoreConfig ?? [];
+
   // Update rule doc for each rule.
   for (const { name, description, schema } of details) {
     const pathToDoc = join(resolve(path, 'docs'), 'rules', `${name}.md`);
@@ -139,7 +145,8 @@ export async function generate(
       plugin,
       configsToRules,
       pluginPrefix,
-      options?.ignoreConfig,
+      configEmojis,
+      ignoreConfig,
       options?.ruleDocTitleFormat,
       options?.urlConfigs
     );
@@ -206,7 +213,8 @@ export async function generate(
     pluginPrefix,
     pathToReadme,
     path,
-    options?.ignoreConfig,
+    configEmojis,
+    ignoreConfig,
     options?.urlConfigs
   );
 

--- a/lib/legend.ts
+++ b/lib/legend.ts
@@ -3,49 +3,112 @@ import {
   EMOJI_FIXABLE,
   EMOJI_HAS_SUGGESTIONS,
   EMOJI_CONFIGS,
-  EMOJI_CONFIG_RECOMMENDED,
   EMOJI_REQUIRES_TYPE_CHECKING,
 } from './emojis.js';
 import { COLUMN_TYPE } from './rule-list-columns.js';
+import { ConfigEmojis, Plugin } from './types.js';
 
-function getMessages(urlConfigs?: string) {
-  const configsLinkOrWord = urlConfigs
-    ? `[Configurations](${urlConfigs})`
-    : 'Configurations';
-  const configLinkOrWord = urlConfigs
-    ? `[configuration](${urlConfigs})`
-    : 'configuration';
-  const MESSAGES: {
-    [key in COLUMN_TYPE]: string | undefined;
-  } = {
-    [COLUMN_TYPE.NAME]: undefined, // No legend for this column.
-    [COLUMN_TYPE.DESCRIPTION]: undefined, // No legend for this column.
-    [COLUMN_TYPE.CONFIGS]: `${EMOJI_CONFIGS} ${configsLinkOrWord} enabled in.`,
-    [COLUMN_TYPE.CONFIG_RECOMMENDED]: `${EMOJI_CONFIG_RECOMMENDED} Enabled in the \`recommended\` ${configLinkOrWord}.`,
-    [COLUMN_TYPE.DEPRECATED]: `${EMOJI_DEPRECATED} Deprecated.`,
-    [COLUMN_TYPE.FIXABLE]: `${EMOJI_FIXABLE} Automatically fixable by the \`--fix\` [CLI option](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).`,
-    [COLUMN_TYPE.HAS_SUGGESTIONS]: `${EMOJI_HAS_SUGGESTIONS} Manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).`,
-    [COLUMN_TYPE.REQUIRES_TYPE_CHECKING]: `${EMOJI_REQUIRES_TYPE_CHECKING} Requires type information.`,
-  };
-  return MESSAGES;
-}
+/**
+ * An object containing the legends for each column (as a string or function to generate the string).
+ */
+const LEGENDS: {
+  [key in COLUMN_TYPE]:
+    | string
+    | undefined
+    | ((data: {
+        configNames: string[];
+        configEmojis: ConfigEmojis;
+        ignoreConfig: string[];
+        urlConfigs?: string;
+      }) => string[]);
+} = {
+  // Legends are included for each config. A generic config legend is also included if there are multiple configs.
+  [COLUMN_TYPE.CONFIGS]: ({
+    configNames,
+    configEmojis,
+    urlConfigs,
+    ignoreConfig,
+  }: {
+    configNames: string[];
+    configEmojis: ConfigEmojis;
+    ignoreConfig: string[];
+    urlConfigs?: string;
+  }) => {
+    // Add link to configs documentation if provided.
+    const configsLinkOrWord = urlConfigs
+      ? `[Configurations](${urlConfigs})`
+      : 'Configurations';
+    const configLinkOrWord = urlConfigs
+      ? `[configuration](${urlConfigs})`
+      : 'configuration';
+
+    const configNamesWithoutIgnored = configNames.filter(
+      (configName) => !ignoreConfig?.includes(configName)
+    );
+
+    const legends = [];
+    if (
+      configNamesWithoutIgnored.length > 1 ||
+      !configEmojis?.find((configEmoji) =>
+        configNamesWithoutIgnored?.includes(configEmoji.config)
+      )?.emoji
+    ) {
+      // Generic config emoji will be used if the plugin has multiple configs or the sole config has no emoji.
+      legends.push(`${EMOJI_CONFIGS} ${configsLinkOrWord} enabled in.`);
+    }
+    legends.push(
+      ...configNames.flatMap((configName) => {
+        const emoji = configEmojis?.find(
+          (configEmoji) => configEmoji.config === configName
+        )?.emoji;
+        if (!emoji) {
+          // No legend for this config as it has no emoji.
+          return [];
+        }
+        return [
+          `${emoji} Enabled in the \`${configName}\` ${configLinkOrWord}.`,
+        ];
+      })
+    );
+    return legends;
+  },
+
+  // Simple strings.
+  [COLUMN_TYPE.DEPRECATED]: `${EMOJI_DEPRECATED} Deprecated.`,
+  [COLUMN_TYPE.DESCRIPTION]: undefined, // No legend for this column.
+  [COLUMN_TYPE.FIXABLE]: `${EMOJI_FIXABLE} Automatically fixable by the \`--fix\` [CLI option](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).`,
+  [COLUMN_TYPE.HAS_SUGGESTIONS]: `${EMOJI_HAS_SUGGESTIONS} Manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).`,
+  [COLUMN_TYPE.NAME]: undefined, // No legend for this column.
+  [COLUMN_TYPE.REQUIRES_TYPE_CHECKING]: `${EMOJI_REQUIRES_TYPE_CHECKING} Requires type information.`,
+};
 
 export function generateLegend(
   columns: Record<COLUMN_TYPE, boolean>,
+  plugin: Plugin,
+  configEmojis: ConfigEmojis,
+  ignoreConfig: string[],
   urlConfigs?: string
 ) {
-  const MESSAGES = getMessages(urlConfigs);
   return (Object.entries(columns) as [COLUMN_TYPE, boolean][])
     .flatMap(([columnType, enabled]) => {
       if (!enabled) {
         // This column is turned off.
         return [];
       }
-      if (!MESSAGES[columnType]) {
+      const legendStrOrFn = LEGENDS[columnType];
+      if (!legendStrOrFn) {
         // No legend specified for this column.
         return [];
       }
-      return [MESSAGES[columnType]];
+      const configNames = Object.keys(plugin.configs || {});
+      return typeof legendStrOrFn === 'function'
+        ? legendStrOrFn({
+            configNames,
+            configEmojis,
+            urlConfigs,
+            ignoreConfig,
+          })
+        : [legendStrOrFn];
     })
     .join('\\\n'); // Back slash ensures these end up displayed on separate lines.
 }

--- a/lib/rule-list-columns.ts
+++ b/lib/rule-list-columns.ts
@@ -1,17 +1,14 @@
-import { hasCustomConfigs, hasAnyConfigs } from './configs.js';
 import {
-  EMOJI_CONFIG_RECOMMENDED,
+  EMOJI_CONFIGS,
   EMOJI_DEPRECATED,
   EMOJI_FIXABLE,
   EMOJI_HAS_SUGGESTIONS,
   EMOJI_REQUIRES_TYPE_CHECKING,
-  EMOJI_CONFIGS,
 } from './emojis.js';
-import type { Plugin, RuleDetails, ConfigsToRules } from './types.js';
+import type { RuleDetails, ConfigsToRules, ConfigEmojis } from './types.js';
 
 export enum COLUMN_TYPE {
   CONFIGS = 'configs',
-  CONFIG_RECOMMENDED = 'configRecommended',
   DEPRECATED = 'deprecated',
   DESCRIPTION = 'description',
   FIXABLE = 'fixable',
@@ -20,11 +17,40 @@ export enum COLUMN_TYPE {
   REQUIRES_TYPE_CHECKING = 'requiresTypeChecking',
 }
 
+/**
+ * An object containing the column header for each column (as a string or function to generate the string).
+ */
 export const COLUMN_HEADER: {
-  [key in COLUMN_TYPE]: string;
+  [key in COLUMN_TYPE]:
+    | string
+    | ((data: {
+        configNames: string[];
+        configEmojis: ConfigEmojis;
+        ignoreConfig: string[];
+      }) => string);
 } = {
-  [COLUMN_TYPE.CONFIGS]: EMOJI_CONFIGS,
-  [COLUMN_TYPE.CONFIG_RECOMMENDED]: EMOJI_CONFIG_RECOMMENDED,
+  // Use the general config emoji if there are multiple configs or the sole config doesn't have an emoji.
+  [COLUMN_TYPE.CONFIGS]: ({
+    configNames,
+    configEmojis,
+    ignoreConfig,
+  }: {
+    configNames: string[];
+    configEmojis: ConfigEmojis;
+    ignoreConfig: string[];
+    urlConfigs?: string;
+  }) => {
+    const configNamesWithoutIgnored = configNames.filter(
+      (configName) => !ignoreConfig?.includes(configName)
+    );
+    return configNamesWithoutIgnored.length > 1
+      ? EMOJI_CONFIGS
+      : configEmojis?.find((configEmoji) =>
+          configNamesWithoutIgnored.includes(configEmoji.config)
+        )?.emoji ?? EMOJI_CONFIGS;
+  },
+
+  // Simple strings.
   [COLUMN_TYPE.DEPRECATED]: EMOJI_DEPRECATED,
   [COLUMN_TYPE.DESCRIPTION]: 'Description',
   [COLUMN_TYPE.FIXABLE]: EMOJI_FIXABLE,
@@ -39,9 +65,8 @@ export const COLUMN_HEADER: {
  */
 export function getColumns(
   details: RuleDetails[],
-  plugin: Plugin,
   configsToRules: ConfigsToRules,
-  ignoreConfig?: string[]
+  ignoreConfig: string[]
 ) {
   const columns: {
     [key in COLUMN_TYPE]: boolean;
@@ -49,9 +74,10 @@ export function getColumns(
     // Object keys in display order.
     [COLUMN_TYPE.NAME]: true,
     [COLUMN_TYPE.DESCRIPTION]: details.some((detail) => detail.description),
-    [COLUMN_TYPE.CONFIGS]: hasCustomConfigs(plugin, ignoreConfig), // If there are custom configs, use the general config emoji.
-    [COLUMN_TYPE.CONFIG_RECOMMENDED]:
-      !hasCustomConfigs(plugin, ignoreConfig) && hasAnyConfigs(configsToRules), // If there are no custom configs, but there are configs, use the recommended config emoji.
+    // Show the configs column if there exists a non-ignored config.
+    [COLUMN_TYPE.CONFIGS]: Object.keys(configsToRules).some(
+      (config) => !ignoreConfig?.includes(config)
+    ),
     [COLUMN_TYPE.FIXABLE]: details.some((detail) => detail.fixable),
     [COLUMN_TYPE.HAS_SUGGESTIONS]: details.some(
       (detail) => detail.hasSuggestions

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -23,3 +23,8 @@ export interface RuleDetails {
   deprecated: boolean;
   schema: JSONSchema.JSONSchema4;
 }
+
+/**
+ * Some configs may have an emoji defined.
+ */
+export type ConfigEmojis = { config: string; emoji: string }[];

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -481,6 +481,7 @@ Description.
 <!-- begin rules list -->
 
 💼 Configurations enabled in.\\
+✅ Enabled in the \`recommended\` configuration.\\
 🔧 Automatically fixable by the \`--fix\` [CLI option](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).\\
 💡 Manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
@@ -497,7 +498,7 @@ more content."
 exports[`generator #generate successful updates the documentation 2`] = `
 "# Description of no-foo (\`test/no-foo\`)
 
-💼 This rule is enabled in the following configs: \`all\`, \`recommended\`.
+💼 This rule is enabled in the following configs: \`all\`, ✅ \`recommended\`.
 
 🔧 This rule is automatically fixable by the \`--fix\` [CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
@@ -548,9 +549,8 @@ exports[`generator #generate uses prettier config from package.json should wrap 
 "# Description of no-foo (\`test/no-foo\`)
 
 💼 This rule is
-enabled in the
-following configs:
-\`all\`.
+enabled in the \`all\`
+config.
 
 <!-- end rule header -->
 ## Rule details
@@ -604,7 +604,8 @@ exports[`generator #generate with \`--url-configs\` option includes the config l
 "## Rules
 <!-- begin rules list -->
 
-💼 [Configurations](http://example.com/configs) enabled in.
+💼 [Configurations](http://example.com/configs) enabled in.\\
+✅ Enabled in the \`recommended\` [configuration](http://example.com/configs).
 
 | Name                           | Description             | 💼                |
 | :----------------------------- | :---------------------- | :---------------- |
@@ -627,7 +628,7 @@ exports[`generator #generate with \`--url-configs\` option includes the config l
 exports[`generator #generate with \`--url-configs\` option includes the config link 3`] = `
 "# Description for no-bar (\`test/no-bar\`)
 
-💼 This rule is enabled in the following [configs](http://example.com/configs): \`customConfig\`.
+💼 This rule is enabled in the \`customConfig\` [config](http://example.com/configs).
 
 <!-- end rule header -->
 "
@@ -662,6 +663,51 @@ exports[`generator #generate with --check prints the issues, exits with failure,
 `;
 
 exports[`generator #generate with --check prints the issues, exits with failure, and does not write changes 2`] = `""`;
+
+exports[`generator #generate with --config-emoji shows the correct emojis 1`] = `
+"## Rules
+<!-- begin rules list -->
+
+💼 Configurations enabled in.\\
+🔥 Enabled in the \`recommended\` configuration.\\
+🎨 Enabled in the \`stylistic\` configuration.
+
+| Name                           | Description             | 💼                         |
+| :----------------------------- | :---------------------- | :------------------------- |
+| [no-bar](docs/rules/no-bar.md) | Description for no-bar. | 🔥 🎨                      |
+| [no-baz](docs/rules/no-baz.md) | Description for no-boz. | ![configWithoutEmoji][] 🎨 |
+| [no-foo](docs/rules/no-foo.md) | Description for no-foo. | 🔥                         |
+
+<!-- end rules list -->
+"
+`;
+
+exports[`generator #generate with --config-emoji shows the correct emojis 2`] = `
+"# Description for no-foo (\`test/no-foo\`)
+
+🔥 This rule is enabled in the \`recommended\` config.
+
+<!-- end rule header -->
+"
+`;
+
+exports[`generator #generate with --config-emoji shows the correct emojis 3`] = `
+"# Description for no-bar (\`test/no-bar\`)
+
+💼 This rule is enabled in the following configs: 🔥 \`recommended\`, 🎨 \`stylistic\`.
+
+<!-- end rule header -->
+"
+`;
+
+exports[`generator #generate with --config-emoji shows the correct emojis 4`] = `
+"# Description for no-boz (\`test/no-baz\`)
+
+💼 This rule is enabled in the following configs: \`configWithoutEmoji\`, 🎨 \`stylistic\`.
+
+<!-- end rule header -->
+"
+`;
 
 exports[`generator #generate with --ignore-config hides the ignored config 1`] = `
 "## Rules


### PR DESCRIPTION
Fixes #34.

Impact:
* An emoji can now be specified for any config (including overriding the `recommended` config emoji)
* A config's emoji (if it exists) will be shown next to the config name in rule doc notices
* All config emojis will be included in the rules list legend

This required a major refactoring. The logic for generating each type of message (rule notice, legend, rule list header) is now better organized.
