### PR TITLE
Add consolidated rule doc notice for fixable and suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ And how it looks:
 | `--config-emoji` | Custom emoji to use for a config. Format is `config-name,emoji`. Default emojis are provided for [common configs](./lib/emojis.ts). To remove a default emoji and rely on a [badge](#badge) instead, provide the config name without an emoji. Option can be repeated. |
 | `--ignore-config` | Config to ignore from being displayed. Often used for an `all` config. Option can be repeated. |
 | `--ignore-deprecated-rules` | Whether to ignore deprecated rules from being checked, displayed, or updated (default: `false`). |
-| `--rule-doc-notices` | Ordered, comma-separated list of notices to display in rule doc. Non-applicable notices will be hidden. Choices: `configs`, `deprecated`, `fixable`, `hasSuggestions`, `requiresTypeChecking`, `type` (off by default). Default: `deprecated,configs,fixable,hasSuggestions,requiresTypeChecking`. |
+| `--rule-doc-notices` | Ordered, comma-separated list of notices to display in rule doc. Non-applicable notices will be hidden. Choices: `configs`, `deprecated`, `fixable`, `fixableAndHasSuggestions`, `hasSuggestions`, `requiresTypeChecking`, `type` (off by default). Default: `deprecated,configs,fixable,fixableAndHasSuggestions,hasSuggestions,requiresTypeChecking`. |
 | `--rule-doc-section-exclude` | Disallowed section in each rule doc. Exit with failure if present. Option can be repeated. |
 | `--rule-doc-section-include` | Required section in each rule doc. Exit with failure if missing. Option can be repeated. |
 | `--rule-doc-title-format` | The format to use for rule doc titles. Defaults to `desc-parens-prefix-name`. See choices in below [table](#--rule-doc-title-format). |

--- a/lib/rule-notices.ts
+++ b/lib/rule-notices.ts
@@ -28,6 +28,7 @@ export const NOTICE_TYPE_DEFAULT_PRESENCE_AND_ORDERING: {
   [NOTICE_TYPE.DEPRECATED]: true, // Most important.
   [NOTICE_TYPE.CONFIGS]: true,
   [NOTICE_TYPE.FIXABLE]: true,
+  [NOTICE_TYPE.FIXABLE_AND_HAS_SUGGESTIONS]: true, // Potentially replaces FIXABLE and HAS_SUGGESTIONS.
   [NOTICE_TYPE.HAS_SUGGESTIONS]: true,
   [NOTICE_TYPE.REQUIRES_TYPE_CHECKING]: true,
   [NOTICE_TYPE.TYPE]: false,
@@ -104,6 +105,7 @@ const RULE_NOTICES: {
 
   // Simple strings.
   [NOTICE_TYPE.FIXABLE]: `${EMOJI_FIXABLE} This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).`,
+  [NOTICE_TYPE.FIXABLE_AND_HAS_SUGGESTIONS]: `${EMOJI_FIXABLE}${EMOJI_HAS_SUGGESTIONS} This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) and manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).`,
   [NOTICE_TYPE.HAS_SUGGESTIONS]: `${EMOJI_HAS_SUGGESTIONS} This rule is manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).`,
   [NOTICE_TYPE.REQUIRES_TYPE_CHECKING]: `${EMOJI_REQUIRES_TYPE_CHECKING} This rule requires type information.`,
 };
@@ -131,8 +133,19 @@ function getNoticesForRule(
     // Alphabetical order.
     [NOTICE_TYPE.CONFIGS]: configsEnabled.length > 0,
     [NOTICE_TYPE.DEPRECATED]: rule.meta.deprecated || false,
-    [NOTICE_TYPE.FIXABLE]: Boolean(rule.meta.fixable),
-    [NOTICE_TYPE.HAS_SUGGESTIONS]: rule.meta.hasSuggestions || false,
+
+    // FIXABLE_AND_HAS_SUGGESTIONS potentially replaces FIXABLE and HAS_SUGGESTIONS.
+    [NOTICE_TYPE.FIXABLE]:
+      Boolean(rule.meta.fixable) &&
+      (!rule.meta.hasSuggestions ||
+        !ruleDocNotices.includes(NOTICE_TYPE.FIXABLE_AND_HAS_SUGGESTIONS)),
+    [NOTICE_TYPE.FIXABLE_AND_HAS_SUGGESTIONS]:
+      Boolean(rule.meta.fixable) && Boolean(rule.meta.hasSuggestions),
+    [NOTICE_TYPE.HAS_SUGGESTIONS]:
+      Boolean(rule.meta.hasSuggestions) &&
+      (!rule.meta.fixable ||
+        !ruleDocNotices.includes(NOTICE_TYPE.FIXABLE_AND_HAS_SUGGESTIONS)),
+
     [NOTICE_TYPE.REQUIRES_TYPE_CHECKING]:
       rule.meta.docs?.requiresTypeChecking || false,
     [NOTICE_TYPE.TYPE]: Boolean(rule.meta.type),

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -38,6 +38,7 @@ export enum NOTICE_TYPE {
   CONFIGS = 'configs',
   DEPRECATED = 'deprecated',
   FIXABLE = 'fixable',
+  FIXABLE_AND_HAS_SUGGESTIONS = 'fixableAndHasSuggestions', // Consolidated notice for space-saving.
   HAS_SUGGESTIONS = 'hasSuggestions',
   REQUIRES_TYPE_CHECKING = 'requiresTypeChecking',
   TYPE = 'type',

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -660,9 +660,7 @@ exports[`generator #generate successful updates the documentation 2`] = `
 
 💼 This rule is enabled in the following configs: 🌐 \`all\`, ✅ \`recommended\`.
 
-🔧 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
-
-💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+🔧💡 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) and manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
 <!-- end rule header -->
 ## Rule details
@@ -966,9 +964,7 @@ exports[`generator #generate with --rule-list-columns shows the right columns an
 
 ❌ This rule is deprecated.
 
-🔧 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
-
-💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+🔧💡 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) and manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
 <!-- end rule header -->
 "


### PR DESCRIPTION
Fixes #99.

This is configurable based on whether the `fixableAndHasSuggestions` notice type is passed to `--rule-doc-notices` (on by default).

This helps save vertical space in the rule doc by combining these related notices.