### PR TITLE
Add `--split-by` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ And how it looks:
 | `--rule-doc-section-include` | Required section in each rule doc. Exit with failure if missing. Option can be repeated. |
 | `--rule-doc-title-format` | The format to use for rule doc titles. Defaults to `desc-parens-prefix-name`. See choices in below [table](#--rule-doc-title-format). |
 | `--rule-list-columns` | Ordered, comma-separated list of columns to display in rule list. Empty columns will be hidden. Choices: `configs`, `deprecated`, `description`, `fixable`, `hasSuggestions`, `name`, `requiresTypeChecking`, `type` (off by default). Default: `name,description,configs,fixable,hasSuggestions,requiresTypeChecking,deprecated`. |
+| `--split-by` | Rule property to split the rules list by. A separate list and header will be created for each value. Example: `meta.type`. |
 | `--url-configs` | Link to documentation about the ESLint configurations exported by the plugin. |
 
 All options are optional.

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -103,6 +103,10 @@ export function run() {
         .join(',')
     )
     .option(
+      '--split-by <property>',
+      '(optional) Rule property to split the rules list by. A separate list and header will be created for each value. Example: `meta.type`.'
+    )
+    .option(
       '--url-configs <url>',
       '(optional) Link to documentation about the ESLint configurations exported by the plugin.'
     )
@@ -119,6 +123,7 @@ export function run() {
         ruleDocTitleFormat: RuleDocTitleFormat;
         ruleListColumns: string;
         urlConfigs?: string;
+        splitBy?: string;
       }
     ) {
       await generate(path, {
@@ -132,6 +137,7 @@ export function run() {
         ruleDocTitleFormat: options.ruleDocTitleFormat,
         ruleListColumns: options.ruleListColumns,
         urlConfigs: options.urlConfigs,
+        splitBy: options.splitBy,
       });
     })
     .parse(process.argv);

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -88,6 +88,7 @@ export async function generate(
     ruleDocTitleFormat?: RuleDocTitleFormat;
     ruleListColumns?: string;
     urlConfigs?: string;
+    splitBy?: string;
   }
 ) {
   const plugin = await loadPlugin(path);
@@ -227,7 +228,8 @@ export async function generate(
     configEmojis,
     ignoreConfig,
     ruleListColumns,
-    options?.urlConfigs
+    options?.urlConfigs,
+    options?.splitBy
   );
 
   if (options?.check) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@typescript-eslint/utils": "^5.38.1",
+        "camelcase": "^7.0.0",
         "commander": "^9.4.0",
         "markdown-table": "^3.0.2",
         "type-fest": "^3.0.0"
@@ -770,6 +771,15 @@
       "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
@@ -2483,18 +2493,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/boxen/node_modules/camelcase": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.0.tgz",
-      "integrity": "sha512-JToIvOmz6nhGsUhAYScbo2d6Py5wojjNfoxoc2mEVLUdJ70gJK2gnd+ABY1Tc3sVMyK7QDPtN0T/XdlCQWITyQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/boxen/node_modules/chalk": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
@@ -2813,12 +2811,14 @@
       }
     },
     "node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.0.tgz",
+      "integrity": "sha512-JToIvOmz6nhGsUhAYScbo2d6Py5wojjNfoxoc2mEVLUdJ70gJK2gnd+ABY1Tc3sVMyK7QDPtN0T/XdlCQWITyQ==",
       "engines": {
-        "node": ">=6"
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/camelcase-keys": {
@@ -2836,6 +2836,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/caniuse-lite": {
@@ -12542,6 +12551,12 @@
             "sprintf-js": "~1.0.2"
           }
         },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -13840,12 +13855,6 @@
           "integrity": "sha512-qDOv24WjnYuL+wbwHdlsYZFy+cgPtrYw0Tn7GLORicQp9BkQLzrgI3Pm4VyR9ERZ41YTn7KlMPuL1n05WdZvmg==",
           "dev": true
         },
-        "camelcase": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.0.tgz",
-          "integrity": "sha512-JToIvOmz6nhGsUhAYScbo2d6Py5wojjNfoxoc2mEVLUdJ70gJK2gnd+ABY1Tc3sVMyK7QDPtN0T/XdlCQWITyQ==",
-          "dev": true
-        },
         "chalk": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
@@ -14066,10 +14075,9 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.0.tgz",
+      "integrity": "sha512-JToIvOmz6nhGsUhAYScbo2d6Py5wojjNfoxoc2mEVLUdJ70gJK2gnd+ABY1Tc3sVMyK7QDPtN0T/XdlCQWITyQ=="
     },
     "camelcase-keys": {
       "version": "6.2.2",
@@ -14080,6 +14088,14 @@
         "camelcase": "^5.3.1",
         "map-obj": "^4.0.0",
         "quick-lru": "^4.0.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        }
       }
     },
     "caniuse-lite": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "@typescript-eslint/utils": "^5.38.1",
+    "camelcase": "^7.0.0",
     "commander": "^9.4.0",
     "markdown-table": "^3.0.2",
     "type-fest": "^3.0.0"

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -656,6 +656,94 @@ exports[`generator #generate shows column and notice for requiresTypeChecking up
 "
 `;
 
+exports[`generator #generate splitting list by nested property meta.docs.category splits the list 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+| Name                           |
+| :----------------------------- |
+| [no-baz](docs/rules/no-baz.md) |
+
+### candy
+
+| Name                           |
+| :----------------------------- |
+| [no-bar](docs/rules/no-bar.md) |
+
+### fruits
+
+| Name                           |
+| :----------------------------- |
+| [no-foo](docs/rules/no-foo.md) |
+
+<!-- end auto-generated rules list -->
+"
+`;
+
+exports[`generator #generate splitting list by type splits the list 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+| Name                           |
+| :----------------------------- |
+| [no-biz](docs/rules/no-biz.md) |
+
+### problem
+
+| Name                           |
+| :----------------------------- |
+| [no-foo](docs/rules/no-foo.md) |
+
+### suggestion
+
+| Name                           |
+| :----------------------------- |
+| [no-bar](docs/rules/no-bar.md) |
+| [no-baz](docs/rules/no-baz.md) |
+
+<!-- end auto-generated rules list -->
+"
+`;
+
+exports[`generator #generate splitting list, with boolean splits the list 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+💡 Manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+
+| Name                           | 💡  |
+| :----------------------------- | :-- |
+| [no-bar](docs/rules/no-bar.md) |     |
+| [no-baz](docs/rules/no-baz.md) |     |
+
+### Has Suggestions
+
+| Name                           | 💡  |
+| :----------------------------- | :-- |
+| [no-foo](docs/rules/no-foo.md) | 💡  |
+
+<!-- end auto-generated rules list -->
+"
+`;
+
+exports[`generator #generate splitting list, with unknown variable type splits the list but does not attempt to convert variable name to title 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+| Name                           |
+| :----------------------------- |
+| [no-foo](docs/rules/no-foo.md) |
+
+### foo_barBIZ-baz3bOz
+
+| Name                           |
+| :----------------------------- |
+| [no-bar](docs/rules/no-bar.md) |
+
+<!-- end auto-generated rules list -->
+"
+`;
+
 exports[`generator #generate successful updates the documentation 1`] = `
 "# eslint-plugin-test
 Description.


### PR DESCRIPTION
Fixes #22.

Allows the rules list to be split into multiple lists based on an arbitrary property on the rules. Will unblock adoption in multiple plugins.

TODO

- [x] Support nested property paths like `docs.category`
- [x] Refactor logic
- [x] Smarter handling of booleans
- [x] More tests
- [x] `values.has(undefined)` consider more values
