### PR TITLE
Redo fix to ensure notation for config that warns/disables a rule does not wrap to separate line in rules table cell

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,11 +219,11 @@ If you have a build step for your code like [Babel](https://babeljs.io/) or [Typ
 
 ### markdownlint
 
-The output of this tool should be compatible with [markdownlint](https://github.com/DavidAnson/markdownlint) which you might use to lint your markdown. However, if any of your ESLint configs disable your rules or set them to warn, you'll need to exempt some elements used for the emoji superscript from [no-inline-html](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md033---inline-html):
+The output of this tool should be compatible with [markdownlint](https://github.com/DavidAnson/markdownlint) which you might use to lint your markdown. However, if any of your ESLint configs disable your rules or set them to warn, you'll need to exempt some elements used for emoji superscripts from [no-inline-html](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md033---inline-html):
 
 ```json
 {
-  "no-inline-html": { "allowed_elements": ["span", "sup"] }
+  "no-inline-html": { "allowed_elements": ["br", "sup"] }
 }
 ```
 

--- a/lib/configs.ts
+++ b/lib/configs.ts
@@ -98,19 +98,12 @@ export function parseConfigEmojiOptions(
   return configEmojis;
 }
 
-function emojiWithSuperscript(
-  emoji: string,
-  superscriptEmoji: string,
-  noWrap = false
-) {
+function emojiWithSuperscript(emoji: string, superscriptEmoji: string) {
   if (emoji === superscriptEmoji) {
     // Avoid double emoji.
     return emoji;
   }
-  // Style is to ensure superscript doesn't wrap to separate line, useful in constrained spaces.
-  return noWrap
-    ? `<span style="white-space:nowrap">${emoji}<sup>${superscriptEmoji}</sup></span>`
-    : `${emoji}<sup>${superscriptEmoji}</sup>`;
+  return `${emoji}<sup>${superscriptEmoji}</sup>`;
 }
 
 /**
@@ -120,7 +113,6 @@ function emojiWithSuperscript(
  * @param options
  * @param options.severity - if present, decorate the config's emoji for the given severity level
  * @param options.fallback - if true and no emoji is found, choose whether to fallback to a generic config emoji or a badge
- * @param options.noWrap - whether to add styling to ensure the superscript doesn't wrap to a separate line when used in constrained spaces
  * @returns the string to display for the config
  */
 export function findConfigEmoji(
@@ -129,7 +121,6 @@ export function findConfigEmoji(
   options?: {
     severity?: SEVERITY_TYPE;
     fallback?: 'badge' | 'emoji';
-    noWrap?: boolean;
   }
 ) {
   let emoji = configEmojis.find(
@@ -148,9 +139,9 @@ export function findConfigEmoji(
 
   switch (options?.severity) {
     case 'warn':
-      return emojiWithSuperscript(emoji, EMOJI_CONFIG_WARN, options.noWrap);
+      return emojiWithSuperscript(emoji, EMOJI_CONFIG_WARN);
     case 'off':
-      return emojiWithSuperscript(emoji, EMOJI_CONFIG_OFF, options.noWrap);
+      return emojiWithSuperscript(emoji, EMOJI_CONFIG_OFF);
     default:
       return emoji;
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -24,6 +24,14 @@ export enum SEVERITY_TYPE {
   'off' = 'off',
 }
 
+export const SEVERITY_TYPE_TO_SET: {
+  [key in SEVERITY_TYPE]: Set<TSESLint.Linter.RuleLevel>;
+} = {
+  [SEVERITY_TYPE.error]: SEVERITY_ERROR,
+  [SEVERITY_TYPE.warn]: SEVERITY_WARN,
+  [SEVERITY_TYPE.off]: SEVERITY_OFF,
+};
+
 export type ConfigsToRules = Record<string, Rules>;
 
 export interface RuleDetails {

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -615,15 +615,15 @@ exports[`generator #generate rules that are disabled or set to warn generates th
 ✅<sup>⚠️</sup> Warns in the \`recommended\` configuration.\\
 ✅<sup>🚫</sup> Disabled in the \`recommended\` configuration.
 
-| Name                           | Description            | 💼                                                                                                                     |
-| :----------------------------- | :--------------------- | :--------------------------------------------------------------------------------------------------------------------- |
-| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | <span style="white-space:nowrap">![other][]<sup>🚫</sup></span> <span style="white-space:nowrap">✅<sup>🚫</sup></span> |
-| [no-baz](docs/rules/no-baz.md) | Description of no-baz. | ✅ <span style="white-space:nowrap">![other][]<sup>🚫</sup></span>                                                      |
-| [no-bez](docs/rules/no-bez.md) | Description of no-bez. | <span style="white-space:nowrap">![other][]<sup>⚠️</sup></span>                                                        |
-| [no-biz](docs/rules/no-biz.md) | Description of no-biz. | <span style="white-space:nowrap">![other][]<sup>🚫</sup></span>                                                        |
-| [no-boz](docs/rules/no-boz.md) | Description of no-boz. | <span style="white-space:nowrap">✅<sup>⚠️</sup></span>                                                                 |
-| [no-buz](docs/rules/no-buz.md) | Description of no-buz. | <span style="white-space:nowrap">![other][]<sup>⚠️</sup></span> <span style="white-space:nowrap">✅<sup>⚠️</sup></span> |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | <span style="white-space:nowrap">✅<sup>🚫</sup></span>                                                                 |
+| Name                           | Description            | 💼                                         |
+| :----------------------------- | :--------------------- | :----------------------------------------- |
+| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | ![other][]<sup>🚫</sup> <br>✅<sup>🚫</sup> |
+| [no-baz](docs/rules/no-baz.md) | Description of no-baz. | ✅ <br>![other][]<sup>🚫</sup>              |
+| [no-bez](docs/rules/no-bez.md) | Description of no-bez. | ![other][]<sup>⚠️</sup>                    |
+| [no-biz](docs/rules/no-biz.md) | Description of no-biz. | ![other][]<sup>🚫</sup>                    |
+| [no-boz](docs/rules/no-boz.md) | Description of no-boz. | ✅<sup>⚠️</sup>                             |
+| [no-buz](docs/rules/no-buz.md) | Description of no-buz. | ![other][]<sup>⚠️</sup> <br>✅<sup>⚠️</sup> |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅<sup>🚫</sup>                             |
 
 <!-- end auto-generated rules list -->
 "
@@ -699,10 +699,10 @@ exports[`generator #generate rules that are disabled or set to warn, only one co
 ✅<sup>⚠️</sup> Warns in the \`recommended\` configuration.\\
 ✅<sup>🚫</sup> Disabled in the \`recommended\` configuration.
 
-| Name                           | Description            | ✅                                                      |
-| :----------------------------- | :--------------------- | :----------------------------------------------------- |
-| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | <span style="white-space:nowrap">✅<sup>🚫</sup></span> |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | <span style="white-space:nowrap">✅<sup>⚠️</sup></span> |
+| Name                           | Description            | ✅              |
+| :----------------------------- | :--------------------- | :------------- |
+| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | ✅<sup>🚫</sup> |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅<sup>⚠️</sup> |
 
 <!-- end auto-generated rules list -->
 "
@@ -734,9 +734,9 @@ exports[`generator #generate rules that are disabled or set to warn, two configs
 ✅<sup>⚠️</sup> Warns in the \`recommended\` configuration.\\
 ⌨️<sup>🚫</sup> Disabled in the \`typescript\` configuration.
 
-| Name                           | Description            | 💼                                                                                                             |
-| :----------------------------- | :--------------------- | :------------------------------------------------------------------------------------------------------------- |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | <span style="white-space:nowrap">✅<sup>⚠️</sup></span> <span style="white-space:nowrap">⌨️<sup>🚫</sup></span> |
+| Name                           | Description            | 💼                                 |
+| :----------------------------- | :--------------------- | :--------------------------------- |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅<sup>⚠️</sup> <br>⌨️<sup>🚫</sup> |
 
 <!-- end auto-generated rules list -->
 "


### PR DESCRIPTION
Redo of #201.

Solutions that didn't work:
* Turns out GitHub markdown filters out CSS styles so the previous solution doesn't work.
* Of the [allowed](https://github.com/gjtorikian/html-pipeline/blob/main/lib/html/pipeline/sanitization_filter.rb) HTML elements, none that I tested helped us avoid the linebreak. `<wbr`> did not help.
* `&nbsp;` in various placements did not help. It might have been more helpful if we could do something like `☑️ ⌨️<sup>&nbsp;🚫</sup>`, but GitHub converts all emojis to a `<g-emoji>` tag for compatibility which prevents this from working.

The only solution that worked is manually inserting a linebreak ahead of the emoji with superscript that we want to ensure does not end up with a linebreak inside it.

I also did some refactoring to DRY up the code.