### PR TITLE
Add optional column and notice for rule type

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ Generated content in a rule doc (everything above the marker comment) (intention
 
 💭 This rule requires type information.
 
+❗ This rule identifies problems that could cause errors or unexpected behavior.
+
+📖 This rule identifies potential improvements.
+
+📏 This rule focuses on code formatting.
+
 ❌ This rule is deprecated. It was replaced by [prefer-bar](prefer-bar.md).
 
 <!-- end rule header -->
@@ -89,7 +95,7 @@ Examples.
 ...
 ```
 
-Generated rules table in `README.md` (everything between the marker comments):
+Generated rules table in `README.md` (everything between the marker comments) (intentionally showing all possible columns):
 
 ```md
 # eslint-plugin-test
@@ -104,13 +110,17 @@ Generated rules table in `README.md` (everything between the marker comments):
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
 💡 Manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).\
 💭 Requires type information.\
+🗂️ The type of rule.\
+❗ Identifies problems that could cause errors or unexpected behavior.\
+📖 Identifies potential improvements.\
+📏 Focuses on code formatting.\
 ❌ Deprecated.
 
-| Name                                     | Description        | 💼    | 🔧  | 💡  | 💭  | ❌  |
-| :--------------------------------------- | :----------------- | :---- | :-- | :-- | :-- | :-- |
-| [no-foo](docs/rules/no-foo.md)           | disallow using foo | ✅    | 🔧  |     |     |
-| [prefer-bar](docs/rules/prefer-bar.md)   | enforce using bar  | ✅ 🎨 |     | 💡  | 💭  |
-| [require-baz](docs/rules/require-baz.md) | require using baz  |       | 🔧  |     |     | ❌  |
+| Name                                     | Description        | 💼    | 🔧  | 💡  | 💭  | 🗂️  | ❌  |
+| :--------------------------------------- | :----------------- | :---- | :-- | :-- | :-- | :-- | :-- |
+| [no-foo](docs/rules/no-foo.md)           | disallow using foo | ✅    | 🔧  |     |     | ❗  |     |
+| [prefer-bar](docs/rules/prefer-bar.md)   | enforce using bar  | ✅ 🎨 |     | 💡  | 💭  | 📖  |     |
+| [require-baz](docs/rules/require-baz.md) | require using baz  |       | 🔧  |     |     | 📏  | ❌  |
 
 <!-- end rules list -->
 
@@ -146,7 +156,7 @@ And how it looks:
 | `--rule-doc-section-exclude` | Disallowed section in each rule doc. Exit with failure if present. Option can be repeated. |
 | `--rule-doc-section-include` | Required section in each rule doc. Exit with failure if missing. Option can be repeated. |
 | `--rule-doc-title-format` | The format to use for rule doc titles. Defaults to `desc-parens-prefix-name`. See choices in below [table](#--rule-doc-title-format). |
-| `--rule-list-columns` | Ordered, comma-separated list of columns to display in rule list. Empty columns will be hidden. Choices: `configs`, `deprecated`, `description`, `fixable`, `hasSuggestions`, `name`, `requiresTypeChecking`. Default: `name,description,configs,fixable,hasSuggestions,requiresTypeChecking,deprecated`. |
+| `--rule-list-columns` | Ordered, comma-separated list of columns to display in rule list. Empty columns will be hidden. Choices: `configs`, `deprecated`, `description`, `fixable`, `hasSuggestions`, `name`, `requiresTypeChecking`, `type` (off by default). Default: `name,description,configs,fixable,hasSuggestions,requiresTypeChecking,deprecated`. |
 | `--url-configs` | Link to documentation about the ESLint configurations exported by the plugin. |
 
 All options are optional.

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -86,7 +86,11 @@ export function run() {
       `(optional) Ordered, comma-separated list of columns to display in rule list. Empty columns will be hidden. (choices: "${Object.values(
         COLUMN_TYPE
       ).join('", "')}")`,
-      Object.keys(COLUMN_TYPE_DEFAULT_PRESENCE_AND_ORDERING).join(',')
+      // List of default enabled columns.
+      Object.entries(COLUMN_TYPE_DEFAULT_PRESENCE_AND_ORDERING)
+        .filter(([_col, enabled]) => enabled)
+        .map(([col]) => col)
+        .join(',')
     )
     .option(
       '--url-configs <url>',

--- a/lib/emojis.ts
+++ b/lib/emojis.ts
@@ -11,5 +11,9 @@ export const EMOJI_HAS_SUGGESTIONS = '💡';
 // TypeScript.
 export const EMOJI_REQUIRES_TYPE_CHECKING = '💭';
 
+// Type.
+export const EMOJI_TYPE = '🗂️';
+// Also see EMOJIS_TYPE defined in rule-type.ts.
+
 // Deprecated.
 export const EMOJI_DEPRECATED = '❌';

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -109,6 +109,7 @@ export async function generate(
             requiresTypeChecking: rule.meta.docs?.requiresTypeChecking ?? false,
             deprecated: rule.meta.deprecated ?? false,
             schema: rule.meta.schema,
+            type: rule.meta.type,
           }
         : // Deprecated function-style rule (does not support most of these features).
           {
@@ -119,6 +120,7 @@ export async function generate(
             requiresTypeChecking: false,
             deprecated: false, // TODO: figure out how to access `deprecated` property that can be exported from function-style rules.
             schema: [], // TODO: figure out how to access `schema` property that can be exported from function-style rules.
+            type: undefined,
           };
     })
     .filter(

--- a/lib/rule-list-columns.ts
+++ b/lib/rule-list-columns.ts
@@ -4,7 +4,9 @@ import {
   EMOJI_FIXABLE,
   EMOJI_HAS_SUGGESTIONS,
   EMOJI_REQUIRES_TYPE_CHECKING,
+  EMOJI_TYPE,
 } from './emojis.js';
+import { RULE_TYPES } from './rule-type.js';
 import type { RuleDetails, ConfigsToRules, ConfigEmojis } from './types.js';
 
 export enum COLUMN_TYPE {
@@ -15,6 +17,7 @@ export enum COLUMN_TYPE {
   HAS_SUGGESTIONS = 'hasSuggestions',
   NAME = 'name',
   REQUIRES_TYPE_CHECKING = 'requiresTypeChecking',
+  TYPE = 'type',
 }
 
 export const COLUMN_TYPE_DEFAULT_PRESENCE_AND_ORDERING: {
@@ -28,6 +31,7 @@ export const COLUMN_TYPE_DEFAULT_PRESENCE_AND_ORDERING: {
   [COLUMN_TYPE.FIXABLE]: true,
   [COLUMN_TYPE.HAS_SUGGESTIONS]: true,
   [COLUMN_TYPE.REQUIRES_TYPE_CHECKING]: true,
+  [COLUMN_TYPE.TYPE]: false,
   [COLUMN_TYPE.DEPRECATED]: true,
 };
 
@@ -71,6 +75,7 @@ export const COLUMN_HEADER: {
   [COLUMN_TYPE.HAS_SUGGESTIONS]: EMOJI_HAS_SUGGESTIONS,
   [COLUMN_TYPE.NAME]: 'Name',
   [COLUMN_TYPE.REQUIRES_TYPE_CHECKING]: EMOJI_REQUIRES_TYPE_CHECKING,
+  [COLUMN_TYPE.TYPE]: EMOJI_TYPE,
 };
 
 /**
@@ -101,6 +106,10 @@ export function getColumns(
     [COLUMN_TYPE.REQUIRES_TYPE_CHECKING]: details.some(
       (detail) => detail.requiresTypeChecking
     ),
+    // Show type column only if we found at least one rule with a standard type.
+    [COLUMN_TYPE.TYPE]: details.some(
+      (detail) => detail.type && RULE_TYPES.includes(detail.type as any) // eslint-disable-line @typescript-eslint/no-explicit-any
+    ),
   };
 
   // Recreate object using the ordering and presence of columns specified in ruleListColumns.
@@ -129,7 +138,11 @@ export function parseRuleListColumnsOption(
 
   if (values.length === 0) {
     // Use default columns and ordering.
-    values.push(...Object.keys(COLUMN_TYPE_DEFAULT_PRESENCE_AND_ORDERING));
+    values.push(
+      ...Object.entries(COLUMN_TYPE_DEFAULT_PRESENCE_AND_ORDERING)
+        .filter(([_col, enabled]) => enabled)
+        .map(([col]) => col)
+    );
   }
 
   return values as COLUMN_TYPE[];

--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -17,6 +17,7 @@ import type {
   ConfigsToRules,
   ConfigEmojis,
 } from './types.js';
+import { EMOJIS_TYPE, RULE_TYPE } from './rule-type.js';
 
 function getConfigurationColumnValueForRule(
   rule: RuleDetails,
@@ -70,6 +71,7 @@ function buildRuleRow(
     [COLUMN_TYPE.REQUIRES_TYPE_CHECKING]: rule.requiresTypeChecking
       ? EMOJI_REQUIRES_TYPE_CHECKING
       : '',
+    [COLUMN_TYPE.TYPE]: rule.type ? EMOJIS_TYPE[rule.type as RULE_TYPE] : '', // Convert union type to enum.
   };
 
   // List columns using the ordering and presence of columns specified in columnsEnabled.

--- a/lib/rule-type.ts
+++ b/lib/rule-type.ts
@@ -1,0 +1,40 @@
+/**
+ * Enum version of this union type: TSESLint.RuleMetaData<''>['type'];
+ */
+export enum RULE_TYPE {
+  'problem' = 'problem',
+  'suggestion' = 'suggestion',
+  'layout' = 'layout',
+}
+
+export const RULE_TYPES = ['problem', 'suggestion', 'layout'] as const;
+
+export const EMOJIS_TYPE: { [key in RULE_TYPE]: string } = {
+  [RULE_TYPE.problem]: '❗',
+  [RULE_TYPE.suggestion]: '📖',
+  [RULE_TYPE.layout]: '📏',
+};
+
+export const RULE_TYPE_MESSAGES_LEGEND: { [key in RULE_TYPE]: string } = {
+  [RULE_TYPE.problem]: `${
+    EMOJIS_TYPE[RULE_TYPE.problem]
+  } Identifies problems that could cause errors or unexpected behavior.`,
+  [RULE_TYPE.suggestion]: `${
+    EMOJIS_TYPE[RULE_TYPE.suggestion]
+  } Identifies potential improvements.`,
+  [RULE_TYPE.layout]: `${
+    EMOJIS_TYPE[RULE_TYPE.layout]
+  } Focuses on code formatting.`,
+};
+
+export const RULE_TYPE_MESSAGES_NOTICES: { [key in RULE_TYPE]: string } = {
+  [RULE_TYPE.problem]: `${
+    EMOJIS_TYPE[RULE_TYPE.problem]
+  } This rule identifies problems that could cause errors or unexpected behavior.`,
+  [RULE_TYPE.suggestion]: `${
+    EMOJIS_TYPE[RULE_TYPE.suggestion]
+  } This rule identifies potential improvements.`,
+  [RULE_TYPE.layout]: `${
+    EMOJIS_TYPE[RULE_TYPE.layout]
+  } This rule focuses on code formatting.`,
+};

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -22,6 +22,7 @@ export interface RuleDetails {
   requiresTypeChecking: boolean;
   deprecated: boolean;
   schema: JSONSchema.JSONSchema4;
+  type?: string; // Rule might not have a type.
 }
 
 /**

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -439,6 +439,108 @@ Pre-existing notice about the rule being recommended.
 Details."
 `;
 
+exports[`generator #generate rule with type, type column enabled displays the type 1`] = `
+"## Rules
+<!-- begin rules list -->
+
+🗂️ The type of rule.\\
+❗ Identifies problems that could cause errors or unexpected behavior.\\
+📖 Identifies potential improvements.\\
+📏 Focuses on code formatting.
+
+| Name                           | 🗂️  |
+| :----------------------------- | :-- |
+| [no-bar](docs/rules/no-bar.md) | 📖  |
+| [no-biz](docs/rules/no-biz.md) | 📏  |
+| [no-boz](docs/rules/no-boz.md) |     |
+| [no-buz](docs/rules/no-buz.md) |     |
+| [no-foo](docs/rules/no-foo.md) | ❗  |
+
+<!-- end rules list -->
+"
+`;
+
+exports[`generator #generate rule with type, type column enabled displays the type 2`] = `
+"# \`test/no-foo\`
+
+❗ This rule identifies problems that could cause errors or unexpected behavior.
+
+<!-- end rule header -->
+"
+`;
+
+exports[`generator #generate rule with type, type column enabled displays the type 3`] = `
+"# \`test/no-bar\`
+
+📖 This rule identifies potential improvements.
+
+<!-- end rule header -->
+"
+`;
+
+exports[`generator #generate rule with type, type column enabled displays the type 4`] = `
+"# \`test/no-biz\`
+
+📏 This rule focuses on code formatting.
+
+<!-- end rule header -->
+"
+`;
+
+exports[`generator #generate rule with type, type column enabled displays the type 5`] = `
+"# \`test/no-boz\`
+
+<!-- end rule header -->
+"
+`;
+
+exports[`generator #generate rule with type, type column enabled displays the type 6`] = `
+"# \`test/no-buz\`
+
+<!-- end rule header -->
+"
+`;
+
+exports[`generator #generate rule with type, type column enabled, but only an unknown type hides the type column and notice 1`] = `
+"## Rules
+<!-- begin rules list -->
+
+| Name                           |
+| :----------------------------- |
+| [no-foo](docs/rules/no-foo.md) |
+
+<!-- end rules list -->
+"
+`;
+
+exports[`generator #generate rule with type, type column enabled, but only an unknown type hides the type column and notice 2`] = `
+"# \`test/no-foo\`
+
+<!-- end rule header -->
+"
+`;
+
+exports[`generator #generate rule with type, type column not enabled hides the type column 1`] = `
+"## Rules
+<!-- begin rules list -->
+
+| Name                           |
+| :----------------------------- |
+| [no-foo](docs/rules/no-foo.md) |
+
+<!-- end rules list -->
+"
+`;
+
+exports[`generator #generate rule with type, type column not enabled hides the type column 2`] = `
+"# \`test/no-foo\`
+
+❗ This rule identifies problems that could cause errors or unexpected behavior.
+
+<!-- end rule header -->
+"
+`;
+
 exports[`generator #generate rules that are disabled generates the documentation 1`] = `
 "## Rules
 <!-- begin rules list -->

--- a/test/lib/generator-test.ts
+++ b/test/lib/generator-test.ts
@@ -2623,5 +2623,134 @@ describe('generator', function () {
         );
       });
     });
+
+    describe('rule with type, type column not enabled', function () {
+      beforeEach(function () {
+        mockFs({
+          'package.json': JSON.stringify({
+            name: 'eslint-plugin-test',
+            main: 'index.js',
+            type: 'module',
+          }),
+
+          'index.js': `
+            export default {
+              rules: {
+                'no-foo': { meta: { type: 'problem' }, create(context) {} },
+              },
+            };`,
+
+          'README.md': '## Rules\n',
+
+          'docs/rules/no-foo.md': '',
+
+          // Needed for some of the test infrastructure to work.
+          node_modules: mockFs.load(
+            resolve(__dirname, '..', '..', 'node_modules')
+          ),
+        });
+      });
+
+      afterEach(function () {
+        mockFs.restore();
+        jest.resetModules();
+      });
+
+      it('hides the type column', async function () {
+        await generate('.');
+        expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
+        expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
+      });
+    });
+
+    describe('rule with type, type column enabled', function () {
+      beforeEach(function () {
+        mockFs({
+          'package.json': JSON.stringify({
+            name: 'eslint-plugin-test',
+            main: 'index.js',
+            type: 'module',
+          }),
+
+          'index.js': `
+            export default {
+              rules: {
+                'no-foo': { meta: { type: 'problem' }, create(context) {} },
+                'no-bar': { meta: { type: 'suggestion' }, create(context) {} },
+                'no-biz': { meta: { type: 'layout' }, create(context) {} },
+                'no-boz': { meta: { type: 'unknown' }, create(context) {} },
+                'no-buz': { meta: { /* no type*/ }, create(context) {} },
+              },
+            };`,
+
+          'README.md': '## Rules\n',
+
+          'docs/rules/no-foo.md': '',
+          'docs/rules/no-bar.md': '',
+          'docs/rules/no-biz.md': '',
+          'docs/rules/no-boz.md': '',
+          'docs/rules/no-buz.md': '',
+
+          // Needed for some of the test infrastructure to work.
+          node_modules: mockFs.load(
+            resolve(__dirname, '..', '..', 'node_modules')
+          ),
+        });
+      });
+
+      afterEach(function () {
+        mockFs.restore();
+        jest.resetModules();
+      });
+
+      it('displays the type', async function () {
+        await generate('.', { ruleListColumns: 'name,type' });
+        expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
+        expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
+        expect(readFileSync('docs/rules/no-bar.md', 'utf8')).toMatchSnapshot();
+        expect(readFileSync('docs/rules/no-biz.md', 'utf8')).toMatchSnapshot();
+        expect(readFileSync('docs/rules/no-boz.md', 'utf8')).toMatchSnapshot();
+        expect(readFileSync('docs/rules/no-buz.md', 'utf8')).toMatchSnapshot();
+      });
+    });
+
+    describe('rule with type, type column enabled, but only an unknown type', function () {
+      beforeEach(function () {
+        mockFs({
+          'package.json': JSON.stringify({
+            name: 'eslint-plugin-test',
+            main: 'index.js',
+            type: 'module',
+          }),
+
+          'index.js': `
+            export default {
+              rules: {
+                'no-foo': { meta: { type: 'unknown' }, create(context) {} },
+              },
+            };`,
+
+          'README.md': '## Rules\n',
+
+          'docs/rules/no-foo.md': '',
+
+          // Needed for some of the test infrastructure to work.
+          node_modules: mockFs.load(
+            resolve(__dirname, '..', '..', 'node_modules')
+          ),
+        });
+      });
+
+      afterEach(function () {
+        mockFs.restore();
+        jest.resetModules();
+      });
+
+      it('hides the type column and notice', async function () {
+        await generate('.', { ruleListColumns: 'name,type' });
+        expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
+        expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
+      });
+    });
   });
 });


### PR DESCRIPTION
We will also have to implement the following feature to ensure that the rule doc notice for type is off by default but configurable.
* [ ] https://github.com/bmish/eslint-doc-generator/issues/135

Fixes #121.