### PR TITLE
Use italics for disabled keyword in notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Generated content in a rule doc (everything above the marker comment) (intention
 
 💼 This rule is enabled in the following configs: ✅ `recommended`, 🎨 `stylistic`.
 
+🎨 This rule is _disabled_ in the `stylistic` config.
+
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
 💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).

--- a/lib/rule-notices.ts
+++ b/lib/rule-notices.ts
@@ -120,9 +120,9 @@ const RULE_NOTICES: {
     // Complete sentence for configs that disable the rule.
     const SENTENCE_DISABLED =
       configsDisabled.length > 1
-        ? `This rule is disabled in the following ${configsLinkOrWord}: ${configsDisabledCSV}.`
+        ? `This rule is _disabled_ in the following ${configsLinkOrWord}: ${configsDisabledCSV}.`
         : configsDisabled.length === 1
-        ? `This rule is disabled in the \`${configsDisabled?.[0]}\` ${configLinkOrWord}.`
+        ? `This rule is _disabled_ in the \`${configsDisabled?.[0]}\` ${configLinkOrWord}.`
         : '';
 
     return `${emoji} ${SENTENCE_ENABLED}${

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -591,7 +591,7 @@ exports[`generator #generate rules that are disabled generates the documentation
 exports[`generator #generate rules that are disabled generates the documentation 2`] = `
 "# Description of no-foo (\`test/no-foo\`)
 
-✅ This rule is disabled in the \`recommended\` config.
+✅ This rule is _disabled_ in the \`recommended\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -600,7 +600,7 @@ exports[`generator #generate rules that are disabled generates the documentation
 exports[`generator #generate rules that are disabled generates the documentation 3`] = `
 "# Description of no-bar (\`test/no-bar\`)
 
-💼 This rule is disabled in the following configs: \`other\`, ✅ \`recommended\`.
+💼 This rule is _disabled_ in the following configs: \`other\`, ✅ \`recommended\`.
 
 <!-- end auto-generated rule header -->
 "
@@ -609,7 +609,7 @@ exports[`generator #generate rules that are disabled generates the documentation
 exports[`generator #generate rules that are disabled generates the documentation 4`] = `
 "# Description of no-bar (\`test/no-baz\`)
 
-💼 This rule is enabled in the \`recommended\` config. This rule is disabled in the \`other\` config.
+💼 This rule is enabled in the \`recommended\` config. This rule is _disabled_ in the \`other\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -618,7 +618,7 @@ exports[`generator #generate rules that are disabled generates the documentation
 exports[`generator #generate rules that are disabled generates the documentation 5`] = `
 "# Description of no-bar (\`test/no-biz\`)
 
-💼 This rule is disabled in the \`other\` config.
+💼 This rule is _disabled_ in the \`other\` config.
 
 <!-- end auto-generated rule header -->
 "


### PR DESCRIPTION
Follow-up to #156.