### PR TITLE
Indicate when a rule is set to off/warn by a config in the README rules list

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Automatic documentation generator for [ESLint](https://eslint.org/) plugins and 
 Generates the following documentation based on ESLint and top [ESLint plugin](https://eslint.org/docs/latest/developer-guide/working-with-plugins) conventions:
 
 - `README.md` rules table
-- Rule doc titles and notices
+- Rule doc titles and config/fixable/etc. notices
 
 Also performs some basic section consistency checks on rule docs:
 
@@ -89,9 +89,9 @@ Generated content in a rule doc (everything above the marker comment) (intention
 
 💼 This rule is enabled in the following configs: ✅ `recommended`, 🎨 `stylistic`.
 
-🎨 This rule will _warn_ in the `stylistic` config.
+🎨<sup>⚠️</sup> This rule _warns_ in the `stylistic` config.
 
-🎨 This rule is _disabled_ in the `stylistic` config.
+🎨<sup>🚫</sup> This rule is _disabled_ in the `stylistic` config.
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
@@ -131,6 +131,8 @@ Generated rules table in `README.md` (everything between the marker comments) (i
 
 💼 Configurations enabled in.\
 ✅ Enabled in the `recommended` configuration.\
+✅<sup>⚠️</sup> Warns in the `recommended` configuration.\
+✅<sup>🚫</sup> Disabled in the `recommended` configuration.\
 🎨 Enabled in the `stylistic` configuration.\
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
 💡 Manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).\
@@ -191,15 +193,27 @@ All options are optional.
 
 ### `--rule-doc-title-format`
 
-Where `no-foo` is the rule name, `Do not use foo` is the rule description, and `eslint-plugin-test` is the plugin name.
+Where `no-foo` is the rule name, `Disallow use of foo` is the rule description, and `eslint-plugin-test` is the plugin name.
 
 | Value | Example |
 | :-- | :-- |
-| `desc` | `# Do not use foo` |
-| `desc-parens-name` | `# Do not use foo (no-foo)` |
-| `desc-parens-prefix-name` (default) | `# Do not use foo (test/no-foo)` |
+| `desc` | `# Disallow use of foo` |
+| `desc-parens-name` | `# Disallow use of foo (no-foo)` |
+| `desc-parens-prefix-name` (default) | `# Disallow use of foo (test/no-foo)` |
 | `name` | `# no-foo` |
 `prefix-name` | `# test/no-foo` |
+
+## Compatibility
+
+### markdownlint
+
+The output of this tool should be compatible with [markdownlint](https://github.com/DavidAnson/markdownlint) which you might use to lint your markdown. However, if any of your ESLint configs disable your rules or set them to warn, you'll need to exempt the [`<sup>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup) (superscript) element from [no-inline-html](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md033---inline-html):
+
+```json
+{
+  "no-inline-html": { "allowed_elements": ["sup"] }
+}
+```
 
 ## Related
 

--- a/lib/emojis.ts
+++ b/lib/emojis.ts
@@ -15,6 +15,8 @@ export const EMOJI_CONFIGS = {
 
 //  General configs.
 export const EMOJI_CONFIG = '💼';
+export const EMOJI_CONFIG_WARN = '⚠️';
+export const EMOJI_CONFIG_OFF = '🚫';
 
 // Fixers.
 export const EMOJI_FIXABLE = '🔧';

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -18,6 +18,12 @@ export const SEVERITY_ERROR = new Set<RuleSeverity>([2, 'error']);
 export const SEVERITY_WARN = new Set<RuleSeverity>([1, 'warn']);
 export const SEVERITY_OFF = new Set<RuleSeverity>([0, 'off']);
 
+export enum SEVERITY_TYPE {
+  'error' = 'error',
+  'warn' = 'warn',
+  'off' = 'off',
+}
+
 export type ConfigsToRules = Record<string, Rules>;
 
 export interface RuleDetails {

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -79,6 +79,41 @@ exports[`generator #generate Scoped plugin name determines the correct plugin pr
 "
 `;
 
+exports[`generator #generate config emoji matches off/warn emoji superscript avoids superscript with double emoji 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+💼 Configurations enabled in.\\
+⚠️ Warns in the \`warning\` configuration.\\
+🚫 Disabled in the \`off\` configuration.
+
+| Name                           | Description            | 💼 |
+| :----------------------------- | :--------------------- | :- |
+| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | 🚫 |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ⚠️ |
+
+<!-- end auto-generated rules list -->
+"
+`;
+
+exports[`generator #generate config emoji matches off/warn emoji superscript avoids superscript with double emoji 2`] = `
+"# Description of no-foo (\`test/no-foo\`)
+
+⚠️ This rule _warns_ in the \`warning\` config.
+
+<!-- end auto-generated rule header -->
+"
+`;
+
+exports[`generator #generate config emoji matches off/warn emoji superscript avoids superscript with double emoji 3`] = `
+"# Description of no-bar (\`test/no-bar\`)
+
+🚫 This rule is _disabled_ in the \`off\` config.
+
+<!-- end auto-generated rule header -->
+"
+`;
+
 exports[`generator #generate config that extends another config generates the documentation 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->
@@ -575,17 +610,20 @@ exports[`generator #generate rules that are disabled or set to warn generates th
 "## Rules
 <!-- begin auto-generated rules list -->
 
-✅ Enabled in the \`recommended\` configuration.
+💼 Configurations enabled in.\\
+✅ Enabled in the \`recommended\` configuration.\\
+✅<sup>⚠️</sup> Warns in the \`recommended\` configuration.\\
+✅<sup>🚫</sup> Disabled in the \`recommended\` configuration.
 
-| Name                           | Description            | ✅  |
-| :----------------------------- | :--------------------- | :- |
-| [no-bar](docs/rules/no-bar.md) | Description of no-bar. |    |
-| [no-baz](docs/rules/no-baz.md) | Description of no-baz. | ✅  |
-| [no-bez](docs/rules/no-bez.md) | Description of no-bez. |    |
-| [no-biz](docs/rules/no-biz.md) | Description of no-biz. |    |
-| [no-boz](docs/rules/no-boz.md) | Description of no-boz. |    |
-| [no-buz](docs/rules/no-buz.md) | Description of no-buz. |    |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. |    |
+| Name                           | Description            | 💼                                     |
+| :----------------------------- | :--------------------- | :------------------------------------- |
+| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | ![other][]<sup>🚫</sup> ✅<sup>🚫</sup> |
+| [no-baz](docs/rules/no-baz.md) | Description of no-baz. | ✅ ![other][]<sup>🚫</sup>              |
+| [no-bez](docs/rules/no-bez.md) | Description of no-bez. | ![other][]<sup>⚠️</sup>                |
+| [no-biz](docs/rules/no-biz.md) | Description of no-biz. | ![other][]<sup>🚫</sup>                |
+| [no-boz](docs/rules/no-boz.md) | Description of no-boz. | ✅<sup>⚠️</sup>                         |
+| [no-buz](docs/rules/no-buz.md) | Description of no-buz. | ![other][]<sup>⚠️</sup> ✅<sup>⚠️</sup> |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅<sup>🚫</sup>                         |
 
 <!-- end auto-generated rules list -->
 "
@@ -594,7 +632,7 @@ exports[`generator #generate rules that are disabled or set to warn generates th
 exports[`generator #generate rules that are disabled or set to warn generates the documentation 2`] = `
 "# Description of no-foo (\`test/no-foo\`)
 
-✅ This rule is _disabled_ in the \`recommended\` config.
+✅<sup>🚫</sup> This rule is _disabled_ in the \`recommended\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -621,7 +659,7 @@ exports[`generator #generate rules that are disabled or set to warn generates th
 exports[`generator #generate rules that are disabled or set to warn generates the documentation 5`] = `
 "# Description of no-biz (\`test/no-biz\`)
 
-💼 This rule is _disabled_ in the \`other\` config.
+💼<sup>🚫</sup> This rule is _disabled_ in the \`other\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -630,7 +668,7 @@ exports[`generator #generate rules that are disabled or set to warn generates th
 exports[`generator #generate rules that are disabled or set to warn generates the documentation 6`] = `
 "# Description of no-boz (\`test/no-boz\`)
 
-✅ This rule will _warn_ in the \`recommended\` config.
+✅<sup>⚠️</sup> This rule _warns_ in the \`recommended\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -639,7 +677,7 @@ exports[`generator #generate rules that are disabled or set to warn generates th
 exports[`generator #generate rules that are disabled or set to warn generates the documentation 7`] = `
 "# Description of no-buz (\`test/no-buz\`)
 
-💼 This rule will _warn_ in the following configs: \`other\`, ✅ \`recommended\`.
+💼 This rule _warns_ in the following configs: \`other\`, ✅ \`recommended\`.
 
 <!-- end auto-generated rule header -->
 "
@@ -648,7 +686,41 @@ exports[`generator #generate rules that are disabled or set to warn generates th
 exports[`generator #generate rules that are disabled or set to warn generates the documentation 8`] = `
 "# Description of no-bez (\`test/no-bez\`)
 
-💼 This rule will _warn_ in the \`other\` config.
+💼<sup>⚠️</sup> This rule _warns_ in the \`other\` config.
+
+<!-- end auto-generated rule header -->
+"
+`;
+
+exports[`generator #generate rules that are disabled or set to warn, only one config present generates the documentation 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+✅<sup>⚠️</sup> Warns in the \`recommended\` configuration.\\
+✅<sup>🚫</sup> Disabled in the \`recommended\` configuration.
+
+| Name                           | Description            | ✅              |
+| :----------------------------- | :--------------------- | :------------- |
+| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | ✅<sup>🚫</sup> |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅<sup>⚠️</sup> |
+
+<!-- end auto-generated rules list -->
+"
+`;
+
+exports[`generator #generate rules that are disabled or set to warn, only one config present generates the documentation 2`] = `
+"# Description of no-foo (\`test/no-foo\`)
+
+✅<sup>⚠️</sup> This rule _warns_ in the \`recommended\` config.
+
+<!-- end auto-generated rule header -->
+"
+`;
+
+exports[`generator #generate rules that are disabled or set to warn, only one config present generates the documentation 3`] = `
+"# Description of no-bar (\`test/no-bar\`)
+
+✅<sup>🚫</sup> This rule is _disabled_ in the \`recommended\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -1235,6 +1307,29 @@ exports[`generator #generate with --rule-list-columns shows the right columns an
 ❌ This rule is deprecated.
 
 🔧💡 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) and manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+
+<!-- end auto-generated rule header -->
+"
+`;
+
+exports[`generator #generate with config that does not have any rules uses recommended config emoji since it is the only relevant config 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+✅ Enabled in the \`recommended\` configuration.
+
+| Name                           | Description             | ✅  |
+| :----------------------------- | :---------------------- | :- |
+| [no-foo](docs/rules/no-foo.md) | Description for no-foo. | ✅  |
+
+<!-- end auto-generated rules list -->
+"
+`;
+
+exports[`generator #generate with config that does not have any rules uses recommended config emoji since it is the only relevant config 2`] = `
+"# Description for no-foo (\`test/no-foo\`)
+
+✅ This rule is enabled in the \`recommended\` config.
 
 <!-- end auto-generated rule header -->
 "


### PR DESCRIPTION
Fixes #182.

Previously, we had no way to indicate that a config set a rule to warn or off severity level in the README rules table. And we also didn't use a distinct emoji in the rule doc notice when indicating this.

### Example of how the README rules table can now indicate when a config sets rules to warn or off:

✅ Enabled in the `recommended` configuration.
✅<sup>⚠️</sup> Warns in the `recommended` configuration.
✅<sup>🚫</sup> Disabled in the `recommended` configuration.
| Name                           | Description            | ✅                                     |
| :----------------------------- | :--------------------- | :------------------------------------- |
| [no-baz](docs/rules/no-baz.md) | Description of no-baz. | ✅<sup>⚠️</sup>              |
| [no-bez](docs/rules/no-bez.md) | Description of no-bez. | ✅<sup>🚫</sup>                |
| [no-biz](docs/rules/no-biz.md) | Description of no-biz. | ✅                |                  |

### Example of how a rule doc notice can now indicate when a config sets the rule to warn or off:

✅<sup>⚠️</sup> This rule _warns_ in the `recommended` config.

✅<sup>🚫</sup> This rule is _disabled_ in the `recommended` config.
