### PR TITLE
Add `--rule-list-columns` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ And how it looks:
 | `--rule-doc-section-exclude` | Disallowed section in each rule doc. Exit with failure if present. Option can be repeated. |
 | `--rule-doc-section-include` | Required section in each rule doc. Exit with failure if missing. Option can be repeated. |
 | `--rule-doc-title-format` | The format to use for rule doc titles. Defaults to `desc-parens-prefix-name`. See choices in below [table](#--rule-doc-title-format). |
+| `--rule-list-columns` | Ordered, comma-separated list of columns to display in rule list. Empty columns will be hidden. Choices: `configs`, `deprecated`, `description`, `fixable`, `hasSuggestions`, `name`, `requiresTypeChecking`. Default: `name,description,configs,fixable,hasSuggestions,requiresTypeChecking,deprecated`. |
 | `--url-configs` | Link to documentation about the ESLint configurations exported by the plugin. |
 
 All options are optional.

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -8,6 +8,10 @@ import {
   RULE_DOC_TITLE_FORMAT_DEFAULT,
   RULE_DOC_TITLE_FORMATS,
 } from './rule-doc-title-format.js';
+import {
+  COLUMN_TYPE,
+  COLUMN_TYPE_DEFAULT_ORDERING,
+} from './rule-list-columns.js';
 import type { PackageJson } from 'type-fest';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -78,6 +82,13 @@ export function run() {
         .default(RULE_DOC_TITLE_FORMAT_DEFAULT)
     )
     .option(
+      '--rule-list-columns <columns>',
+      `(optional) Ordered, comma-separated list of columns to display in rule list. Empty columns will be hidden. (choices: "${Object.values(
+        COLUMN_TYPE
+      ).join('", "')}")`,
+      COLUMN_TYPE_DEFAULT_ORDERING.join(',')
+    )
+    .option(
       '--url-configs <url>',
       '(optional) Link to documentation about the ESLint configurations exported by the plugin.'
     )
@@ -91,6 +102,7 @@ export function run() {
         ruleDocSectionExclude: string[];
         ruleDocSectionInclude: string[];
         ruleDocTitleFormat: RuleDocTitleFormat;
+        ruleListColumns: string;
         urlConfigs?: string;
       }
     ) {
@@ -102,6 +114,7 @@ export function run() {
         ruleDocSectionExclude: options.ruleDocSectionExclude,
         ruleDocSectionInclude: options.ruleDocSectionInclude,
         ruleDocTitleFormat: options.ruleDocTitleFormat,
+        ruleListColumns: options.ruleListColumns,
         urlConfigs: options.urlConfigs,
       });
     })

--- a/lib/configs.ts
+++ b/lib/configs.ts
@@ -1,10 +1,6 @@
 import { EMOJI_CONFIG_RECOMMENDED } from './emojis.js';
 import type { Plugin, ConfigsToRules, ConfigEmojis } from './types.js';
 
-export function hasAnyConfigs(configsToRules: ConfigsToRules) {
-  return Object.keys(configsToRules).length > 0;
-}
-
 const SEVERITY_ENABLED = new Set([2, 'error']);
 
 /**

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -14,6 +14,7 @@ import { findSectionHeader, replaceOrCreateHeader } from './markdown.js';
 import { resolveConfigsToRules } from './config-resolution.js';
 import { RuleDocTitleFormat } from './rule-doc-title-format.js';
 import { parseConfigEmojiOptions } from './configs.js';
+import { parseRuleListColumnsOption } from './rule-list-columns.js';
 import type { RuleDetails } from './types.js';
 
 /**
@@ -81,6 +82,7 @@ export async function generate(
     ruleDocSectionExclude?: string[];
     ruleDocSectionInclude?: string[];
     ruleDocTitleFormat?: RuleDocTitleFormat;
+    ruleListColumns?: string;
     urlConfigs?: string;
   }
 ) {
@@ -127,6 +129,7 @@ export async function generate(
   // Options.
   const configEmojis = parseConfigEmojiOptions(plugin, options?.configEmoji);
   const ignoreConfig = options?.ignoreConfig ?? [];
+  const ruleListColumns = parseRuleListColumnsOption(options?.ruleListColumns);
 
   // Update rule doc for each rule.
   for (const { name, description, schema } of details) {
@@ -215,6 +218,7 @@ export async function generate(
     path,
     configEmojis,
     ignoreConfig,
+    ruleListColumns,
     options?.urlConfigs
   );
 

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -194,6 +194,7 @@ exports[`generator #generate deprecated rules updates the documentation 1`] = `
 | :----------------------------- | :----------- | :-- |
 | [no-bar](docs/rules/no-bar.md) | Description. | ❌  |
 | [no-baz](docs/rules/no-baz.md) | Description. | ❌  |
+| [no-biz](docs/rules/no-biz.md) | Description. |     |
 | [no-foo](docs/rules/no-foo.md) | Description. | ❌  |
 
 <!-- end rules list -->"
@@ -221,6 +222,13 @@ exports[`generator #generate deprecated rules updates the documentation 4`] = `
 "# Description (\`test/no-baz\`)
 
 ❌ This rule is deprecated.
+
+<!-- end rule header -->
+"
+`;
+
+exports[`generator #generate deprecated rules updates the documentation 5`] = `
+"# Description (\`test/no-biz\`)
 
 <!-- end rule header -->
 "
@@ -745,6 +753,34 @@ exports[`generator #generate with --ignore-config hides the ignored config 2`] =
 "# Description for no-foo (\`test/no-foo\`)
 
 ✅ This rule is enabled in the \`recommended\` config.
+
+<!-- end rule header -->
+"
+`;
+
+exports[`generator #generate with --rule-list-columns shows the right columns and legend 1`] = `
+"## Rules
+<!-- begin rules list -->
+
+💡 Manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).\\
+🔧 Automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
+
+| 💡  | 🔧  | Name                           |
+| :-- | :-- | :----------------------------- |
+| 💡  | 🔧  | [no-foo](docs/rules/no-foo.md) |
+
+<!-- end rules list -->
+"
+`;
+
+exports[`generator #generate with --rule-list-columns shows the right columns and legend 2`] = `
+"# Description for no-foo (\`test/no-foo\`)
+
+❌ This rule is deprecated.
+
+🔧 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
 <!-- end rule header -->
 "


### PR DESCRIPTION
Ability to choose what columns are displayed in the README rule list table and in what order.

Fixes #124.