### PR TITLE
Support removing the default emoji for a config with `--config-emoji` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ And how it looks:
 | Name | Description |
 | :-- | :-- |
 | `--check` | Whether to check for and fail if there is a diff. No output will be written. Typically used during CI. |
-| `--config-emoji` | Custom emoji to use for a config. Format is `config-name,emoji`. Default emojis are provided for [common configs](./lib/emojis.ts). Configs for which no emoji is specified will expect a corresponding [badge](#badge) to be specified in `README.md` instead. Option can be repeated. |
+| `--config-emoji` | Custom emoji to use for a config. Format is `config-name,emoji`. Default emojis are provided for [common configs](./lib/emojis.ts). To remove a default emoji and rely on a [badge](#badge) instead, provide the config name without an emoji. Option can be repeated. |
 | `--ignore-config` | Config to ignore from being displayed. Often used for an `all` config. Option can be repeated. |
 | `--ignore-deprecated-rules` | Whether to ignore deprecated rules from being checked, displayed, or updated (default: `false`). |
 | `--rule-doc-section-exclude` | Disallowed section in each rule doc. Exit with failure if present. Option can be repeated. |

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -794,6 +794,29 @@ exports[`generator #generate with --check prints the issues, exits with failure,
 
 exports[`generator #generate with --check prints the issues, exits with failure, and does not write changes 2`] = `""`;
 
+exports[`generator #generate with --config-emoji and removing default emoji for a config reverts to using a badge for the config 1`] = `
+"## Rules
+<!-- begin rules list -->
+
+💼 Configurations enabled in.
+
+| Name                           | Description             | 💼               |
+| :----------------------------- | :---------------------- | :--------------- |
+| [no-foo](docs/rules/no-foo.md) | Description for no-foo. | ![recommended][] |
+
+<!-- end rules list -->
+"
+`;
+
+exports[`generator #generate with --config-emoji and removing default emoji for a config reverts to using a badge for the config 2`] = `
+"# Description for no-foo (\`test/no-foo\`)
+
+💼 This rule is enabled in the \`recommended\` config.
+
+<!-- end rule header -->
+"
+`;
+
 exports[`generator #generate with --config-emoji shows the correct emojis 1`] = `
 "## Rules
 <!-- begin rules list -->


### PR DESCRIPTION
Especially because we now provide default emojis for many common configs (#136), we need to ensure the user can remove these default emojis if they simple want to rely on [badges](https://github.com/bmish/eslint-doc-generator#badge) instead.