### PR TITLE
Use code styling for replacement rule name in deprecated rule notice

### DIFF
--- a/lib/rule-notices.ts
+++ b/lib/rule-notices.ts
@@ -115,7 +115,7 @@ const RULE_NOTICES: {
  */
 function ruleNamesToList(ruleNames: readonly string[]) {
   return ruleNames
-    .map((ruleName) => `[${ruleName}](${ruleName}.md)`)
+    .map((ruleName) => `[\`${ruleName}\`](${ruleName}.md)`)
     .join(', ');
 }
 

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -203,7 +203,7 @@ exports[`generator #generate deprecated rules updates the documentation 1`] = `
 exports[`generator #generate deprecated rules updates the documentation 2`] = `
 "# Description (\`test/no-foo\`)
 
-❌ This rule is deprecated. It was replaced by [no-bar](no-bar.md).
+❌ This rule is deprecated. It was replaced by [\`no-bar\`](no-bar.md).
 
 <!-- end rule header -->
 "


### PR DESCRIPTION
Requested here: https://github.com/jsx-eslint/eslint-plugin-react/pull/3469#discussion_r1001115683

Code styling for rule names seems to work. However, I don't think we should use code styling for the rule names in the README rules list, as that would be a lot of extra/unnecessary formatting.