### PR TITLE
Remove prettier formatting of outputted markdown

### DIFF
--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -174,11 +174,10 @@ export async function generate(
     );
 
     const contents = readFileSync(pathToDoc).toString();
-    const contentsNew = await replaceOrCreateHeader(
+    const contentsNew = replaceOrCreateHeader(
       contents,
       newHeaderLines,
-      END_RULE_HEADER_MARKER,
-      pathToDoc
+      END_RULE_HEADER_MARKER
     );
 
     if (options?.check) {
@@ -230,7 +229,7 @@ export async function generate(
 
   // Update the rules list in the README.
   const readmeContents = readFileSync(pathToReadme, 'utf8');
-  const readmeContentsNew = await updateRulesList(
+  const readmeContentsNew = updateRulesList(
     details,
     readmeContents,
     plugin,

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -1,22 +1,5 @@
 // General helpers for dealing with markdown files / content.
 
-export async function format(str: string, filePath: string): Promise<string> {
-  try {
-    const { default: prettier } = await import('prettier');
-    const options = await prettier.resolveConfig(filePath);
-    return prettier
-      .format(str, {
-        ...options,
-        parser: 'markdown',
-      })
-      .trimEnd(); // Trim the ending newline that prettier may add.
-  } catch {
-    // Skip prettier formatting if not installed.
-    /* istanbul ignore next -- TODO: Figure out how to test when prettier is not installed. */
-    return str;
-  }
-}
-
 /**
  * Replace the header of a doc up to and including the specified marker.
  * Insert at beginning if header doesn't exist.
@@ -24,11 +7,10 @@ export async function format(str: string, filePath: string): Promise<string> {
  * @param newHeader - new header including marker
  * @param marker - marker to indicate end of header
  */
-export async function replaceOrCreateHeader(
+export function replaceOrCreateHeader(
   markdown: string,
   newHeader: string,
-  marker: string,
-  pathToDoc: string
+  marker: string
 ) {
   const lines = markdown.split('\n');
 
@@ -39,9 +21,7 @@ export async function replaceOrCreateHeader(
     lines.splice(0, 1);
   }
 
-  return `${await format(newHeader, pathToDoc)}\n${lines
-    .slice(markerLineIndex + 1)
-    .join('\n')}`;
+  return `${newHeader}\n${lines.slice(markerLineIndex + 1).join('\n')}`;
 }
 
 /**

--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -7,7 +7,7 @@ import {
 } from './emojis.js';
 import { getConfigsForRule } from './configs.js';
 import { getColumns, COLUMN_HEADER } from './rule-list-columns.js';
-import { findSectionHeader, format } from './markdown.js';
+import { findSectionHeader } from './markdown.js';
 import { getPluginRoot } from './package-json.js';
 import { generateLegend } from './legend.js';
 import { relative } from 'node:path';
@@ -271,7 +271,7 @@ function generateRulesListMarkdownWithSplitBy(
   return parts.join('\n\n');
 }
 
-export async function updateRulesList(
+export function updateRulesList(
   details: RuleDetails[],
   markdown: string,
   plugin: Plugin,
@@ -284,7 +284,7 @@ export async function updateRulesList(
   ruleListColumns: COLUMN_TYPE[],
   urlConfigs?: string,
   splitBy?: string
-): Promise<string> {
+): string {
   let listStartIndex = markdown.indexOf(BEGIN_RULE_LIST_MARKER);
   let listEndIndex = markdown.indexOf(END_RULE_LIST_MARKER);
 
@@ -360,7 +360,7 @@ export async function updateRulesList(
         ignoreConfig
       );
 
-  const newContent = await format(`${legend}\n\n${list}`, pathToReadme);
+  const newContent = `${legend ? `${legend}\n\n` : ''}${list}`;
 
   return `${preList}${BEGIN_RULE_LIST_MARKER}\n\n${newContent}\n\n${END_RULE_LIST_MARKER}${postList}`;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@types/jest": "^29.1.0",
         "@types/mock-fs": "^4.13.1",
         "@types/node": "^18.7.23",
-        "@types/prettier": "^2.7.1",
         "@types/sinon": "^10.0.13",
         "@typescript-eslint/eslint-plugin": "^5.38.1",
         "@typescript-eslint/parser": "^5.38.1",
@@ -49,8 +48,7 @@
         "node": "^14.18.0 || ^16.0.0 || >=18.0.0"
       },
       "peerDependencies": {
-        "eslint": ">= 7",
-        "prettier": ">= 2"
+        "eslint": ">= 7"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -9696,6 +9694,7 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
       "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -19264,7 +19263,8 @@
     "prettier": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "dev": true
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@types/jest": "^29.1.0",
     "@types/mock-fs": "^4.13.1",
     "@types/node": "^18.7.23",
-    "@types/prettier": "^2.7.1",
     "@types/sinon": "^10.0.13",
     "@typescript-eslint/eslint-plugin": "^5.38.1",
     "@typescript-eslint/parser": "^5.38.1",
@@ -77,8 +76,7 @@
     "typescript": "^4.8.4"
   },
   "peerDependencies": {
-    "eslint": ">= 7",
-    "prettier": ">= 2"
+    "eslint": ">= 7"
   },
   "engines": {
     "node": "^14.18.0 || ^16.0.0 || >=18.0.0"

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -86,7 +86,7 @@ exports[`generator #generate config that extends another config generates the do
 ✅ Enabled in the \`recommended\` configuration.
 
 | Name                           | Description            | ✅  |
-| :----------------------------- | :--------------------- | :-- |
+| :----------------------------- | :--------------------- | :- |
 | [no-bar](docs/rules/no-bar.md) | Description of no-bar. | ✅  |
 | [no-baz](docs/rules/no-baz.md) | Description of no-baz. | ✅  |
 | [no-biz](docs/rules/no-biz.md) | Description of no-biz. | ✅  |
@@ -139,7 +139,7 @@ exports[`generator #generate config with overrides generates the documentation 1
 ✅ Enabled in the \`recommended\` configuration.
 
 | Name                           | Description            | ✅  |
-| :----------------------------- | :--------------------- | :-- |
+| :----------------------------- | :--------------------- | :- |
 | [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅  |
 
 <!-- end auto-generated rules list -->
@@ -162,7 +162,7 @@ exports[`generator #generate deprecated function-style rule generates the docume
 ✅ Enabled in the \`recommended\` configuration.
 
 | Name                           | ✅  |
-| :----------------------------- | :-- |
+| :----------------------------- | :- |
 | [no-foo](docs/rules/no-foo.md) | ✅  |
 
 <!-- end auto-generated rules list -->
@@ -191,10 +191,10 @@ exports[`generator #generate deprecated rules updates the documentation 1`] = `
 ❌ Deprecated.
 
 | Name                           | Description  | ❌  |
-| :----------------------------- | :----------- | :-- |
+| :----------------------------- | :----------- | :- |
 | [no-bar](docs/rules/no-bar.md) | Description. | ❌  |
 | [no-baz](docs/rules/no-baz.md) | Description. | ❌  |
-| [no-biz](docs/rules/no-biz.md) | Description. |     |
+| [no-biz](docs/rules/no-biz.md) | Description. |    |
 | [no-foo](docs/rules/no-foo.md) | Description. | ❌  |
 
 <!-- end auto-generated rules list -->"
@@ -250,9 +250,9 @@ exports[`generator #generate no existing comment markers - minimal doc content g
 
 🔧 Automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
-| Name                           | Description            | 🔧  |
-| :----------------------------- | :--------------------- | :-- |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧  |
+| Name                           | Description            | 🔧 |
+| :----------------------------- | :--------------------- | :- |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧 |
 
 <!-- end auto-generated rules list -->
 "
@@ -273,9 +273,9 @@ exports[`generator #generate no existing comment markers - with no blank lines i
 
 🔧 Automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
-| Name                           | Description            | 🔧  |
-| :----------------------------- | :--------------------- | :-- |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧  |
+| Name                           | Description            | 🔧 |
+| :----------------------------- | :--------------------- | :- |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧 |
 
 <!-- end auto-generated rules list -->
 Existing rules section content."
@@ -296,9 +296,9 @@ exports[`generator #generate no existing comment markers - with one blank line a
 
 🔧 Automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
-| Name                           | Description            | 🔧  |
-| :----------------------------- | :--------------------- | :-- |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧  |
+| Name                           | Description            | 🔧 |
+| :----------------------------- | :--------------------- | :- |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧 |
 
 <!-- end auto-generated rules list -->
 
@@ -313,29 +313,6 @@ exports[`generator #generate no existing comment markers - with one blank line a
 <!-- end auto-generated rule header -->
 
 Existing rule doc content."
-`;
-
-exports[`generator #generate no prettier config generates the documentation 1`] = `
-"<!-- begin auto-generated rules list -->
-
-🔧 Automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
-
-| Name                           | Description            | 🔧  |
-| :----------------------------- | :--------------------- | :-- |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧  |
-
-<!-- end auto-generated rules list -->"
-`;
-
-exports[`generator #generate no prettier config generates the documentation 2`] = `
-"# Description of no-foo (\`test/no-foo\`)
-
-🔧 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
-
-<!-- end auto-generated rule header -->
-## Rule details
-details
-Long line that SHOULD NOT get wrapped by prettier since it's outside the header. Long line that SHOULD NOT get wrapped by prettier since it's outside the header.""
 `;
 
 exports[`generator #generate no rules with description generates the documentation 1`] = `
@@ -390,7 +367,7 @@ exports[`generator #generate only a \`recommended\` config updates the documenta
 ✅ Enabled in the \`recommended\` configuration.
 
 | Name                           | Description  | ✅  |
-| :----------------------------- | :----------- | :-- |
+| :----------------------------- | :----------- | :- |
 | [no-foo](docs/rules/no-foo.md) | Description. | ✅  |
 
 <!-- end auto-generated rules list -->"
@@ -412,7 +389,7 @@ exports[`generator #generate rule config with options generates the documentatio
 ✅ Enabled in the \`recommended\` configuration.
 
 | Name                           | Description            | ✅  |
-| :----------------------------- | :--------------------- | :-- |
+| :----------------------------- | :--------------------- | :- |
 | [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅  |
 
 <!-- end auto-generated rules list -->
@@ -484,7 +461,7 @@ exports[`generator #generate rule with no meta object generates the documentatio
 ✅ Enabled in the \`recommended\` configuration.
 
 | Name                           | ✅  |
-| :----------------------------- | :-- |
+| :----------------------------- | :- |
 | [no-foo](docs/rules/no-foo.md) | ✅  |
 
 <!-- end auto-generated rules list -->
@@ -509,13 +486,13 @@ exports[`generator #generate rule with type, type column enabled displays the ty
 📖 Identifies potential improvements.\\
 📏 Focuses on code formatting.
 
-| Name                           | 🗂️  |
+| Name                           | 🗂️ |
 | :----------------------------- | :-- |
 | [no-bar](docs/rules/no-bar.md) | 📖  |
 | [no-biz](docs/rules/no-biz.md) | 📏  |
 | [no-boz](docs/rules/no-boz.md) |     |
 | [no-buz](docs/rules/no-buz.md) |     |
-| [no-foo](docs/rules/no-foo.md) | ❗  |
+| [no-foo](docs/rules/no-foo.md) | ❗   |
 
 <!-- end auto-generated rules list -->
 "
@@ -601,14 +578,14 @@ exports[`generator #generate rules that are disabled or set to warn generates th
 ✅ Enabled in the \`recommended\` configuration.
 
 | Name                           | Description            | ✅  |
-| :----------------------------- | :--------------------- | :-- |
-| [no-bar](docs/rules/no-bar.md) | Description of no-bar. |     |
+| :----------------------------- | :--------------------- | :- |
+| [no-bar](docs/rules/no-bar.md) | Description of no-bar. |    |
 | [no-baz](docs/rules/no-baz.md) | Description of no-baz. | ✅  |
-| [no-bez](docs/rules/no-bez.md) | Description of no-bez. |     |
-| [no-biz](docs/rules/no-biz.md) | Description of no-biz. |     |
-| [no-boz](docs/rules/no-boz.md) | Description of no-boz. |     |
-| [no-buz](docs/rules/no-buz.md) | Description of no-buz. |     |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. |     |
+| [no-bez](docs/rules/no-bez.md) | Description of no-bez. |    |
+| [no-biz](docs/rules/no-biz.md) | Description of no-biz. |    |
+| [no-boz](docs/rules/no-boz.md) | Description of no-boz. |    |
+| [no-buz](docs/rules/no-buz.md) | Description of no-buz. |    |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. |    |
 
 <!-- end auto-generated rules list -->
 "
@@ -683,10 +660,10 @@ exports[`generator #generate shows column and notice for requiresTypeChecking up
 🌐 Enabled in the \`all\` configuration.\\
 💭 Requires type information.
 
-| Name                           | Description            | 🌐  | 💭  |
-| :----------------------------- | :--------------------- | :-- | :-- |
-| [no-bar](docs/rules/no-bar.md) | Description of no-bar. |     | 💭  |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🌐  |     |
+| Name                           | Description            | 🌐 | 💭 |
+| :----------------------------- | :--------------------- | :- | :- |
+| [no-bar](docs/rules/no-bar.md) | Description of no-bar. |    | 💭 |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🌐 |    |
 
 <!-- end auto-generated rules list -->"
 `;
@@ -829,16 +806,16 @@ exports[`generator #generate splitting list, with boolean splits the list 1`] = 
 
 💡 Manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
-| Name                           | 💡  |
-| :----------------------------- | :-- |
-| [no-bar](docs/rules/no-bar.md) |     |
-| [no-baz](docs/rules/no-baz.md) |     |
+| Name                           | 💡 |
+| :----------------------------- | :- |
+| [no-bar](docs/rules/no-bar.md) |    |
+| [no-baz](docs/rules/no-baz.md) |    |
 
 ### Has Suggestions
 
-| Name                           | 💡  |
-| :----------------------------- | :-- |
-| [no-foo](docs/rules/no-foo.md) | 💡  |
+| Name                           | 💡 |
+| :----------------------------- | :- |
+| [no-foo](docs/rules/no-foo.md) | 💡 |
 
 <!-- end auto-generated rules list -->
 "
@@ -853,13 +830,13 @@ exports[`generator #generate splitting list, with one sub-list having no rules e
 ### bar
 
 | Name                           | ✅  |
-| :----------------------------- | :-- |
-| [no-bar](docs/rules/no-bar.md) |     |
+| :----------------------------- | :- |
+| [no-bar](docs/rules/no-bar.md) |    |
 
 ### foo
 
 | Name                           | ✅  |
-| :----------------------------- | :-- |
+| :----------------------------- | :- |
 | [no-foo](docs/rules/no-foo.md) | ✅  |
 
 <!-- end auto-generated rules list -->
@@ -897,11 +874,11 @@ Description.
 🔧 Automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\\
 💡 Manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
-| Name                           | Description            | 💼    | 🔧  | 💡  |
-| :----------------------------- | :--------------------- | :---- | :-- | :-- |
-| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | 🌐 🎨 | 🔧  |     |
-| [no-baz](docs/rules/no-baz.md) | Description of no-boz. |       |     |     |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🌐 ✅ | 🔧  | 💡  |
+| Name                           | Description            | 💼    | 🔧 | 💡 |
+| :----------------------------- | :--------------------- | :---- | :- | :- |
+| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | 🌐 🎨 | 🔧 |    |
+| [no-baz](docs/rules/no-baz.md) | Description of no-boz. |       |    |    |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🌐 ✅  | 🔧 | 💡 |
 
 <!-- end auto-generated rules list -->
 more content."
@@ -940,32 +917,6 @@ exports[`generator #generate successful updates the documentation 4`] = `
 <!-- end auto-generated rule header -->
 ## Rule details
 details"
-`;
-
-exports[`generator #generate uses prettier config from package.json should wrap prose in rule doc header to just 20 chars 1`] = `
-"<!-- begin auto-generated rules list -->
-
-🌐 Enabled in the
-\`all\` configuration.
-
-| Name                           | Description            | 🌐  |
-| :----------------------------- | :--------------------- | :-- |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🌐  |
-
-<!-- end auto-generated rules list -->"
-`;
-
-exports[`generator #generate uses prettier config from package.json should wrap prose in rule doc header to just 20 chars 2`] = `
-"# Description of no-foo (\`test/no-foo\`)
-
-🌐 This rule is
-enabled in the \`all\`
-config.
-
-<!-- end auto-generated rule header -->
-## Rule details
-details
-Long line that SHOULD NOT get wrapped by prettier since it's outside the header. Long line that SHOULD NOT get wrapped by prettier since it's outside the header."
 `;
 
 exports[`generator #generate with \`--rule-doc-title-format\` option = desc uses the right rule doc title format 1`] = `
@@ -1034,7 +985,7 @@ exports[`generator #generate with \`--url-configs\` option includes the config l
 | Name                           | Description             | 💼                |
 | :----------------------------- | :---------------------- | :---------------- |
 | [no-bar](docs/rules/no-bar.md) | Description for no-bar. | ![customConfig][] |
-| [no-foo](docs/rules/no-foo.md) | Description for no-foo. | ✅                |
+| [no-foo](docs/rules/no-foo.md) | Description for no-foo. | ✅                 |
 
 <!-- end auto-generated rules list -->
 "
@@ -1065,7 +1016,7 @@ exports[`generator #generate with \`--url-configs\` option with only recommended
 ✅ Enabled in the \`recommended\` [configuration](http://example.com/configs).
 
 | Name                           | Description             | ✅  |
-| :----------------------------- | :---------------------- | :-- |
+| :----------------------------- | :---------------------- | :- |
 | [no-foo](docs/rules/no-foo.md) | Description for no-foo. | ✅  |
 
 <!-- end auto-generated rules list -->
@@ -1147,9 +1098,9 @@ exports[`generator #generate with --config-emoji and using the general configs e
 
 💼 Enabled in the \`recommended\` configuration.
 
-| Name                           | Description             | 💼  |
-| :----------------------------- | :---------------------- | :-- |
-| [no-foo](docs/rules/no-foo.md) | Description for no-foo. | 💼  |
+| Name                           | Description             | 💼 |
+| :----------------------------- | :---------------------- | :- |
+| [no-foo](docs/rules/no-foo.md) | Description for no-foo. | 💼 |
 
 <!-- end auto-generated rules list -->
 "
@@ -1216,7 +1167,7 @@ exports[`generator #generate with --ignore-config hides the ignored config 1`] =
 ✅ Enabled in the \`recommended\` configuration.
 
 | Name                           | Description             | ✅  |
-| :----------------------------- | :---------------------- | :-- |
+| :----------------------------- | :---------------------- | :- |
 | [no-foo](docs/rules/no-foo.md) | Description for no-foo. | ✅  |
 
 <!-- end auto-generated rules list -->
@@ -1240,9 +1191,9 @@ exports[`generator #generate with --rule-doc-notices shows the right rule doc no
 💡 Manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).\\
 ❌ Deprecated.
 
-| Name                           | Description             | 🔧  | 💡  | ❌  |
-| :----------------------------- | :---------------------- | :-- | :-- | :-- |
-| [no-foo](docs/rules/no-foo.md) | Description for no-foo. | 🔧  | 💡  | ❌  |
+| Name                           | Description             | 🔧 | 💡 | ❌  |
+| :----------------------------- | :---------------------- | :- | :- | :- |
+| [no-foo](docs/rules/no-foo.md) | Description for no-foo. | 🔧 | 💡 | ❌  |
 
 <!-- end auto-generated rules list -->
 "
@@ -1270,9 +1221,9 @@ exports[`generator #generate with --rule-list-columns shows the right columns an
 💡 Manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).\\
 🔧 Automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
-| 💡  | 🔧  | Name                           |
-| :-- | :-- | :----------------------------- |
-| 💡  | 🔧  | [no-foo](docs/rules/no-foo.md) |
+| 💡 | 🔧 | Name                           |
+| :- | :- | :----------------------------- |
+| 💡 | 🔧 | [no-foo](docs/rules/no-foo.md) |
 
 <!-- end auto-generated rules list -->
 "
@@ -1297,9 +1248,9 @@ No blank line after this.
 
 🔧 Automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
-| Name                           | Description            | 🔧  |
-| :----------------------------- | :--------------------- | :-- |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧  |
+| Name                           | Description            | 🔧 |
+| :----------------------------- | :--------------------- | :- |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧 |
 
 <!-- end auto-generated rules list -->
 No blank line before this."
@@ -1323,9 +1274,9 @@ One blank line after this.
 
 🔧 Automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
-| Name                           | Description            | 🔧  |
-| :----------------------------- | :--------------------- | :-- |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧  |
+| Name                           | Description            | 🔧 |
+| :----------------------------- | :--------------------- | :- |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧 |
 
 <!-- end auto-generated rules list -->
 


### PR DESCRIPTION
This reduces unnecessary complexity of trying to format the outputted markdown with prettier which may or may not be installed in user's repository. Instead, the user can choose to run prettier on their own after running this tool if they'd like. This puts the user more in control and avoids potential issues.

* Prettier hid potential markdown formatting issues
* Prettier's API will change between v2 and v3 (https://github.com/bmish/eslint-doc-generator/pull/186#issuecomment-1296281539)
* Even if prettier is installed, the user might not want to use it for markdown formatting
* It was difficult to test different prettier setups
* We recently added markdown-table to do the table formatting for us and it's very similar to prettier formatting

Fixes #185.
Fixes #88.