### PR TITLE
Indicate that content is auto-generated in marker comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Add scripts to `package.json` (both a lint script to ensure everything is up-to-
 Delete any old rules list from your `README.md`. A new one will be automatically added to your `## Rules` section (along with the following marker comments if they don't already exist):
 
 ```md
-<!-- begin rules list -->
-<!-- end rules list -->
+<!-- begin auto-generated rules list -->
+<!-- end auto-generated rules list -->
 ```
 
 Delete any old recommended/fixable/etc. notices from your rule docs. A new title and notices will be automatically added to the top of each rule doc (along with a marker comment if it doesn't exist yet).
@@ -86,7 +86,7 @@ Generated content in a rule doc (everything above the marker comment) (intention
 
 ❌ This rule is deprecated. It was replaced by [prefer-bar](prefer-bar.md).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 Description.
 
@@ -104,7 +104,7 @@ Generated rules table in `README.md` (everything between the marker comments) (i
 
 ## Rules
 
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 💼 Configurations enabled in.\
 ✅ Enabled in the `recommended` configuration.\
@@ -124,7 +124,7 @@ Generated rules table in `README.md` (everything between the marker comments) (i
 | [prefer-bar](docs/rules/prefer-bar.md)   | enforce using bar  | ✅ 🎨 |     | 💡  | 💭  | 📖  |     |
 | [require-baz](docs/rules/require-baz.md) | require using baz  |       | 🔧  |     |     | 📏  | ❌  |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 
 ...
 ```

--- a/lib/markers.ts
+++ b/lib/markers.ts
@@ -1,6 +1,7 @@
 // Markers so that the README rules list can be automatically updated.
-export const BEGIN_RULE_LIST_MARKER = '<!-- begin rules list -->';
-export const END_RULE_LIST_MARKER = '<!-- end rules list -->';
+export const BEGIN_RULE_LIST_MARKER =
+  '<!-- begin auto-generated rules list -->';
+export const END_RULE_LIST_MARKER = '<!-- end auto-generated rules list -->';
 
 // Marker so that rule doc header (title/notices) can be automatically updated.
-export const END_RULE_HEADER_MARKER = '<!-- end rule header -->';
+export const END_RULE_HEADER_MARKER = '<!-- end auto-generated rule header -->';

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`generator #generate CJS (non-ESM) generates the documentation 1`] = `
-"<!-- begin rules list -->
+"<!-- begin auto-generated rules list -->
 
 | Name                           | Description   |
 | :----------------------------- | :------------ |
 | [no-foo](docs/rules/no-foo.md) | disallow foo. |
 
-<!-- end rules list -->"
+<!-- end auto-generated rules list -->"
 `;
 
 exports[`generator #generate CJS (non-ESM) generates the documentation 2`] = `
 "# Disallow foo (\`test/no-foo\`)
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
@@ -22,25 +22,25 @@ exports[`generator #generate Missing plugin package.json \`name\` field throws a
 exports[`generator #generate Missing plugin package.json throws an error 1`] = `"Could not find package.json of ESLint plugin."`;
 
 exports[`generator #generate No configs found omits the config column 1`] = `
-"<!-- begin rules list -->
+"<!-- begin auto-generated rules list -->
 
 | Name                           | Description   |
 | :----------------------------- | :------------ |
 | [no-foo](docs/rules/no-foo.md) | disallow foo. |
 
-<!-- end rules list -->"
+<!-- end auto-generated rules list -->"
 `;
 
 exports[`generator #generate No configs found omits the config column 2`] = `
 "# Disallow foo (\`test/no-foo\`)
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate No exported rules object found throws an error 1`] = `"Could not find exported \`rules\` object in ESLint plugin."`;
 
-exports[`generator #generate README missing rule list markers and no rules section throws an error 1`] = `"README.md is missing rules list markers: <!-- begin rules list --><!-- end rules list -->"`;
+exports[`generator #generate README missing rule list markers and no rules section throws an error 1`] = `"README.md is missing rules list markers: <!-- begin auto-generated rules list --><!-- end auto-generated rules list -->"`;
 
 exports[`generator #generate README missing rule list markers but with rules section adds rule list markers to rule section 1`] = `
 "# eslint-plugin-test
@@ -48,13 +48,13 @@ exports[`generator #generate README missing rule list markers but with rules sec
 Foo.
 
 ## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 | Name                           | Description            |
 | :----------------------------- | :--------------------- |
 | [no-foo](docs/rules/no-foo.md) | Description of no-foo. |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 
 Old rules list.
 
@@ -66,7 +66,7 @@ Bar."
 exports[`generator #generate Rule description needs to be formatted capitalizes the first letter and removes the trailing period from the description 1`] = `
 "# Disallow foo (\`test/no-foo\`)
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
@@ -75,13 +75,13 @@ exports[`generator #generate Scoped plugin name determines the correct plugin pr
 
 ✅ This rule is enabled in the \`recommended\` config.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate config that extends another config generates the documentation 1`] = `
 "## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 ✅ Enabled in the \`recommended\` configuration.
 
@@ -92,7 +92,7 @@ exports[`generator #generate config that extends another config generates the do
 | [no-biz](docs/rules/no-biz.md) | Description of no-biz. | ✅  |
 | [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅  |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 "
 `;
 
@@ -101,7 +101,7 @@ exports[`generator #generate config that extends another config generates the do
 
 ✅ This rule is enabled in the \`recommended\` config.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
@@ -110,7 +110,7 @@ exports[`generator #generate config that extends another config generates the do
 
 ✅ This rule is enabled in the \`recommended\` config.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
@@ -119,7 +119,7 @@ exports[`generator #generate config that extends another config generates the do
 
 ✅ This rule is enabled in the \`recommended\` config.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
@@ -128,13 +128,13 @@ exports[`generator #generate config that extends another config generates the do
 
 ✅ This rule is enabled in the \`recommended\` config.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate config with overrides generates the documentation 1`] = `
 "## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 ✅ Enabled in the \`recommended\` configuration.
 
@@ -142,7 +142,7 @@ exports[`generator #generate config with overrides generates the documentation 1
 | :----------------------------- | :--------------------- | :-- |
 | [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅  |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 "
 `;
 
@@ -151,13 +151,13 @@ exports[`generator #generate config with overrides generates the documentation 2
 
 ✅ This rule is enabled in the \`recommended\` config.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate deprecated function-style rule generates the documentation 1`] = `
 "## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 ✅ Enabled in the \`recommended\` configuration.
 
@@ -165,28 +165,28 @@ exports[`generator #generate deprecated function-style rule generates the docume
 | :----------------------------- | :-- |
 | [no-foo](docs/rules/no-foo.md) | ✅  |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 "
 `;
 
 exports[`generator #generate deprecated function-style rule generates the documentation 2`] = `
 "# \`test/no-foo\`
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate deprecated rule with no rule doc but --ignore-deprecated-rules omits the rule from the README and does not try to update its non-existent rule doc 1`] = `
-"<!-- begin rules list -->
+"<!-- begin auto-generated rules list -->
 
 | Name |
 | :--- |
 
-<!-- end rules list -->"
+<!-- end auto-generated rules list -->"
 `;
 
 exports[`generator #generate deprecated rules updates the documentation 1`] = `
-"<!-- begin rules list -->
+"<!-- begin auto-generated rules list -->
 
 ❌ Deprecated.
 
@@ -197,7 +197,7 @@ exports[`generator #generate deprecated rules updates the documentation 1`] = `
 | [no-biz](docs/rules/no-biz.md) | Description. |     |
 | [no-foo](docs/rules/no-foo.md) | Description. | ❌  |
 
-<!-- end rules list -->"
+<!-- end auto-generated rules list -->"
 `;
 
 exports[`generator #generate deprecated rules updates the documentation 2`] = `
@@ -205,7 +205,7 @@ exports[`generator #generate deprecated rules updates the documentation 2`] = `
 
 ❌ This rule is deprecated. It was replaced by [\`no-bar\`](no-bar.md).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
@@ -214,7 +214,7 @@ exports[`generator #generate deprecated rules updates the documentation 3`] = `
 
 ❌ This rule is deprecated.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
@@ -223,30 +223,30 @@ exports[`generator #generate deprecated rules updates the documentation 4`] = `
 
 ❌ This rule is deprecated.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate deprecated rules updates the documentation 5`] = `
 "# Description (\`test/no-biz\`)
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate lowercase README file generates the documentation 1`] = `
-"<!-- begin rules list -->
+"<!-- begin auto-generated rules list -->
 
 | Name                           |
 | :----------------------------- |
 | [no-foo](docs/rules/no-foo.md) |
 
-<!-- end rules list -->"
+<!-- end auto-generated rules list -->"
 `;
 
 exports[`generator #generate no existing comment markers - minimal doc content generates the documentation 1`] = `
 "## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 🔧 Automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
@@ -254,7 +254,7 @@ exports[`generator #generate no existing comment markers - minimal doc content g
 | :----------------------------- | :--------------------- | :-- |
 | [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧  |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 "
 `;
 
@@ -263,13 +263,13 @@ exports[`generator #generate no existing comment markers - minimal doc content g
 
 🔧 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate no existing comment markers - with no blank lines in existing content generates the documentation 1`] = `
 "## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 🔧 Automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
@@ -277,7 +277,7 @@ exports[`generator #generate no existing comment markers - with no blank lines i
 | :----------------------------- | :--------------------- | :-- |
 | [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧  |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 Existing rules section content."
 `;
 
@@ -286,13 +286,13 @@ exports[`generator #generate no existing comment markers - with no blank lines i
 
 🔧 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 Existing rule doc content."
 `;
 
 exports[`generator #generate no existing comment markers - with one blank line around existing content generates the documentation 1`] = `
 "## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 🔧 Automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
@@ -300,7 +300,7 @@ exports[`generator #generate no existing comment markers - with one blank line a
 | :----------------------------- | :--------------------- | :-- |
 | [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧  |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 
 Existing rules section content."
 `;
@@ -310,13 +310,13 @@ exports[`generator #generate no existing comment markers - with one blank line a
 
 🔧 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 Existing rule doc content."
 `;
 
 exports[`generator #generate no prettier config generates the documentation 1`] = `
-"<!-- begin rules list -->
+"<!-- begin auto-generated rules list -->
 
 🔧 Automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
@@ -324,7 +324,7 @@ exports[`generator #generate no prettier config generates the documentation 1`] 
 | :----------------------------- | :--------------------- | :-- |
 | [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧  |
 
-<!-- end rules list -->"
+<!-- end auto-generated rules list -->"
 `;
 
 exports[`generator #generate no prettier config generates the documentation 2`] = `
@@ -332,7 +332,7 @@ exports[`generator #generate no prettier config generates the documentation 2`] 
 
 🔧 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 ## Rule details
 details
 Long line that SHOULD NOT get wrapped by prettier since it's outside the header. Long line that SHOULD NOT get wrapped by prettier since it's outside the header.""
@@ -340,52 +340,52 @@ Long line that SHOULD NOT get wrapped by prettier since it's outside the header.
 
 exports[`generator #generate no rules with description generates the documentation 1`] = `
 "## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 | Name                           |
 | :----------------------------- |
 | [no-foo](docs/rules/no-foo.md) |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 "
 `;
 
 exports[`generator #generate no rules with description generates the documentation 2`] = `
 "# \`test/no-foo\`
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate one rule missing description generates the documentation 1`] = `
 "## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 | Name                           | Description             |
 | :----------------------------- | :---------------------- |
 | [no-bar](docs/rules/no-bar.md) |                         |
 | [no-foo](docs/rules/no-foo.md) | Description for no-foo. |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 "
 `;
 
 exports[`generator #generate one rule missing description generates the documentation 2`] = `
 "# Description for no-foo (\`test/no-foo\`)
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate one rule missing description generates the documentation 3`] = `
 "# \`test/no-bar\`
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate only a \`recommended\` config updates the documentation 1`] = `
-"<!-- begin rules list -->
+"<!-- begin auto-generated rules list -->
 
 ✅ Enabled in the \`recommended\` configuration.
 
@@ -393,7 +393,7 @@ exports[`generator #generate only a \`recommended\` config updates the documenta
 | :----------------------------- | :----------- | :-- |
 | [no-foo](docs/rules/no-foo.md) | Description. | ✅  |
 
-<!-- end rules list -->"
+<!-- end auto-generated rules list -->"
 `;
 
 exports[`generator #generate only a \`recommended\` config updates the documentation 2`] = `
@@ -401,13 +401,13 @@ exports[`generator #generate only a \`recommended\` config updates the documenta
 
 ✅ This rule is enabled in the \`recommended\` config.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate rule config with options generates the documentation 1`] = `
 "## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 ✅ Enabled in the \`recommended\` configuration.
 
@@ -415,7 +415,7 @@ exports[`generator #generate rule config with options generates the documentatio
 | :----------------------------- | :--------------------- | :-- |
 | [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅  |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 "
 `;
 
@@ -424,7 +424,7 @@ exports[`generator #generate rule config with options generates the documentatio
 
 ✅ This rule is enabled in the \`recommended\` config.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
@@ -433,7 +433,7 @@ exports[`generator #generate rule doc without header marker but pre-existing hea
 
 ✅ This rule is enabled in the \`recommended\` config.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 Pre-existing notice about the rule being recommended.
 ## Rule details
 Details."
@@ -441,45 +441,45 @@ Details."
 
 exports[`generator #generate rule with long-enough description to require name column wrapping avoidance adds spaces to the name column 1`] = `
 "## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 | Name&nbsp;&nbsp;               | Description                                                                         |
 | :----------------------------- | :---------------------------------------------------------------------------------- |
 | [no-foo](docs/rules/no-foo.md) | over 60 chars over 60 chars over 60 chars over 60 chars over 60 chars over 60 chars |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 "
 `;
 
 exports[`generator #generate rule with long-enough description to require name column wrapping avoidance adds spaces to the name column 2`] = `
 "# Over 60 chars over 60 chars over 60 chars over 60 chars over 60 chars over 60 chars (\`test/no-foo\`)
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate rule with long-enough description to require name column wrapping avoidance but rule name too short does not add spaces to name column 1`] = `
 "## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 | Name                     | Description                                                                         |
 | :----------------------- | :---------------------------------------------------------------------------------- |
 | [foo](docs/rules/foo.md) | over 60 chars over 60 chars over 60 chars over 60 chars over 60 chars over 60 chars |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 "
 `;
 
 exports[`generator #generate rule with long-enough description to require name column wrapping avoidance but rule name too short does not add spaces to name column 2`] = `
 "# Over 60 chars over 60 chars over 60 chars over 60 chars over 60 chars over 60 chars (\`test/foo\`)
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate rule with type, type column enabled displays the type 1`] = `
 "## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 🗂️ The type of rule.\\
 ❗ Identifies problems that could cause errors or unexpected behavior.\\
@@ -494,86 +494,86 @@ exports[`generator #generate rule with type, type column enabled displays the ty
 | [no-buz](docs/rules/no-buz.md) |     |
 | [no-foo](docs/rules/no-foo.md) | ❗  |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 "
 `;
 
 exports[`generator #generate rule with type, type column enabled displays the type 2`] = `
 "# \`test/no-foo\`
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate rule with type, type column enabled displays the type 3`] = `
 "# \`test/no-bar\`
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate rule with type, type column enabled displays the type 4`] = `
 "# \`test/no-biz\`
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate rule with type, type column enabled displays the type 5`] = `
 "# \`test/no-boz\`
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate rule with type, type column enabled displays the type 6`] = `
 "# \`test/no-buz\`
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate rule with type, type column enabled, but only an unknown type hides the type column and notice 1`] = `
 "## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 | Name                           |
 | :----------------------------- |
 | [no-foo](docs/rules/no-foo.md) |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 "
 `;
 
 exports[`generator #generate rule with type, type column enabled, but only an unknown type hides the type column and notice 2`] = `
 "# \`test/no-foo\`
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate rule with type, type column not enabled hides the type column 1`] = `
 "## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 | Name                           |
 | :----------------------------- |
 | [no-foo](docs/rules/no-foo.md) |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 "
 `;
 
 exports[`generator #generate rule with type, type column not enabled hides the type column 2`] = `
 "# \`test/no-foo\`
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate rules that are disabled generates the documentation 1`] = `
 "## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 ✅ Enabled in the \`recommended\` configuration.
 
@@ -582,26 +582,26 @@ exports[`generator #generate rules that are disabled generates the documentation
 | [no-bar](docs/rules/no-bar.md) | Description of no-bar. |     |
 | [no-foo](docs/rules/no-foo.md) | Description of no-foo. |     |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 "
 `;
 
 exports[`generator #generate rules that are disabled generates the documentation 2`] = `
 "# Description of no-foo (\`test/no-foo\`)
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate rules that are disabled generates the documentation 3`] = `
 "# Description of no-bar (\`test/no-bar\`)
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate shows column and notice for requiresTypeChecking updates the documentation 1`] = `
-"<!-- begin rules list -->
+"<!-- begin auto-generated rules list -->
 
 🌐 Enabled in the \`all\` configuration.\\
 💭 Requires type information.
@@ -611,7 +611,7 @@ exports[`generator #generate shows column and notice for requiresTypeChecking up
 | [no-bar](docs/rules/no-bar.md) | Description of no-bar. |     | 💭  |
 | [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🌐  |     |
 
-<!-- end rules list -->"
+<!-- end auto-generated rules list -->"
 `;
 
 exports[`generator #generate shows column and notice for requiresTypeChecking updates the documentation 2`] = `
@@ -619,7 +619,7 @@ exports[`generator #generate shows column and notice for requiresTypeChecking up
 
 🌐 This rule is enabled in the \`all\` config.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
@@ -628,7 +628,7 @@ exports[`generator #generate shows column and notice for requiresTypeChecking up
 
 💭 This rule requires type information.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
@@ -636,7 +636,7 @@ exports[`generator #generate successful updates the documentation 1`] = `
 "# eslint-plugin-test
 Description.
 ## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 💼 Configurations enabled in.\\
 🌐 Enabled in the \`all\` configuration.\\
@@ -651,7 +651,7 @@ Description.
 | [no-baz](docs/rules/no-baz.md) | Description of no-boz. |       |     |     |
 | [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🌐 ✅ | 🔧  | 💡  |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 more content."
 `;
 
@@ -662,7 +662,7 @@ exports[`generator #generate successful updates the documentation 2`] = `
 
 🔧💡 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) and manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 ## Rule details
 details
 ## Options
@@ -677,7 +677,7 @@ exports[`generator #generate successful updates the documentation 3`] = `
 
 🔧 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 ## Rule details
 details"
 `;
@@ -685,13 +685,13 @@ details"
 exports[`generator #generate successful updates the documentation 4`] = `
 "# Description of no-boz (\`test/no-baz\`)
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 ## Rule details
 details"
 `;
 
 exports[`generator #generate uses prettier config from package.json should wrap prose in rule doc header to just 20 chars 1`] = `
-"<!-- begin rules list -->
+"<!-- begin auto-generated rules list -->
 
 🌐 Enabled in the
 \`all\` configuration.
@@ -700,7 +700,7 @@ exports[`generator #generate uses prettier config from package.json should wrap 
 | :----------------------------- | :--------------------- | :-- |
 | [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🌐  |
 
-<!-- end rules list -->"
+<!-- end auto-generated rules list -->"
 `;
 
 exports[`generator #generate uses prettier config from package.json should wrap prose in rule doc header to just 20 chars 2`] = `
@@ -710,7 +710,7 @@ exports[`generator #generate uses prettier config from package.json should wrap 
 enabled in the \`all\`
 config.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 ## Rule details
 details
 Long line that SHOULD NOT get wrapped by prettier since it's outside the header. Long line that SHOULD NOT get wrapped by prettier since it's outside the header."
@@ -719,48 +719,48 @@ Long line that SHOULD NOT get wrapped by prettier since it's outside the header.
 exports[`generator #generate with \`--rule-doc-title-format\` option = desc uses the right rule doc title format 1`] = `
 "# Description for no-foo
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate with \`--rule-doc-title-format\` option = desc-parens-name uses the right rule doc title format 1`] = `
 "# Description for no-foo (\`no-foo\`)
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate with \`--rule-doc-title-format\` option = desc-parens-prefix-name uses the right rule doc title format, with fallback when missing description 1`] = `
 "# Description for no-foo (\`test/no-foo\`)
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate with \`--rule-doc-title-format\` option = desc-parens-prefix-name uses the right rule doc title format, with fallback when missing description 2`] = `
 "# \`test/no-bar\`
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate with \`--rule-doc-title-format\` option = name uses the right rule doc title format 1`] = `
 "# \`no-foo\`
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate with \`--rule-doc-title-format\` option = prefix-name uses the right rule doc title format 1`] = `
 "# \`test/no-foo\`
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate with \`--url-configs\` option includes the config link 1`] = `
 "## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 💼 [Configurations](http://example.com/configs) enabled in.\\
 ✅ Enabled in the \`recommended\` [configuration](http://example.com/configs).
@@ -770,7 +770,7 @@ exports[`generator #generate with \`--url-configs\` option includes the config l
 | [no-bar](docs/rules/no-bar.md) | Description for no-bar. | ![customConfig][] |
 | [no-foo](docs/rules/no-foo.md) | Description for no-foo. | ✅                |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 "
 `;
 
@@ -779,7 +779,7 @@ exports[`generator #generate with \`--url-configs\` option includes the config l
 
 ✅ This rule is enabled in the \`recommended\` [config](http://example.com/configs).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
@@ -788,13 +788,13 @@ exports[`generator #generate with \`--url-configs\` option includes the config l
 
 💼 This rule is enabled in the \`customConfig\` [config](http://example.com/configs).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate with \`--url-configs\` option with only recommended config includes the config link 1`] = `
 "## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 ✅ Enabled in the \`recommended\` [configuration](http://example.com/configs).
 
@@ -802,7 +802,7 @@ exports[`generator #generate with \`--url-configs\` option with only recommended
 | :----------------------------- | :---------------------- | :-- |
 | [no-foo](docs/rules/no-foo.md) | Description for no-foo. | ✅  |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 "
 `;
 
@@ -811,7 +811,7 @@ exports[`generator #generate with \`--url-configs\` option with only recommended
 
 ✅ This rule is enabled in the \`recommended\` [config](http://example.com/configs).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
@@ -824,7 +824,7 @@ exports[`generator #generate with --check prints the issues, exits with failure,
 
 exports[`generator #generate with --config-emoji and removing default emoji for a config reverts to using a badge for the config 1`] = `
 "## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 💼 Configurations enabled in.
 
@@ -832,7 +832,7 @@ exports[`generator #generate with --config-emoji and removing default emoji for 
 | :----------------------------- | :---------------------- | :--------------- |
 | [no-foo](docs/rules/no-foo.md) | Description for no-foo. | ![recommended][] |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 "
 `;
 
@@ -841,13 +841,13 @@ exports[`generator #generate with --config-emoji and removing default emoji for 
 
 💼 This rule is enabled in the \`recommended\` config.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate with --config-emoji and using the default config emoji for a config hides the generic config emoji legend to avoid two legends for the same emoji 1`] = `
 "## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 💼 Enabled in the \`recommended\` configuration.
 
@@ -855,7 +855,7 @@ exports[`generator #generate with --config-emoji and using the default config em
 | :----------------------------- | :---------------------- | :-- |
 | [no-foo](docs/rules/no-foo.md) | Description for no-foo. | 💼  |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 "
 `;
 
@@ -864,13 +864,13 @@ exports[`generator #generate with --config-emoji and using the default config em
 
 💼 This rule is enabled in the \`recommended\` config.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate with --config-emoji shows the correct emojis 1`] = `
 "## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 💼 Configurations enabled in.\\
 🔥 Enabled in the \`recommended\` configuration.\\
@@ -882,7 +882,7 @@ exports[`generator #generate with --config-emoji shows the correct emojis 1`] = 
 | [no-baz](docs/rules/no-baz.md) | Description for no-boz. | ![configWithoutEmoji][] 🎨 |
 | [no-foo](docs/rules/no-foo.md) | Description for no-foo. | 🔥                         |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 "
 `;
 
@@ -891,7 +891,7 @@ exports[`generator #generate with --config-emoji shows the correct emojis 2`] = 
 
 🔥 This rule is enabled in the \`recommended\` config.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
@@ -900,7 +900,7 @@ exports[`generator #generate with --config-emoji shows the correct emojis 3`] = 
 
 💼 This rule is enabled in the following configs: 🔥 \`recommended\`, 🎨 \`stylistic\`.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
@@ -909,13 +909,13 @@ exports[`generator #generate with --config-emoji shows the correct emojis 4`] = 
 
 💼 This rule is enabled in the following configs: \`configWithoutEmoji\`, 🎨 \`stylistic\`.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate with --ignore-config hides the ignored config 1`] = `
 "## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 ✅ Enabled in the \`recommended\` configuration.
 
@@ -923,7 +923,7 @@ exports[`generator #generate with --ignore-config hides the ignored config 1`] =
 | :----------------------------- | :---------------------- | :-- |
 | [no-foo](docs/rules/no-foo.md) | Description for no-foo. | ✅  |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 "
 `;
 
@@ -932,13 +932,13 @@ exports[`generator #generate with --ignore-config hides the ignored config 2`] =
 
 ✅ This rule is enabled in the \`recommended\` config.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate with --rule-doc-notices shows the right rule doc notices 1`] = `
 "## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 🔧 Automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\\
 💡 Manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).\\
@@ -948,7 +948,7 @@ exports[`generator #generate with --rule-doc-notices shows the right rule doc no
 | :----------------------------- | :---------------------- | :-- | :-- | :-- |
 | [no-foo](docs/rules/no-foo.md) | Description for no-foo. | 🔧  | 💡  | ❌  |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 "
 `;
 
@@ -963,13 +963,13 @@ exports[`generator #generate with --rule-doc-notices shows the right rule doc no
 
 ❗ This rule identifies problems that could cause errors or unexpected behavior.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generator #generate with --rule-list-columns shows the right columns and legend 1`] = `
 "## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 💡 Manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).\\
 🔧 Automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
@@ -978,7 +978,7 @@ exports[`generator #generate with --rule-list-columns shows the right columns an
 | :-- | :-- | :----------------------------- |
 | 💡  | 🔧  | [no-foo](docs/rules/no-foo.md) |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 "
 `;
 
@@ -989,7 +989,7 @@ exports[`generator #generate with --rule-list-columns shows the right columns an
 
 🔧💡 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) and manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;
 
@@ -997,7 +997,7 @@ exports[`generator #generate with no blank lines around comment markers generate
 "# Rules
 
 No blank line after this.
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 🔧 Automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
@@ -1005,7 +1005,7 @@ No blank line after this.
 | :----------------------------- | :--------------------- | :-- |
 | [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧  |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 No blank line before this."
 `;
 
@@ -1014,7 +1014,7 @@ exports[`generator #generate with no blank lines around comment markers generate
 
 🔧 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 No blank line before this."
 `;
 
@@ -1023,7 +1023,7 @@ exports[`generator #generate with one blank line around comment markers generate
 
 One blank line after this.
 
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 🔧 Automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
@@ -1031,7 +1031,7 @@ One blank line after this.
 | :----------------------------- | :--------------------- | :-- |
 | [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧  |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 
 One blank line before this."
 `;
@@ -1041,14 +1041,14 @@ exports[`generator #generate with one blank line around comment markers generate
 
 🔧 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 One blank line before this."
 `;
 
 exports[`generator #generate with one config that does not have emoji shows the default config emoji 1`] = `
 "## Rules
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 💼 Configurations enabled in.
 
@@ -1056,7 +1056,7 @@ exports[`generator #generate with one config that does not have emoji shows the 
 | :----------------------------- | :---------------------- | :---------------------- |
 | [no-foo](docs/rules/no-foo.md) | Description for no-foo. | ![configWithoutEmoji][] |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 "
 `;
 
@@ -1065,6 +1065,6 @@ exports[`generator #generate with one config that does not have emoji shows the 
 
 💼 This rule is enabled in the \`configWithoutEmoji\` config.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 "
 `;

--- a/test/lib/generator-test.ts
+++ b/test/lib/generator-test.ts
@@ -112,9 +112,9 @@ describe('generator', function () {
             # eslint-plugin-test
             Description.
             ## Rules
-            <!-- begin rules list -->
+            <!-- begin auto-generated rules list -->
             ...
-            <!-- end rules list -->
+            <!-- end auto-generated rules list -->
             more content.
           `,
 
@@ -123,7 +123,7 @@ describe('generator', function () {
           'docs/rules/no-foo.md': outdent`
             # title (rule-name)
             description
-            <!-- end rule header -->
+            <!-- end auto-generated rule header -->
             ## Rule details
             details
             ## Options
@@ -131,7 +131,7 @@ describe('generator', function () {
             optionToDoSomething2 - explanation
           `, // rule doc with incorrect header content
           'docs/rules/no-bar.md': outdent`
-            <!-- end rule header -->
+            <!-- end auto-generated rule header -->
             ## Rule details
             details
           `, // marker but no header content
@@ -189,7 +189,8 @@ describe('generator', function () {
               }
             };`,
 
-          'README.md': '<!-- begin rules list --><!-- end rules list -->',
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
 
           'docs/rules/no-foo.md': '',
 
@@ -240,7 +241,8 @@ describe('generator', function () {
               }
             };`,
 
-          'README.md': '<!-- begin rules list --><!-- end rules list -->',
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
 
           'docs/rules/no-foo.md': outdent`
             # Some pre-existing title.
@@ -314,7 +316,8 @@ describe('generator', function () {
               configs: {}
             };`,
 
-          'README.md': '<!-- begin rules list --><!-- end rules list -->',
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
 
           'docs/rules/no-foo.md': '',
           'docs/rules/no-bar.md': '',
@@ -365,7 +368,8 @@ describe('generator', function () {
               configs: {}
             };`,
 
-          'README.md': '<!-- begin rules list --><!-- end rules list -->',
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
 
           // Needed for some of the test infrastructure to work.
           node_modules: mockFs.load(
@@ -405,7 +409,8 @@ describe('generator', function () {
               },
             };`,
 
-          'README.md': '<!-- begin rules list --><!-- end rules list -->',
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
 
           // Needed for some of the test infrastructure to work.
           node_modules: mockFs.load(
@@ -483,7 +488,8 @@ describe('generator', function () {
               },
             };`,
 
-          'readme.md': '<!-- begin rules list --><!-- end rules list -->',
+          'readme.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
           'docs/rules/no-foo.md': '',
 
           // Needed for some of the test infrastructure to work.
@@ -534,7 +540,8 @@ describe('generator', function () {
               }
             };`,
 
-          'README.md': '<!-- begin rules list --><!-- end rules list -->',
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
 
           'docs/rules/no-foo.md': '',
           'docs/rules/no-bar.md': '',
@@ -570,7 +577,8 @@ describe('generator', function () {
 
           'index.js': 'export default { rules: {} };',
 
-          'README.md': '<!-- begin rules list --><!-- end rules list -->',
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
 
           // Needed for some of the test infrastructure to work.
           node_modules: mockFs.load(
@@ -598,7 +606,8 @@ describe('generator', function () {
 
           'lib/index.js': 'export default { rules: {} };',
 
-          'README.md': '<!-- begin rules list --><!-- end rules list -->',
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
 
           // Needed for some of the test infrastructure to work.
           node_modules: mockFs.load(
@@ -757,7 +766,8 @@ describe('generator', function () {
               }
             };`,
 
-          'README.md': '<!-- begin rules list --><!-- end rules list -->',
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
 
           'docs/rules/no-foo.md': '## Options\n', // empty
 
@@ -804,7 +814,8 @@ describe('generator', function () {
               },
             };`,
 
-          'README.md': '<!-- begin rules list --><!-- end rules list -->',
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
 
           'docs/rules/no-foo.md': '', // empty
 
@@ -849,7 +860,8 @@ describe('generator', function () {
               configs: {}
             };`,
 
-          'README.md': '<!-- begin rules list --><!-- end rules list -->',
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
 
           'docs/rules/no-foo.md': '',
 
@@ -909,7 +921,8 @@ describe('generator', function () {
               }
             };`,
 
-          'README.md': '<!-- begin rules list --><!-- end rules list -->',
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
 
           'docs/rules/no-foo.md': '## Options\n', // empty
 
@@ -998,7 +1011,8 @@ describe('generator', function () {
               }
             };`,
 
-          'README.md': '<!-- begin rules list --><!-- end rules list -->',
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
 
           'docs/rules/no-foo.md': '',
 
@@ -1037,7 +1051,8 @@ describe('generator', function () {
               }
             };`,
 
-          'README.md': '<!-- begin rules list --><!-- end rules list -->',
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
 
           'docs/rules/no-foo.md': '',
 
@@ -1069,7 +1084,8 @@ describe('generator', function () {
 
           'index.js': 'export default {};',
 
-          'README.md': '<!-- begin rules list --><!-- end rules list -->',
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
 
           'docs/rules/no-foo.md': '',
 
@@ -1106,7 +1122,8 @@ describe('generator', function () {
             },
           };`,
 
-          'README.md': '<!-- begin rules list --><!-- end rules list -->',
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
 
           'docs/rules/no-foo.md': '',
 
@@ -1146,7 +1163,8 @@ describe('generator', function () {
             },
           };`,
 
-          'README.md': '<!-- begin rules list --><!-- end rules list -->',
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
 
           'docs/rules/no-foo.md': '',
 
@@ -1182,7 +1200,8 @@ describe('generator', function () {
             },
           };`,
 
-          'README.md': '<!-- begin rules list --><!-- end rules list -->',
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
 
           'docs/rules/no-foo.md': '',
 
@@ -1218,7 +1237,8 @@ describe('generator', function () {
             },
           };`,
 
-          'README.md': '<!-- begin rules list --><!-- end rules list -->',
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
 
           'docs/rules/no-foo.md': '',
 
@@ -1264,7 +1284,8 @@ describe('generator', function () {
                       },
                     };`,
 
-          'README.md': '<!-- begin rules list --><!-- end rules list -->',
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
 
           'docs/rules/no-foo.md': outdent`
             ## Rule details
@@ -1319,7 +1340,8 @@ describe('generator', function () {
                   }
                 };`,
 
-          'README.md': '<!-- begin rules list --><!-- end rules list -->',
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
 
           'docs/rules/no-foo.md': outdent`
             ## Rule details
@@ -1371,16 +1393,16 @@ describe('generator', function () {
 
             One blank line after this.
 
-            <!-- begin rules list -->
+            <!-- begin auto-generated rules list -->
 
 
-            <!-- end rules list -->
+            <!-- end auto-generated rules list -->
 
             One blank line before this.
           `,
 
           'docs/rules/no-foo.md': outdent`
-            <!-- end rule header -->
+            <!-- end auto-generated rule header -->
 
             One blank line before this.
           `,
@@ -1428,13 +1450,13 @@ describe('generator', function () {
             # Rules
 
             No blank line after this.
-            <!-- begin rules list -->
-            <!-- end rules list -->
+            <!-- begin auto-generated rules list -->
+            <!-- end auto-generated rules list -->
             No blank line before this.
           `,
 
           'docs/rules/no-foo.md': outdent`
-            <!-- end rule header -->
+            <!-- end auto-generated rule header -->
             No blank line before this.
           `,
 


### PR DESCRIPTION
This will help decrease the chance that ESLint plugin contributors will try to manually edit the managed content. It should help them realize there's likely a command to run instead.

This is a breaking change in that consumers will need to find-and-replace to switch over to the new marker comments.

Fixes #150.