### PR TITLE
More robust loading of CJS plugins using `require()`

### DIFF
--- a/lib/package-json.ts
+++ b/lib/package-json.ts
@@ -1,8 +1,11 @@
-import { join, resolve, extname, basename, dirname } from 'node:path';
+import { join, resolve, basename, dirname } from 'node:path';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { importAbs } from './import.js';
+import { createRequire } from 'node:module';
 import type { Plugin } from './types.js';
 import type { PackageJson } from 'type-fest';
+
+const require = createRequire(import.meta.url);
 
 export function getPluginRoot(path: string) {
   return join(process.cwd(), path);
@@ -23,66 +26,54 @@ function loadPackageJson(path: string): PackageJson {
 
 export async function loadPlugin(path: string): Promise<Plugin> {
   const pluginRoot = getPluginRoot(path);
-  const pluginPackageJson = loadPackageJson(path);
-
-  // Check for the entry point on the `exports` or `main` field in package.json.
-  let pluginEntryPoint;
-  const exports = pluginPackageJson.exports;
-  if (typeof exports === 'string') {
-    pluginEntryPoint = exports;
-  } else if (
-    typeof exports === 'object' &&
-    exports !== null &&
-    !Array.isArray(exports)
-  ) {
-    // Check various properties on the `exports` object.
-    // https://nodejs.org/api/packages.html#conditional-exports
-    const propertiesToCheck: (keyof PackageJson.ExportConditions)[] = [
-      '.',
-      'node',
-      'import',
-      'require',
-      'default',
-    ];
-    for (const prop of propertiesToCheck) {
-      // @ts-expect-error -- The union type for the object is causing trouble.
-      const value = exports[prop];
-      if (typeof value === 'string') {
-        pluginEntryPoint = value;
-        break;
+  try {
+    // Try require first which should work for CJS plugins.
+    return require(pluginRoot); // eslint-disable-line import/no-dynamic-require
+  } catch {
+    // Otherwise, for ESM plugins, we'll have to try to resolve the exact plugin entry point and import it.
+    const pluginPackageJson = loadPackageJson(path);
+    let pluginEntryPoint;
+    const exports = pluginPackageJson.exports;
+    if (typeof exports === 'string') {
+      pluginEntryPoint = exports;
+    } else if (
+      typeof exports === 'object' &&
+      exports !== null &&
+      !Array.isArray(exports)
+    ) {
+      // Check various properties on the `exports` object.
+      // https://nodejs.org/api/packages.html#conditional-exports
+      const propertiesToCheck: (keyof PackageJson.ExportConditions)[] = [
+        '.',
+        'node',
+        'import',
+        'require',
+        'default',
+      ];
+      for (const prop of propertiesToCheck) {
+        // @ts-expect-error -- The union type for the object is causing trouble.
+        const value = exports[prop];
+        if (typeof value === 'string') {
+          pluginEntryPoint = value;
+          break;
+        }
       }
     }
-  } else if (typeof pluginPackageJson.main === 'string') {
-    pluginEntryPoint = pluginPackageJson.main;
-  }
 
-  if (!pluginEntryPoint) {
-    pluginEntryPoint = 'index.js'; // This is the default value for the `main` field: https://docs.npmjs.com/cli/v8/configuring-npm/package-json#main
-  }
+    if (!pluginEntryPoint) {
+      throw new Error('Unable to determine plugin entry point.');
+    }
 
-  if (pluginEntryPoint.endsWith('/')) {
-    // The `main` field is allowed to specify a directory.
-    pluginEntryPoint = `${pluginEntryPoint}/index.js`;
-  }
+    const pluginEntryPointAbs = join(pluginRoot, pluginEntryPoint);
+    if (!existsSync(pluginEntryPointAbs)) {
+      throw new Error(
+        `ESLint plugin entry point does not exist. Tried: ${pluginEntryPoint}`
+      );
+    }
 
-  const SUPPORTED_FILE_TYPES = ['.js', '.cjs', '.mjs'];
-  if (!SUPPORTED_FILE_TYPES.includes(extname(pluginEntryPoint))) {
-    throw new Error(
-      `Unsupported file type for plugin entry point. Current types supported: ${SUPPORTED_FILE_TYPES.join(
-        ', '
-      )}. Entry point detected: ${pluginEntryPoint}`
-    );
+    const { default: plugin } = await importAbs(pluginEntryPointAbs);
+    return plugin;
   }
-
-  const pluginEntryPointAbs = join(pluginRoot, pluginEntryPoint);
-  if (!existsSync(pluginEntryPointAbs)) {
-    throw new Error(
-      `Could not find entry point for ESLint plugin. Tried: ${pluginEntryPoint}`
-    );
-  }
-
-  const { default: plugin } = await importAbs(pluginEntryPointAbs);
-  return plugin;
 }
 
 export function getPluginPrefix(path: string): string {

--- a/test/fixtures/cjs-config-extends/README.md
+++ b/test/fixtures/cjs-config-extends/README.md
@@ -1,0 +1,17 @@
+# eslint-plugin-test
+
+## Rules
+
+<!-- begin auto-generated rules list -->
+
+💼 Configurations enabled in.\
+✅ Set in the `recommended` configuration.
+
+| Name                           | Description            | 💼 |
+| :----------------------------- | :--------------------- | :- |
+| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | ✅  |
+| [no-baz](docs/rules/no-baz.md) | Description of no-baz. | ✅  |
+| [no-biz](docs/rules/no-biz.md) | Description of no-biz. | ✅  |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅  |
+
+<!-- end auto-generated rules list -->

--- a/test/fixtures/cjs-config-extends/base-base-base-config.cjs
+++ b/test/fixtures/cjs-config-extends/base-base-base-config.cjs
@@ -1,0 +1,1 @@
+module.exports = { rules: { 'test/no-bar': 'error' } };

--- a/test/fixtures/cjs-config-extends/base-base-config.cjs
+++ b/test/fixtures/cjs-config-extends/base-base-config.cjs
@@ -1,0 +1,1 @@
+module.exports = { extends: require.resolve('./base-base-base-config.cjs') };

--- a/test/fixtures/cjs-config-extends/base-config.cjs
+++ b/test/fixtures/cjs-config-extends/base-config.cjs
@@ -1,0 +1,11 @@
+module.exports = {
+  extends: [require.resolve('./base-base-config.cjs')],
+  rules: { 'test/no-foo': 'error' },
+  overrides: [
+    {
+      extends: [require.resolve('./override-config.cjs')],
+      files: ['*.js'],
+      rules: { 'test/no-baz': 'error' },
+    },
+  ],
+};

--- a/test/fixtures/cjs-config-extends/docs/rules/no-bar.md
+++ b/test/fixtures/cjs-config-extends/docs/rules/no-bar.md
@@ -1,0 +1,5 @@
+# Description of no-bar (`test/no-bar`)
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->

--- a/test/fixtures/cjs-config-extends/docs/rules/no-baz.md
+++ b/test/fixtures/cjs-config-extends/docs/rules/no-baz.md
@@ -1,0 +1,5 @@
+# Description of no-baz (`test/no-baz`)
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->

--- a/test/fixtures/cjs-config-extends/docs/rules/no-biz.md
+++ b/test/fixtures/cjs-config-extends/docs/rules/no-biz.md
@@ -1,0 +1,5 @@
+# Description of no-biz (`test/no-biz`)
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->

--- a/test/fixtures/cjs-config-extends/docs/rules/no-foo.md
+++ b/test/fixtures/cjs-config-extends/docs/rules/no-foo.md
@@ -1,0 +1,5 @@
+# Description of no-foo (`test/no-foo`)
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->

--- a/test/fixtures/cjs-config-extends/index.cjs
+++ b/test/fixtures/cjs-config-extends/index.cjs
@@ -1,0 +1,31 @@
+module.exports = {
+  rules: {
+    'no-foo': {
+      meta: { docs: { description: 'Description of no-foo.' } },
+      create() {},
+    },
+    'no-bar': {
+      meta: { docs: { description: 'Description of no-bar.' } },
+      create() {},
+    },
+    'no-baz': {
+      meta: { docs: { description: 'Description of no-baz.' } },
+      create() {},
+    },
+    'no-biz': {
+      meta: { docs: { description: 'Description of no-biz.' } },
+      create() {},
+    },
+  },
+  configs: {
+    recommended: {
+      extends: [
+        require.resolve('./base-config.cjs'),
+        // Should ignore these since they're external:
+        'eslint:recommended',
+        'plugin:some-plugin/recommended',
+        'prettier',
+      ],
+    },
+  },
+};

--- a/test/fixtures/cjs-config-extends/override-config.cjs
+++ b/test/fixtures/cjs-config-extends/override-config.cjs
@@ -1,0 +1,1 @@
+module.exports = { rules: { 'test/no-biz': 'error' } };

--- a/test/fixtures/cjs-config-extends/package.json
+++ b/test/fixtures/cjs-config-extends/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "eslint-plugin-test",
+  "type": "commonjs"
+}

--- a/test/fixtures/cjs-main-directory/README.md
+++ b/test/fixtures/cjs-main-directory/README.md
@@ -1,0 +1,8 @@
+# eslint-plugin-test
+
+<!-- begin auto-generated rules list -->
+
+| Name |
+| :--- |
+
+<!-- end auto-generated rules list -->

--- a/test/fixtures/cjs-main-directory/lib/index.cjs
+++ b/test/fixtures/cjs-main-directory/lib/index.cjs
@@ -1,0 +1,1 @@
+module.exports = { rules: {} };

--- a/test/fixtures/cjs-main-directory/package.json
+++ b/test/fixtures/cjs-main-directory/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "eslint-plugin-test",
+  "type": "commonjs",
+  "main": "lib/index.cjs"
+}

--- a/test/fixtures/cjs-main-file-does-not-exist/README.md
+++ b/test/fixtures/cjs-main-file-does-not-exist/README.md
@@ -1,0 +1,2 @@
+<!-- begin auto-generated rules list -->
+<!-- end auto-generated rules list -->

--- a/test/fixtures/cjs-main-file-does-not-exist/package.json
+++ b/test/fixtures/cjs-main-file-does-not-exist/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "eslint-plugin-test",
+  "type": "commonjs",
+  "main": "index.js"
+}

--- a/test/fixtures/cjs-missing-main/README.md
+++ b/test/fixtures/cjs-missing-main/README.md
@@ -1,0 +1,8 @@
+# eslint-plugin-test
+
+<!-- begin auto-generated rules list -->
+
+| Name |
+| :--- |
+
+<!-- end auto-generated rules list -->

--- a/test/fixtures/cjs-missing-main/index.cjs
+++ b/test/fixtures/cjs-missing-main/index.cjs
@@ -1,0 +1,1 @@
+module.exports = { rules: {} };

--- a/test/fixtures/cjs-missing-main/package.json
+++ b/test/fixtures/cjs-missing-main/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "eslint-plugin-test",
+  "type": "commonjs"
+}

--- a/test/fixtures/cjs/README.md
+++ b/test/fixtures/cjs/README.md
@@ -1,0 +1,9 @@
+# eslint-plugin-test
+
+<!-- begin auto-generated rules list -->
+
+| Name                           | Description   |
+| :----------------------------- | :------------ |
+| [no-foo](docs/rules/no-foo.md) | disallow foo. |
+
+<!-- end auto-generated rules list -->

--- a/test/fixtures/cjs/docs/rules/no-foo.md
+++ b/test/fixtures/cjs/docs/rules/no-foo.md
@@ -1,0 +1,3 @@
+# Disallow foo (`test/no-foo`)
+
+<!-- end auto-generated rule header -->

--- a/test/fixtures/cjs/index.cjs
+++ b/test/fixtures/cjs/index.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  rules: {
+    'no-foo': {
+      meta: { docs: { description: 'disallow foo.' } },
+      create() {},
+    },
+  },
+};

--- a/test/fixtures/cjs/package.json
+++ b/test/fixtures/cjs/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "eslint-plugin-test",
+  "type": "commonjs"
+}

--- a/test/lib/__snapshots__/generate-cjs-test.ts.snap
+++ b/test/lib/__snapshots__/generate-cjs-test.ts.snap
@@ -1,0 +1,78 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generate (cjs) basic generates the documentation 1`] = `
+"# eslint-plugin-test
+
+<!-- begin auto-generated rules list -->
+
+| Name                           | Description   |
+| :----------------------------- | :------------ |
+| [no-foo](docs/rules/no-foo.md) | disallow foo. |
+
+<!-- end auto-generated rules list -->
+"
+`;
+
+exports[`generate (cjs) basic generates the documentation 2`] = `
+"# Disallow foo (\`test/no-foo\`)
+
+<!-- end auto-generated rule header -->
+"
+`;
+
+exports[`generate (cjs) config that extends another config generates the documentation 1`] = `
+"# eslint-plugin-test
+
+## Rules
+
+<!-- begin auto-generated rules list -->
+
+💼 Configurations enabled in.\\
+✅ Set in the \`recommended\` configuration.
+
+| Name                           | Description            | 💼 |
+| :----------------------------- | :--------------------- | :- |
+| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | ✅  |
+| [no-baz](docs/rules/no-baz.md) | Description of no-baz. | ✅  |
+| [no-biz](docs/rules/no-biz.md) | Description of no-biz. | ✅  |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅  |
+
+<!-- end auto-generated rules list -->
+"
+`;
+
+exports[`generate (cjs) config that extends another config generates the documentation 2`] = `
+"# Description of no-foo (\`test/no-foo\`)
+
+💼 This rule is enabled in the ✅ \`recommended\` config.
+
+<!-- end auto-generated rule header -->
+"
+`;
+
+exports[`generate (cjs) config that extends another config generates the documentation 3`] = `
+"# Description of no-bar (\`test/no-bar\`)
+
+💼 This rule is enabled in the ✅ \`recommended\` config.
+
+<!-- end auto-generated rule header -->
+"
+`;
+
+exports[`generate (cjs) config that extends another config generates the documentation 4`] = `
+"# Description of no-baz (\`test/no-baz\`)
+
+💼 This rule is enabled in the ✅ \`recommended\` config.
+
+<!-- end auto-generated rule header -->
+"
+`;
+
+exports[`generate (cjs) config that extends another config generates the documentation 5`] = `
+"# Description of no-biz (\`test/no-biz\`)
+
+💼 This rule is enabled in the ✅ \`recommended\` config.
+
+<!-- end auto-generated rule header -->
+"
+`;

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -1,22 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`generator #generate CJS (non-ESM) generates the documentation 1`] = `
-"<!-- begin auto-generated rules list -->
-
-| Name                           | Description   |
-| :----------------------------- | :------------ |
-| [no-foo](docs/rules/no-foo.md) | disallow foo. |
-
-<!-- end auto-generated rules list -->"
-`;
-
-exports[`generator #generate CJS (non-ESM) generates the documentation 2`] = `
-"# Disallow foo (\`test/no-foo\`)
-
-<!-- end auto-generated rule header -->
-"
-`;
-
 exports[`generator #generate Missing plugin package.json \`name\` field throws an error 1`] = `"Could not find \`name\` field in ESLint plugin's package.json."`;
 
 exports[`generator #generate Missing plugin package.json throws an error 1`] = `"Could not find package.json of ESLint plugin."`;
@@ -72,60 +55,6 @@ exports[`generator #generate Rule description needs to be formatted capitalizes 
 
 exports[`generator #generate Scoped plugin name determines the correct plugin prefix 1`] = `
 "# Disallow foo (\`@my-scope/no-foo\`)
-
-💼 This rule is enabled in the ✅ \`recommended\` config.
-
-<!-- end auto-generated rule header -->
-"
-`;
-
-exports[`generator #generate config that extends another config generates the documentation 1`] = `
-"## Rules
-<!-- begin auto-generated rules list -->
-
-💼 Configurations enabled in.\\
-✅ Set in the \`recommended\` configuration.
-
-| Name                           | Description            | 💼 |
-| :----------------------------- | :--------------------- | :- |
-| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | ✅  |
-| [no-baz](docs/rules/no-baz.md) | Description of no-baz. | ✅  |
-| [no-biz](docs/rules/no-biz.md) | Description of no-biz. | ✅  |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅  |
-
-<!-- end auto-generated rules list -->
-"
-`;
-
-exports[`generator #generate config that extends another config generates the documentation 2`] = `
-"# Description of no-foo (\`test/no-foo\`)
-
-💼 This rule is enabled in the ✅ \`recommended\` config.
-
-<!-- end auto-generated rule header -->
-"
-`;
-
-exports[`generator #generate config that extends another config generates the documentation 3`] = `
-"# Description of no-bar (\`test/no-bar\`)
-
-💼 This rule is enabled in the ✅ \`recommended\` config.
-
-<!-- end auto-generated rule header -->
-"
-`;
-
-exports[`generator #generate config that extends another config generates the documentation 4`] = `
-"# Description of no-baz (\`test/no-baz\`)
-
-💼 This rule is enabled in the ✅ \`recommended\` config.
-
-<!-- end auto-generated rule header -->
-"
-`;
-
-exports[`generator #generate config that extends another config generates the documentation 5`] = `
-"# Description of no-biz (\`test/no-biz\`)
 
 💼 This rule is enabled in the ✅ \`recommended\` config.
 
@@ -456,6 +385,28 @@ exports[`generator #generate only a \`recommended\` config updates the documenta
 
 exports[`generator #generate only a \`recommended\` config updates the documentation 2`] = `
 "# Description (\`test/no-foo\`)
+
+💼 This rule is enabled in the ✅ \`recommended\` config.
+
+<!-- end auto-generated rule header -->
+"
+`;
+
+exports[`generator #generate plugin entry point in JSON format generates the documentation 1`] = `
+"<!-- begin auto-generated rules list -->
+
+💼 Configurations enabled in.\\
+✅ Set in the \`recommended\` configuration.
+
+| Name                           | Description            | 💼 |
+| :----------------------------- | :--------------------- | :- |
+| [no-foo](docs/rules/no-foo.md) | Description for no-foo | ✅  |
+
+<!-- end auto-generated rules list -->"
+`;
+
+exports[`generator #generate plugin entry point in JSON format generates the documentation 2`] = `
+"# Description for no-foo (\`test/no-foo\`)
 
 💼 This rule is enabled in the ✅ \`recommended\` config.
 

--- a/test/lib/generate-cjs-test.ts
+++ b/test/lib/generate-cjs-test.ts
@@ -1,0 +1,75 @@
+// This file uses actual test fixtures on the file system instead of mock-fs due to
+// trouble with the combination of require() for loading CJS plugins, jest, and mock-fs.
+
+import { generate } from '../../lib/generator.js';
+import { join } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const FIXTURE_ROOT = join('test', 'fixtures'); // Relative to project root.
+
+describe('generate (cjs)', function () {
+  describe('basic', function () {
+    it('generates the documentation', async function () {
+      const FIXTURE_PATH = join(FIXTURE_ROOT, 'cjs');
+
+      await generate(FIXTURE_PATH);
+
+      expect(
+        readFileSync(join(FIXTURE_PATH, 'README.md'), 'utf8')
+      ).toMatchSnapshot();
+
+      expect(
+        readFileSync(join(FIXTURE_PATH, 'docs/rules/no-foo.md'), 'utf8')
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe('Missing plugin package.json `main` field', function () {
+    it('defaults to correct entry point', async function () {
+      const FIXTURE_PATH = join(FIXTURE_ROOT, 'cjs-missing-main');
+      await expect(generate(FIXTURE_PATH)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('package.json `main` field points to directory', function () {
+    it('finds entry point', async function () {
+      const FIXTURE_PATH = join(FIXTURE_ROOT, 'cjs-main-directory');
+      await expect(generate(FIXTURE_PATH)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('config that extends another config', function () {
+    it('generates the documentation', async function () {
+      const FIXTURE_PATH = join(FIXTURE_ROOT, 'cjs-config-extends');
+      await generate(FIXTURE_PATH);
+      expect(
+        readFileSync(join(FIXTURE_PATH, 'README.md'), 'utf8')
+      ).toMatchSnapshot();
+      expect(
+        readFileSync(join(FIXTURE_PATH, 'docs/rules/no-foo.md'), 'utf8')
+      ).toMatchSnapshot();
+      expect(
+        readFileSync(join(FIXTURE_PATH, 'docs/rules/no-bar.md'), 'utf8')
+      ).toMatchSnapshot();
+      expect(
+        readFileSync(join(FIXTURE_PATH, 'docs/rules/no-baz.md'), 'utf8')
+      ).toMatchSnapshot();
+      expect(
+        readFileSync(join(FIXTURE_PATH, 'docs/rules/no-biz.md'), 'utf8')
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe('package.json `main` field points to non-existent file', function () {
+    it('throws an error', async function () {
+      const FIXTURE_PATH = join(
+        'test',
+        'fixtures',
+        'cjs-main-file-does-not-exist'
+      );
+      await expect(generate(FIXTURE_PATH)).rejects.toThrow(
+        'Unable to determine plugin entry point.'
+      );
+    });
+  });
+});

--- a/test/lib/generator-test.ts
+++ b/test/lib/generator-test.ts
@@ -20,7 +20,7 @@ describe('generator', function () {
           // package.json
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -163,7 +163,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -215,7 +215,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -270,7 +270,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -334,7 +334,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -412,7 +412,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -468,7 +468,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -510,7 +510,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -552,7 +552,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -592,7 +592,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -630,7 +630,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -674,7 +674,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -725,96 +725,12 @@ describe('generator', function () {
         expect(readFileSync('docs/rules/no-bar.md', 'utf8')).toMatchSnapshot();
       });
     });
-
-    describe('Missing plugin package.json `main` field', function () {
-      beforeEach(function () {
-        mockFs({
-          'package.json': JSON.stringify({
-            name: 'eslint-plugin-test',
-            type: 'module',
-          }),
-
-          'index.js': 'export default { rules: {} };',
-
-          'README.md':
-            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
-
-          // Needed for some of the test infrastructure to work.
-          node_modules: mockFs.load(
-            resolve(__dirname, '..', '..', 'node_modules')
-          ),
-        });
-      });
-      afterEach(function () {
-        mockFs.restore();
-        jest.resetModules();
-      });
-      it('defaults to index.js entry point', async function () {
-        await expect(generate('.')).resolves.toBeUndefined();
-      });
-    });
-
-    describe('Package.json `main` field points to directory', function () {
-      beforeEach(function () {
-        mockFs({
-          'package.json': JSON.stringify({
-            name: 'eslint-plugin-test',
-            type: 'module',
-            main: 'lib/',
-          }),
-
-          'lib/index.js': 'export default { rules: {} };',
-
-          'README.md':
-            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
-
-          // Needed for some of the test infrastructure to work.
-          node_modules: mockFs.load(
-            resolve(__dirname, '..', '..', 'node_modules')
-          ),
-        });
-      });
-      afterEach(function () {
-        mockFs.restore();
-        jest.resetModules();
-      });
-      it('finds index.js entry point', async function () {
-        await expect(generate('.')).resolves.toBeUndefined();
-      });
-    });
-
-    describe('Package.json `main` field points to non-existent file', function () {
-      beforeEach(function () {
-        mockFs({
-          'package.json': JSON.stringify({
-            name: 'eslint-plugin-test',
-            type: 'module',
-            main: 'index.js',
-          }),
-
-          // Needed for some of the test infrastructure to work.
-          node_modules: mockFs.load(
-            resolve(__dirname, '..', '..', 'node_modules')
-          ),
-        });
-      });
-      afterEach(function () {
-        mockFs.restore();
-        jest.resetModules();
-      });
-      it('throws an error', async function () {
-        await expect(generate('.')).rejects.toThrow(
-          'Could not find entry point for ESLint plugin. Tried: index.js'
-        );
-      });
-    });
-
     describe('README missing rule list markers but with rules section', function () {
       beforeEach(function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -866,7 +782,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -904,7 +820,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -956,7 +872,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -1004,7 +920,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -1052,7 +968,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -1097,7 +1013,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -1158,7 +1074,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -1199,7 +1115,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -1282,7 +1198,7 @@ describe('generator', function () {
       beforeEach(function () {
         mockFs({
           'package.json': JSON.stringify({
-            main: 'index.js',
+            exports: 'index.js',
           }),
 
           'index.js': 'export default { rules: {} }',
@@ -1307,7 +1223,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: '@my-scope/eslint-plugin',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -1350,7 +1266,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -1391,7 +1307,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -1414,48 +1330,6 @@ describe('generator', function () {
       });
       it('throws an error', async function () {
         await expect(generate('.')).rejects.toThrowErrorMatchingSnapshot();
-      });
-    });
-
-    describe('CJS (non-ESM)', function () {
-      beforeEach(function () {
-        mockFs({
-          'package.json': JSON.stringify({
-            name: 'eslint-plugin-test',
-            main: 'index.cjs',
-            type: 'commonjs', // ts-jest doesn't seem to respect this `type`, so we have to use .cjs extension.
-          }),
-
-          'index.cjs': `module.exports = {
-            rules: {
-              'no-foo': {
-                meta: { docs: { description: 'disallow foo.' }, },
-                create(context) {}
-              },
-            },
-          };`,
-
-          'README.md':
-            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
-
-          'docs/rules/no-foo.md': '',
-
-          // Needed for some of the test infrastructure to work.
-          node_modules: mockFs.load(
-            resolve(__dirname, '..', '..', 'node_modules')
-          ),
-        });
-      });
-      afterEach(function () {
-        mockFs.restore();
-        jest.resetModules();
-      });
-      it('generates the documentation', async function () {
-        await generate('.');
-
-        expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
-
-        expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
       });
     });
 
@@ -1533,7 +1407,7 @@ describe('generator', function () {
       });
     });
 
-    describe('package.json using exports, with unsupported entry point file type', function () {
+    describe('plugin entry point in JSON format', function () {
       beforeEach(function () {
         mockFs({
           'package.json': JSON.stringify({
@@ -1541,14 +1415,26 @@ describe('generator', function () {
             exports: './index.json',
           }),
 
-          'index.js': `export default {
-            rules: {
-              'no-foo': {
-                meta: { docs: { description: 'disallow foo.' }, },
-                create(context) {}
+          'index.json': `
+            {
+              "rules": {
+                "no-foo": {
+                  "meta": {
+                    "docs": {
+                      "description": "Description for no-foo"
+                    }
+                  }
+                }
               },
-            },
-          };`,
+              "configs": {
+                "recommended": {
+                  "rules": {
+                    "test/no-foo": "error"
+                  }
+                }
+              }
+            }
+          `,
 
           'README.md':
             '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
@@ -1565,12 +1451,12 @@ describe('generator', function () {
         mockFs.restore();
         jest.resetModules();
       });
-      it('throws an error', async function () {
-        await expect(
-          generate('.', { configEmoji: ['foo,bar,baz'] })
-        ).rejects.toThrow(
-          'Unsupported file type for plugin entry point. Current types supported: .js, .cjs, .mjs. Entry point detected: ./index.json'
-        );
+      it('generates the documentation', async function () {
+        await generate('.');
+
+        expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
+
+        expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
       });
     });
 
@@ -1580,6 +1466,7 @@ describe('generator', function () {
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
             type: 'module',
+            exports: 'index.js',
           }),
 
           'index.js': `
@@ -1638,6 +1525,7 @@ describe('generator', function () {
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
             type: 'module',
+            exports: 'index.js',
           }),
 
           'index.js': `
@@ -1691,6 +1579,7 @@ describe('generator', function () {
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
             type: 'module',
+            exports: 'index.js',
           }),
 
           'index.js': `
@@ -1740,6 +1629,7 @@ describe('generator', function () {
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
             type: 'module',
+            exports: 'index.js',
           }),
 
           'index.js': `
@@ -1791,6 +1681,7 @@ describe('generator', function () {
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
             type: 'module',
+            exports: 'index.js',
           }),
 
           'index.js': `
@@ -1828,107 +1719,12 @@ describe('generator', function () {
       });
     });
 
-    describe('config that extends another config', function () {
-      beforeEach(function () {
-        mockFs({
-          'package.json': JSON.stringify({
-            name: 'eslint-plugin-test',
-            main: 'index.cjs',
-            type: 'commonjs',
-          }),
-
-          'index.cjs': `
-            module.exports = {
-              rules: {
-                'no-foo': {
-                  meta: { docs: { description: 'Description of no-foo.' }, },
-                  create(context) {}
-                },
-                'no-bar': {
-                  meta: { docs: { description: 'Description of no-bar.' }, },
-                  create(context) {}
-                },
-                'no-baz': {
-                  meta: { docs: { description: 'Description of no-baz.' }, },
-                  create(context) {}
-                },
-                'no-biz': {
-                  meta: { docs: { description: 'Description of no-biz.' }, },
-                  create(context) {}
-                },
-              },
-              configs: {
-                recommended: {
-                  extends: [
-                    require.resolve('./base-config'),
-                    // Should ignore these since they're external:
-                    'eslint:recommended',
-                    'plugin:some-plugin/recommended',
-                    'prettier',
-                  ],
-                }
-              }
-            };`,
-
-          // Multi-level nested config with `rules` and `extends`.
-          'base-config.cjs': `
-            module.exports = {
-              extends: [require.resolve("./base-base-config")],
-              rules: { "test/no-foo": "error" },
-              overrides: [{
-                extends: [require.resolve("./override-config")],
-                files: ["*.js"],
-                rules: { "test/no-baz": "error" },
-              }]
-            };`,
-
-          // Multi-level nested config with no `rules` and string (non-array) version of `extends`.
-          'base-base-config.cjs':
-            'module.exports = { extends: require.resolve("./base-base-base-config") };',
-
-          // Multi-level nested config with no further `extends`.
-          'base-base-base-config.cjs':
-            'module.exports = { rules: { "test/no-bar": "error" } };',
-
-          // Config extended from an override.
-          'override-config.cjs':
-            'module.exports = { rules: { "test/no-biz": "error" } };',
-
-          'README.md': '## Rules\n',
-
-          'docs/rules/no-foo.md': '',
-          'docs/rules/no-bar.md': '',
-          'docs/rules/no-baz.md': '',
-          'docs/rules/no-biz.md': '',
-
-          // Needed for some of the test infrastructure to work.
-          node_modules: mockFs.load(
-            resolve(__dirname, '..', '..', 'node_modules')
-          ),
-        });
-      });
-
-      afterEach(function () {
-        mockFs.restore();
-        jest.resetModules();
-      });
-
-      it('generates the documentation', async function () {
-        await generate('.');
-        expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
-        expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
-        expect(readFileSync('docs/rules/no-bar.md', 'utf8')).toMatchSnapshot();
-        expect(readFileSync('docs/rules/no-baz.md', 'utf8')).toMatchSnapshot();
-        expect(readFileSync('docs/rules/no-biz.md', 'utf8')).toMatchSnapshot();
-      });
-    });
-
     describe('config with overrides', function () {
       beforeEach(function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -1980,7 +1776,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -2030,7 +1826,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -2128,7 +1924,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -2184,7 +1980,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -2238,7 +2034,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -2280,7 +2076,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -2328,7 +2124,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -2374,7 +2170,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -2420,7 +2216,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -2476,7 +2272,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -2524,7 +2320,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -2567,7 +2363,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -2610,7 +2406,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -2653,7 +2449,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -2693,7 +2489,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -2733,7 +2529,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -2775,7 +2571,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -2824,7 +2620,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -2874,7 +2670,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -2930,7 +2726,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -2988,7 +2784,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -3029,7 +2825,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -3070,7 +2866,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -3114,7 +2910,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -3156,7 +2952,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -3201,7 +2997,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -3245,7 +3041,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -3287,7 +3083,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -3330,7 +3126,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -3379,7 +3175,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -3441,7 +3237,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -3480,7 +3276,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -3521,7 +3317,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -3571,7 +3367,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -3610,7 +3406,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -3649,7 +3445,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -3688,7 +3484,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -3739,7 +3535,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -3778,7 +3574,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -3824,7 +3620,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -3866,7 +3662,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -3910,7 +3706,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -3954,7 +3750,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -3996,7 +3792,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -4041,7 +3837,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -4082,7 +3878,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -4133,7 +3929,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -4172,7 +3968,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -4211,7 +4007,7 @@ describe('generator', function () {
         mockFs({
           'package.json': JSON.stringify({
             name: 'eslint-plugin-test',
-            main: 'index.js',
+            exports: 'index.js',
             type: 'module',
           }),
 
@@ -4253,6 +4049,37 @@ describe('generator', function () {
         expect(readFileSync('docs/rules/a.md', 'utf8')).toMatchSnapshot();
         expect(readFileSync('docs/rules/B.md', 'utf8')).toMatchSnapshot();
         expect(readFileSync('docs/rules/c.md', 'utf8')).toMatchSnapshot();
+      });
+    });
+
+    describe('plugin entry point specified but does not exist', function () {
+      beforeEach(function () {
+        mockFs({
+          'package.json': JSON.stringify({
+            name: 'eslint-plugin-test',
+            exports: 'index.js',
+            type: 'module',
+          }),
+
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
+
+          // Needed for some of the test infrastructure to work.
+          node_modules: mockFs.load(
+            resolve(__dirname, '..', '..', 'node_modules')
+          ),
+        });
+      });
+
+      afterEach(function () {
+        mockFs.restore();
+        jest.resetModules();
+      });
+
+      it('throws an error', async function () {
+        await expect(generate('.')).rejects.toThrow(
+          'ESLint plugin entry point does not exist. Tried: index.js'
+        );
       });
     });
   });


### PR DESCRIPTION
For CJS plugins, we should just load them with Node's `require` function. This defers to Node on resolving/loading the package entry point, meaning we don't have to try to handle any of that logic ourselves. As a result, support for CJS plugins should be improved. This greater robustness means any file types (e.g. JSON) handled by require are also supported now.

Only for ESM plugins do we need to manually try to resolve the package entry point to pass to the `import` function. That's because you can't just do `import('path/to/plugin')` for importing a local directory. `import` does not automatically resolve anything, so we have to do attempt to do it ourselves by looking at `exports` in package.json.

Related to #140. Helps with #132.
