### PR TITLE
Use markdown-table for generating rules list

### DIFF
--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -12,6 +12,7 @@ import { getPluginRoot } from './package-json.js';
 import { generateLegend } from './legend.js';
 import { relative } from 'node:path';
 import { COLUMN_TYPE } from './types.js';
+import { markdownTable } from 'markdown-table';
 import type {
   Plugin,
   RuleDetails,
@@ -109,27 +110,25 @@ function generateRulesListMarkdown(
         : headerStrOrFn,
     ];
   });
-  const listSpacerRow = Array.from({ length: listHeaderRow.length }).fill(
-    ':--'
-  ); // Left-align header with colon.
-  return [
-    listHeaderRow,
-    listSpacerRow,
-    ...details
-      .sort(({ name: a }, { name: b }) => a.localeCompare(b))
-      .map((rule: RuleDetails) =>
-        buildRuleRow(
-          columns,
-          rule,
-          configsToRules,
-          pluginPrefix,
-          configEmojis,
-          ignoreConfig
-        )
-      ),
-  ]
-    .map((column) => [...column, ' '].join('|'))
-    .join('\n');
+
+  return markdownTable(
+    [
+      listHeaderRow,
+      ...details
+        .sort(({ name: a }, { name: b }) => a.localeCompare(b))
+        .map((rule: RuleDetails) =>
+          buildRuleRow(
+            columns,
+            rule,
+            configsToRules,
+            pluginPrefix,
+            configEmojis,
+            ignoreConfig
+          )
+        ),
+    ],
+    { align: 'l' } // Left-align headers.
+  );
 }
 
 export async function updateRulesList(

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@typescript-eslint/utils": "^5.38.1",
         "commander": "^9.4.0",
+        "markdown-table": "^3.0.2",
         "type-fest": "^3.0.0"
       },
       "bin": {
@@ -7427,6 +7428,15 @@
       },
       "bin": {
         "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.2.tgz",
+      "integrity": "sha512-y8j3a5/DkJCmS5x4dMCQL+OR0+2EAq3DOtio1COSHsmW2BGXnNCK3v12hJt1LrUz5iZH5g0LmuYOjDdI+czghA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/markdownlint": {
@@ -17455,6 +17465,11 @@
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
       }
+    },
+    "markdown-table": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.2.tgz",
+      "integrity": "sha512-y8j3a5/DkJCmS5x4dMCQL+OR0+2EAq3DOtio1COSHsmW2BGXnNCK3v12hJt1LrUz5iZH5g0LmuYOjDdI+czghA=="
     },
     "markdownlint": {
       "version": "0.26.2",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@typescript-eslint/utils": "^5.38.1",
     "commander": "^9.4.0",
+    "markdown-table": "^3.0.2",
     "type-fest": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Eliminates need for us to manually create the table syntax.

Fixes a bug where we might end up with an extra space at the end of each table line (encountered in eslint-plugin-react).

Ensures prettier will be able to format the table nicely due to the valid table syntax generated.

https://www.npmjs.com/package/markdown-table