### PR TITLE
Fix ts-jest deprecation warning

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -6,10 +6,7 @@ module.exports = {
   testEnvironment: 'node',
   testMatch: ['<rootDir>/test/**/*-test.ts'],
   transform: {
-    '^.+\\.tsx?$': [
-      'ts-jest',
-      { useESM: true },
-    ],
+    '^.+\\.tsx?$': ['ts-jest', { useESM: true }],
   },
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -5,10 +5,11 @@ module.exports = {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testMatch: ['<rootDir>/test/**/*-test.ts'],
-  globals: {
-    'ts-jest': {
-      useESM: true,
-    },
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      { useESM: true },
+    ],
   },
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',


### PR DESCRIPTION
Fix for this warning:
```
ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
},
```