### PR TITLE
Ensure notation for config that warns/disables a rule does not wrap to separate line

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,11 +219,11 @@ If you have a build step for your code like [Babel](https://babeljs.io/) or [Typ
 
 ### markdownlint
 
-The output of this tool should be compatible with [markdownlint](https://github.com/DavidAnson/markdownlint) which you might use to lint your markdown. However, if any of your ESLint configs disable your rules or set them to warn, you'll need to exempt the [`<sup>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup) (superscript) element from [no-inline-html](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md033---inline-html):
+The output of this tool should be compatible with [markdownlint](https://github.com/DavidAnson/markdownlint) which you might use to lint your markdown. However, if any of your ESLint configs disable your rules or set them to warn, you'll need to exempt some elements used for the emoji superscript from [no-inline-html](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md033---inline-html):
 
 ```json
 {
-  "no-inline-html": { "allowed_elements": ["sup"] }
+  "no-inline-html": { "allowed_elements": ["span", "sup"] }
 }
 ```
 

--- a/lib/configs.ts
+++ b/lib/configs.ts
@@ -98,6 +98,21 @@ export function parseConfigEmojiOptions(
   return configEmojis;
 }
 
+function emojiWithSuperscript(
+  emoji: string,
+  superscriptEmoji: string,
+  noWrap = false
+) {
+  if (emoji === superscriptEmoji) {
+    // Avoid double emoji.
+    return emoji;
+  }
+  // Style is to ensure superscript doesn't wrap to separate line, useful in constrained spaces.
+  return noWrap
+    ? `<span style="white-space:nowrap">${emoji}<sup>${superscriptEmoji}</sup></span>`
+    : `${emoji}<sup>${superscriptEmoji}</sup>`;
+}
+
 /**
  * Find the representation of a config to display.
  * @param configEmojis - known list of configs and corresponding emojis
@@ -105,6 +120,7 @@ export function parseConfigEmojiOptions(
  * @param options
  * @param options.severity - if present, decorate the config's emoji for the given severity level
  * @param options.fallback - if true and no emoji is found, choose whether to fallback to a generic config emoji or a badge
+ * @param options.noWrap - whether to add styling to ensure the superscript doesn't wrap to a separate line when used in constrained spaces
  * @returns the string to display for the config
  */
 export function findConfigEmoji(
@@ -113,6 +129,7 @@ export function findConfigEmoji(
   options?: {
     severity?: SEVERITY_TYPE;
     fallback?: 'badge' | 'emoji';
+    noWrap?: boolean;
   }
 ) {
   let emoji = configEmojis.find(
@@ -128,17 +145,12 @@ export function findConfigEmoji(
       return undefined; // eslint-disable-line unicorn/no-useless-undefined
     }
   }
+
   switch (options?.severity) {
     case 'warn':
-      return `${emoji}${
-        // Conditional is to avoid double emoji.
-        emoji === EMOJI_CONFIG_WARN ? '' : `<sup>${EMOJI_CONFIG_WARN}</sup>`
-      }`;
+      return emojiWithSuperscript(emoji, EMOJI_CONFIG_WARN, options.noWrap);
     case 'off':
-      // Conditional is to avoid double emoji.
-      return `${emoji}${
-        emoji === EMOJI_CONFIG_OFF ? '' : `<sup>${EMOJI_CONFIG_OFF}</sup>`
-      }`;
+      return emojiWithSuperscript(emoji, EMOJI_CONFIG_OFF, options.noWrap);
     default:
       return emoji;
   }

--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -109,6 +109,7 @@ function getConfigurationColumnValueForRule(
       findConfigEmoji(configEmojis, configName, {
         severity: SEVERITY_TYPE.error,
         fallback: 'badge',
+        noWrap: true,
       })
     );
   }
@@ -119,6 +120,7 @@ function getConfigurationColumnValueForRule(
       findConfigEmoji(configEmojis, configName, {
         severity: SEVERITY_TYPE.warn,
         fallback: 'badge',
+        noWrap: true,
       })
     );
   }
@@ -129,6 +131,7 @@ function getConfigurationColumnValueForRule(
       findConfigEmoji(configEmojis, configName, {
         severity: SEVERITY_TYPE.off,
         fallback: 'badge',
+        noWrap: true,
       })
     );
   }

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -615,15 +615,15 @@ exports[`generator #generate rules that are disabled or set to warn generates th
 ✅<sup>⚠️</sup> Warns in the \`recommended\` configuration.\\
 ✅<sup>🚫</sup> Disabled in the \`recommended\` configuration.
 
-| Name                           | Description            | 💼                                     |
-| :----------------------------- | :--------------------- | :------------------------------------- |
-| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | ![other][]<sup>🚫</sup> ✅<sup>🚫</sup> |
-| [no-baz](docs/rules/no-baz.md) | Description of no-baz. | ✅ ![other][]<sup>🚫</sup>              |
-| [no-bez](docs/rules/no-bez.md) | Description of no-bez. | ![other][]<sup>⚠️</sup>                |
-| [no-biz](docs/rules/no-biz.md) | Description of no-biz. | ![other][]<sup>🚫</sup>                |
-| [no-boz](docs/rules/no-boz.md) | Description of no-boz. | ✅<sup>⚠️</sup>                         |
-| [no-buz](docs/rules/no-buz.md) | Description of no-buz. | ![other][]<sup>⚠️</sup> ✅<sup>⚠️</sup> |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅<sup>🚫</sup>                         |
+| Name                           | Description            | 💼                                                                                                                     |
+| :----------------------------- | :--------------------- | :--------------------------------------------------------------------------------------------------------------------- |
+| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | <span style="white-space:nowrap">![other][]<sup>🚫</sup></span> <span style="white-space:nowrap">✅<sup>🚫</sup></span> |
+| [no-baz](docs/rules/no-baz.md) | Description of no-baz. | ✅ <span style="white-space:nowrap">![other][]<sup>🚫</sup></span>                                                      |
+| [no-bez](docs/rules/no-bez.md) | Description of no-bez. | <span style="white-space:nowrap">![other][]<sup>⚠️</sup></span>                                                        |
+| [no-biz](docs/rules/no-biz.md) | Description of no-biz. | <span style="white-space:nowrap">![other][]<sup>🚫</sup></span>                                                        |
+| [no-boz](docs/rules/no-boz.md) | Description of no-boz. | <span style="white-space:nowrap">✅<sup>⚠️</sup></span>                                                                 |
+| [no-buz](docs/rules/no-buz.md) | Description of no-buz. | <span style="white-space:nowrap">![other][]<sup>⚠️</sup></span> <span style="white-space:nowrap">✅<sup>⚠️</sup></span> |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | <span style="white-space:nowrap">✅<sup>🚫</sup></span>                                                                 |
 
 <!-- end auto-generated rules list -->
 "
@@ -699,10 +699,10 @@ exports[`generator #generate rules that are disabled or set to warn, only one co
 ✅<sup>⚠️</sup> Warns in the \`recommended\` configuration.\\
 ✅<sup>🚫</sup> Disabled in the \`recommended\` configuration.
 
-| Name                           | Description            | ✅              |
-| :----------------------------- | :--------------------- | :------------- |
-| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | ✅<sup>🚫</sup> |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅<sup>⚠️</sup> |
+| Name                           | Description            | ✅                                                      |
+| :----------------------------- | :--------------------- | :----------------------------------------------------- |
+| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | <span style="white-space:nowrap">✅<sup>🚫</sup></span> |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | <span style="white-space:nowrap">✅<sup>⚠️</sup></span> |
 
 <!-- end auto-generated rules list -->
 "


### PR DESCRIPTION
Follow-up to: #198

Prevents the emoji superscript for indicating that a config warns/disables a rule from wrapping due to the constrained space in the rules list config column.

In this example, <span style="white-space:nowrap"><g-emoji class="g-emoji" alias="keyboard" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/2328.png">⌨️</g-emoji><sup><g-emoji class="g-emoji" alias="no_entry_sign" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f6ab.png">🚫</g-emoji></sup> indicates that the TypeScript config that warns for a rule.

| Before | After |
| --- | --- |
| <img width="243" alt="Screenshot 2022-11-01 at 8 52 02 AM" src="https://user-images.githubusercontent.com/698306/199236624-bddf648f-b2d9-4577-b8f6-16ef6bb3c297.png"> | <img width="241" alt="Screenshot 2022-11-01 at 8 52 42 AM" src="https://user-images.githubusercontent.com/698306/199236643-0f764207-1a53-4284-a2c0-b3df3bb7f723.png"> |

