### PR TITLE
Use correct rule doc title format fallback when rule missing description

### DIFF
--- a/lib/rule-notices.ts
+++ b/lib/rule-notices.ts
@@ -311,8 +311,24 @@ function makeTitle(
 
   let ruleDocTitleFormatWithFallback: RuleDocTitleFormat =
     ruleDocTitleFormat ?? RULE_DOC_TITLE_FORMAT_DEFAULT;
+
   if (ruleDocTitleFormatWithFallback.includes('desc') && !description) {
-    ruleDocTitleFormatWithFallback = 'prefix-name'; // Fallback if rule missing description.
+    // If format includes the description but the rule is missing a description,
+    // fallback to the corresponding format without the description.
+    switch (ruleDocTitleFormatWithFallback) {
+      case 'desc':
+      case 'desc-parens-prefix-name':
+        ruleDocTitleFormatWithFallback = 'prefix-name';
+        break;
+      case 'desc-parens-name':
+        ruleDocTitleFormatWithFallback = 'name';
+        break;
+      /* istanbul ignore next -- this shouldn't happen */
+      default:
+        throw new Error(
+          `Unhandled rule doc title format fallback: ${ruleDocTitleFormatWithFallback}`
+        );
+    }
   }
 
   switch (ruleDocTitleFormatWithFallback) {

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -922,8 +922,22 @@ exports[`generator #generate with \`--rule-doc-title-format\` option = desc uses
 "
 `;
 
+exports[`generator #generate with \`--rule-doc-title-format\` option = desc uses the right rule doc title format 2`] = `
+"# test/no-bar
+
+<!-- end auto-generated rule header -->
+"
+`;
+
 exports[`generator #generate with \`--rule-doc-title-format\` option = desc-parens-name uses the right rule doc title format 1`] = `
 "# Description for no-foo (\`no-foo\`)
+
+<!-- end auto-generated rule header -->
+"
+`;
+
+exports[`generator #generate with \`--rule-doc-title-format\` option = desc-parens-name uses the right rule doc title format 2`] = `
+"# no-bar
 
 <!-- end auto-generated rule header -->
 "

--- a/test/lib/generator-test.ts
+++ b/test/lib/generator-test.ts
@@ -2193,12 +2193,14 @@ describe('generator', function () {
             export default {
               rules: {
                 'no-foo': { meta: { docs: { description: 'Description for no-foo.'} }, create(context) {} },
+                'no-bar': { meta: { docs: { /* one rule without description */ } }, create(context) {} },
               },
             };`,
 
           'README.md': '## Rules\n',
 
           'docs/rules/no-foo.md': '',
+          'docs/rules/no-bar.md': '',
 
           // Needed for some of the test infrastructure to work.
           node_modules: mockFs.load(
@@ -2217,6 +2219,7 @@ describe('generator', function () {
           ruleDocTitleFormat: 'desc-parens-name',
         });
         expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
+        expect(readFileSync('docs/rules/no-bar.md', 'utf8')).toMatchSnapshot();
       });
     });
 
@@ -2233,12 +2236,14 @@ describe('generator', function () {
             export default {
               rules: {
                 'no-foo': { meta: { docs: { description: 'Description for no-foo.'} }, create(context) {} },
+                'no-bar': { meta: { docs: { /* one rule without description */ } }, create(context) {} },
               },
             };`,
 
           'README.md': '## Rules\n',
 
           'docs/rules/no-foo.md': '',
+          'docs/rules/no-bar.md': '',
 
           // Needed for some of the test infrastructure to work.
           node_modules: mockFs.load(
@@ -2257,6 +2262,7 @@ describe('generator', function () {
           ruleDocTitleFormat: 'desc',
         });
         expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
+        expect(readFileSync('docs/rules/no-bar.md', 'utf8')).toMatchSnapshot();
       });
     });
 


### PR DESCRIPTION
If format includes the description but the rule is missing a description, fallback to the corresponding format without the description.