### PR TITLE
Avoid two config legends for the same emoji

### DIFF
--- a/lib/legend.ts
+++ b/lib/legend.ts
@@ -52,10 +52,12 @@ const LEGENDS: {
 
     const legends = [];
     if (
-      configNamesWithoutIgnored.length > 1 ||
-      !configEmojis.find((configEmoji) =>
-        configNamesWithoutIgnored?.includes(configEmoji.config)
-      )?.emoji
+      (configNamesWithoutIgnored.length > 1 ||
+        !configEmojis.find((configEmoji) =>
+          configNamesWithoutIgnored?.includes(configEmoji.config)
+        )?.emoji) &&
+      // If any configs are using the generic config emoji, then don't display the generic config legend.
+      !configEmojis.some((configEmoji) => configEmoji.emoji === EMOJI_CONFIG)
     ) {
       // Generic config emoji will be used if the plugin has multiple configs or the sole config has no emoji.
       legends.push(`${EMOJI_CONFIG} ${configsLinkOrWord} enabled in.`);

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -845,6 +845,29 @@ exports[`generator #generate with --config-emoji and removing default emoji for 
 "
 `;
 
+exports[`generator #generate with --config-emoji and using the default config emoji for a config hides the generic config emoji legend to avoid two legends for the same emoji 1`] = `
+"## Rules
+<!-- begin rules list -->
+
+💼 Enabled in the \`recommended\` configuration.
+
+| Name                           | Description             | 💼  |
+| :----------------------------- | :---------------------- | :-- |
+| [no-foo](docs/rules/no-foo.md) | Description for no-foo. | 💼  |
+
+<!-- end rules list -->
+"
+`;
+
+exports[`generator #generate with --config-emoji and using the default config emoji for a config hides the generic config emoji legend to avoid two legends for the same emoji 2`] = `
+"# Description for no-foo (\`test/no-foo\`)
+
+💼 This rule is enabled in the \`recommended\` config.
+
+<!-- end rule header -->
+"
+`;
+
 exports[`generator #generate with --config-emoji shows the correct emojis 1`] = `
 "## Rules
 <!-- begin rules list -->

--- a/test/lib/generator-test.ts
+++ b/test/lib/generator-test.ts
@@ -2719,6 +2719,50 @@ describe('generator', function () {
       });
     });
 
+    describe('with --config-emoji and using the default config emoji for a config', function () {
+      beforeEach(function () {
+        mockFs({
+          'package.json': JSON.stringify({
+            name: 'eslint-plugin-test',
+            main: 'index.js',
+            type: 'module',
+          }),
+
+          'index.js': `
+            export default {
+              rules: {
+                'no-foo': { meta: { docs: { description: 'Description for no-foo.'} }, create(context) {} },
+              },
+              configs: {
+                recommended: { rules: { 'test/no-foo': 'error' } },
+              }
+            };`,
+
+          'README.md': '## Rules\n',
+
+          'docs/rules/no-foo.md': '',
+
+          // Needed for some of the test infrastructure to work.
+          node_modules: mockFs.load(
+            resolve(__dirname, '..', '..', 'node_modules')
+          ),
+        });
+      });
+
+      afterEach(function () {
+        mockFs.restore();
+        jest.resetModules();
+      });
+
+      it('hides the generic config emoji legend to avoid two legends for the same emoji', async function () {
+        await generate('.', {
+          configEmoji: ['recommended,💼'],
+        });
+        expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
+        expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
+      });
+    });
+
     describe('with one config that does not have emoji', function () {
       beforeEach(function () {
         mockFs({


### PR DESCRIPTION
For example, if wants to specify `--config-emoji recommended,💼`, then we don't want to show two legends for the same emoji like this:

```
💼 [Configurations](https://github.com/jsx-eslint/eslint-plugin-react/#shareable-configs) enabled in.\
💼 Enabled in the `recommended` [configuration](https://github.com/jsx-eslint/eslint-plugin-react/#shareable-configs).\
```

Instead, just remove the generic config legend.

Example request for this: https://github.com/jsx-eslint/eslint-plugin-react/pull/3469#discussion_r1001115159