### PR TITLE
Fix escaped quote option check

### DIFF
--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -38,8 +38,8 @@ function expectContent(
   // in case escaping is needed where the content is referenced.
   const hasContent =
     contents.includes(content) ||
-    contents.includes(content.replace('"', '\\"')) ||
-    contents.includes(content.replace("'", "\\'"));
+    contents.includes(content.replace(/"/g, '\\"')) ||
+    contents.includes(content.replace(/'/g, "\\'"));
   if (hasContent !== expected) {
     console.error(
       `\`${ruleName}\` rule doc should ${

--- a/test/lib/generator-test.ts
+++ b/test/lib/generator-test.ts
@@ -988,7 +988,10 @@ describe('generator', function () {
         jest.resetModules();
       });
       it('successfully finds the options mentioned in the rule doc despite quote escaping', async function () {
-        await expect(generate('.')).resolves.toBeUndefined();
+        const consoleErrorStub = sinon.stub(console, 'error');
+        await generate('.');
+        expect(consoleErrorStub.callCount).toBe(0);
+        consoleErrorStub.restore();
       });
     });
 


### PR DESCRIPTION
Follow-up to #176.

The check and the test were both faulty.

Originally I wanted to use `String.replaceAll()` but this isn't available until Node 15.