### PR TITLE
Consistent rule list header config emoji when splitting lists

### DIFF
--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -140,12 +140,11 @@ function generateRulesListMarkdown(
       return [];
     }
     const headerStrOrFn = COLUMN_HEADER[columnType];
-    const ruleNames = details.map((rule) => rule.name);
     const configsThatEnableAnyRule = Object.entries(configsToRules)
-      .filter(([configName, _config]) =>
-        ruleNames.some((ruleName) =>
+      .filter(([configName, config]) =>
+        Object.keys(config).some((ruleNameWithPrefix) =>
           getConfigsForRule(
-            ruleName,
+            ruleNameWithPrefix.replace(`${pluginPrefix}/`, ''),
             configsToRules,
             pluginPrefix,
             SEVERITY_ERROR

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -791,6 +791,28 @@ exports[`generator #generate splitting list, with boolean splits the list 1`] = 
 "
 `;
 
+exports[`generator #generate splitting list, with one sub-list having no rules enabled by the config splits the list and still uses recommended config emoji in both lists 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+✅ Enabled in the \`recommended\` configuration.
+
+### bar
+
+| Name                           | ✅  |
+| :----------------------------- | :-- |
+| [no-bar](docs/rules/no-bar.md) |     |
+
+### foo
+
+| Name                           | ✅  |
+| :----------------------------- | :-- |
+| [no-foo](docs/rules/no-foo.md) | ✅  |
+
+<!-- end auto-generated rules list -->
+"
+`;
+
 exports[`generator #generate splitting list, with unknown variable type splits the list but does not attempt to convert variable name to title 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->

--- a/test/lib/generator-test.ts
+++ b/test/lib/generator-test.ts
@@ -3451,6 +3451,51 @@ describe('generator', function () {
       });
     });
 
+    describe('splitting list, with one sub-list having no rules enabled by the config', function () {
+      beforeEach(function () {
+        mockFs({
+          'package.json': JSON.stringify({
+            name: 'eslint-plugin-test',
+            main: 'index.js',
+            type: 'module',
+          }),
+
+          'index.js': `
+            export default {
+              rules: {
+                'no-foo': { 'type': 'foo', meta: { }, create(context) {} },
+                'no-bar': { 'type': 'bar', meta: { }, create(context) {} },
+              },
+              configs: {
+                recommended: { rules: { 'test/no-foo': 'error' } },
+              }
+            };`,
+
+          'README.md': '## Rules\n',
+
+          'docs/rules/no-foo.md': '',
+          'docs/rules/no-bar.md': '',
+
+          // Needed for some of the test infrastructure to work.
+          node_modules: mockFs.load(
+            resolve(__dirname, '..', '..', 'node_modules')
+          ),
+        });
+      });
+
+      afterEach(function () {
+        mockFs.restore();
+        jest.resetModules();
+      });
+
+      it('splits the list and still uses recommended config emoji in both lists', async function () {
+        await generate('.', {
+          splitBy: 'type',
+        });
+        expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
+      });
+    });
+
     describe('splitting list by property that no rules have', function () {
       beforeEach(function () {
         mockFs({


### PR DESCRIPTION
Follow-up to #162.

Bug in previous unreleased PR to implement split lists.

Ensures we don't use the generic config emoji in one of the sub-lists, as it would be inconsistent and we wouldn't have provided a legend for that emoji.