### PR TITLE
Use actual nbsp character instead of HTML entity when avoiding wrapping rule names in rules list

### DIFF
--- a/lib/rule-list-columns.ts
+++ b/lib/rule-list-columns.ts
@@ -70,7 +70,7 @@ export const COLUMN_HEADER: {
       ruleNames.length > 0 &&
       longestRuleDescriptionLength >= 60 &&
       longestRuleNameLength > title.length
-        ? '&nbsp;'.repeat(longestRuleNameLength - title.length)
+        ? ' '.repeat(longestRuleNameLength - title.length) // U+00A0 nbsp character.
         : '';
 
     return `${title}${spaces}`;

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -443,7 +443,7 @@ exports[`generator #generate rule with long-enough description to require name c
 "## Rules
 <!-- begin auto-generated rules list -->
 
-| Name&nbsp;&nbsp;               | Description                                                                         |
+| Name                           | Description                                                                         |
 | :----------------------------- | :---------------------------------------------------------------------------------- |
 | [no-foo](docs/rules/no-foo.md) | over 60 chars over 60 chars over 60 chars over 60 chars over 60 chars over 60 chars |
 


### PR DESCRIPTION
Not a bug fix but more like a tweak with no user-facing behavior change.

Avoids excessively-long name column in markdown due to repeated `&nbsp;` HTML entity as seen here: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/7d804e3ce8ecb9d51b16d558eeae6dc12a81ec4c/readme.md?plain=1#L53

Non-breaking space character copied from here: https://unicode-table.com/en/00A0/

Idea suggested here: https://github.com/jsx-eslint/eslint-plugin-react/pull/3469#discussion_r1006188858

This is a follow-up to the original issue for avoiding wrapping rule names: https://github.com/bmish/eslint-doc-generator/issues/110.

The only downside I see is that it this non-breaking space can be indistinguishable from a regular space to many readers and could cause confusion. The HTML entity is more clear.

What do you think? Add thumbs up or thumbs down emoji to this PR.

CC: @ljharb @sindresorhus @fisker