### PR TITLE
Redesign information architecture of rules table columns and rule doc notices for representing rule configs/severities

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,11 @@ Generated content in a rule doc (everything above the marker comment) (intention
 ```md
 # Disallow using foo (`test/no-foo`)
 
-✅ This rule is enabled in the `recommended` config.
-
 💼 This rule is enabled in the following configs: ✅ `recommended`, 🎨 `stylistic`.
 
-🎨<sup>⚠️</sup> This rule _warns_ in the `stylistic` config.
+⚠️ This rule _warns_ in the 🎨 `stylistic` config.
 
-🎨<sup>🚫</sup> This rule is _disabled_ in the `stylistic` config.
+🚫 This rule is _disabled_ in the 🎨 `stylistic` config.
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
@@ -131,10 +129,10 @@ Generated rules table in `README.md` (everything between the marker comments) (i
 <!-- begin auto-generated rules list -->
 
 💼 Configurations enabled in.\
-✅ Enabled in the `recommended` configuration.\
-✅<sup>⚠️</sup> Warns in the `recommended` configuration.\
-✅<sup>🚫</sup> Disabled in the `recommended` configuration.\
-🎨 Enabled in the `stylistic` configuration.\
+⚠️ Configurations set to warn in.\
+🚫 Configurations disabled in.\
+✅ Set in the `recommended` configuration.\
+🎨 Set in the `stylistic` configuration.\
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
 💡 Manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).\
 💭 Requires type information.\
@@ -186,7 +184,7 @@ And how it looks:
 | `--rule-doc-section-include` | Required section in each rule doc. Exit with failure if missing. Option can be repeated. |
 | `--rule-doc-section-options` | Whether to require an "Options" or "Config" rule doc section and mention of any named options for rules with options (default: `true`). |
 | `--rule-doc-title-format` | The format to use for rule doc titles. Defaults to `desc-parens-prefix-name`. See choices in below [table](#--rule-doc-title-format). |
-| `--rule-list-columns` | Ordered, comma-separated list of columns to display in rule list. Empty columns will be hidden. Choices: `configs`, `deprecated`, `description`, `fixable`, `hasSuggestions`, `name`, `requiresTypeChecking`, `type` (off by default). Default: `name,description,configs,fixable,hasSuggestions,requiresTypeChecking,deprecated`. |
+| `--rule-list-columns` | Ordered, comma-separated list of columns to display in rule list. Empty columns will be hidden. Choices: `configsError`, `configsOff`, `configsWarn`, `deprecated`, `description`, `fixable`, `hasSuggestions`, `name`, `requiresTypeChecking`, `type` (off by default). Default: `name,description,configsError,configsWarn,configsOff,fixable,hasSuggestions,requiresTypeChecking,deprecated`. |
 | `--split-by` | Rule property to split the rules list by. A separate list and header will be created for each value. Example: `meta.type`. |
 | `--url-configs` | Link to documentation about the ESLint configurations exported by the plugin. |
 
@@ -214,16 +212,6 @@ If you have a build step for your code like [Babel](https://babeljs.io/) or [Typ
 {
   "build": "tsc",
   "update:eslint-docs": "npm run build && eslint-doc-generator"
-}
-```
-
-### markdownlint
-
-The output of this tool should be compatible with [markdownlint](https://github.com/DavidAnson/markdownlint) which you might use to lint your markdown. However, if any of your ESLint configs disable your rules or set them to warn, you'll need to exempt some elements used for emoji superscripts from [no-inline-html](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md033---inline-html):
-
-```json
-{
-  "no-inline-html": { "allowed_elements": ["br", "sup"] }
 }
 ```
 

--- a/lib/emojis.ts
+++ b/lib/emojis.ts
@@ -1,9 +1,12 @@
+import { SEVERITY_TYPE } from './types.js';
+import { EMOJIS_TYPE } from './rule-type.js';
+
 // Default emojis for common configs.
 const EMOJI_A11Y = '♿';
 const EMOJI_ERROR = '❗';
 const EMOJI_STYLE = '🎨';
 const EMOJI_TYPESCRIPT = '⌨️';
-const EMOJI_WARNING = '⚠️';
+const EMOJI_WARNING = '🚸';
 export const EMOJI_CONFIGS = {
   a11y: EMOJI_A11Y,
   accessibility: EMOJI_A11Y,
@@ -24,9 +27,16 @@ export const EMOJI_CONFIGS = {
 };
 
 //  General configs.
-export const EMOJI_CONFIG = '💼';
+export const EMOJI_CONFIG_ERROR = '💼';
 export const EMOJI_CONFIG_WARN = '⚠️';
 export const EMOJI_CONFIG_OFF = '🚫';
+export const EMOJI_CONFIG_FROM_SEVERITY: {
+  [key in SEVERITY_TYPE]: string;
+} = {
+  [SEVERITY_TYPE.error]: EMOJI_CONFIG_ERROR,
+  [SEVERITY_TYPE.warn]: EMOJI_CONFIG_WARN,
+  [SEVERITY_TYPE.off]: EMOJI_CONFIG_OFF,
+};
 
 // Fixers.
 export const EMOJI_FIXABLE = '🔧';
@@ -41,3 +51,14 @@ export const EMOJI_TYPE = '🗂️';
 
 // Deprecated.
 export const EMOJI_DEPRECATED = '❌';
+
+export const RESERVED_EMOJIS = [
+  ...Object.values(EMOJI_CONFIG_FROM_SEVERITY),
+  ...Object.values(EMOJIS_TYPE),
+
+  EMOJI_FIXABLE,
+  EMOJI_HAS_SUGGESTIONS,
+  EMOJI_REQUIRES_TYPE_CHECKING,
+  EMOJI_TYPE,
+  EMOJI_DEPRECATED,
+];

--- a/lib/legend.ts
+++ b/lib/legend.ts
@@ -2,22 +2,27 @@ import {
   EMOJI_DEPRECATED,
   EMOJI_FIXABLE,
   EMOJI_HAS_SUGGESTIONS,
-  EMOJI_CONFIG,
   EMOJI_REQUIRES_TYPE_CHECKING,
   EMOJI_TYPE,
+  EMOJI_CONFIG_FROM_SEVERITY,
 } from './emojis.js';
-import { getConfigsForRule, findConfigEmoji } from './configs.js';
+import { findConfigEmoji, getConfigsThatSetARule } from './configs.js';
 import {
   COLUMN_TYPE,
   ConfigEmojis,
   Plugin,
   ConfigsToRules,
-  SEVERITY_ERROR,
-  SEVERITY_WARN,
-  SEVERITY_OFF,
   SEVERITY_TYPE,
 } from './types.js';
 import { RULE_TYPE_MESSAGES_LEGEND, RULE_TYPES } from './rule-type.js';
+
+export const SEVERITY_TYPE_TO_WORD: {
+  [key in SEVERITY_TYPE]: string;
+} = {
+  [SEVERITY_TYPE.error]: 'enabled',
+  [SEVERITY_TYPE.warn]: 'set to warn',
+  [SEVERITY_TYPE.off]: 'disabled',
+};
 
 /**
  * An object containing the legends for each column (as a string or function to generate the string).
@@ -35,128 +40,60 @@ const LEGENDS: {
         urlConfigs?: string;
       }) => string[]);
 } = {
-  // Legends are included for each config. A generic config legend is also included if there are multiple configs.
-  [COLUMN_TYPE.CONFIGS]: ({
+  [COLUMN_TYPE.CONFIGS_ERROR]: ({
     plugin,
     configsToRules,
     configEmojis,
     pluginPrefix,
     urlConfigs,
     ignoreConfig,
-  }) => {
-    /* istanbul ignore next -- this shouldn't happen */
-    if (!plugin.configs || !plugin.rules) {
-      throw new Error(
-        'Should not be attempting to display configs column when there are no configs/rules.'
-      );
-    }
-
-    // Add link to configs documentation if provided.
-    const configsLinkOrWord = urlConfigs
-      ? `[Configurations](${urlConfigs})`
-      : 'Configurations';
-    const configLinkOrWord = urlConfigs
-      ? `[configuration](${urlConfigs})`
-      : 'configuration';
-
-    const ruleNames = Object.keys(plugin.rules);
-    const configNamesWithoutIgnored = Object.entries(configsToRules)
-      .filter(([configName, _config]) =>
-        // Only consider configs that configure at least one of the plugin's rules.
-        ruleNames.some((ruleName) =>
-          getConfigsForRule(ruleName, configsToRules, pluginPrefix).includes(
-            configName
-          )
-        )
-      )
-      // Filter out ignored configs.
-      .filter(([configName]) => !ignoreConfig?.includes(configName))
-      .map(([configName]) => configName);
-
-    const legends = [];
-    if (
-      (configNamesWithoutIgnored.length > 1 ||
-        !configEmojis.find((configEmoji) =>
-          configNamesWithoutIgnored.includes(configEmoji.config)
-        )?.emoji) &&
-      // If any configs are using the generic config emoji, then don't display the generic config legend.
-      !configEmojis
-        .filter(({ config }) => !ignoreConfig?.includes(config))
-        .some((configEmoji) => configEmoji.emoji === EMOJI_CONFIG)
-    ) {
-      // Generic config emoji will be used if the plugin has multiple configs or the sole config has no emoji.
-      legends.push(`${EMOJI_CONFIG} ${configsLinkOrWord} enabled in.`);
-    }
-    legends.push(
-      ...configNamesWithoutIgnored.flatMap((configName) => {
-        if (!findConfigEmoji(configEmojis, configName)) {
-          // No legend for this config as it has no emoji.
-          return [];
-        }
-
-        let hasErrorRule = false;
-        let hasWarnRule = false;
-        let hasOffRule = false;
-        for (const ruleName of ruleNames) {
-          if (
-            getConfigsForRule(
-              ruleName,
-              configsToRules,
-              pluginPrefix,
-              SEVERITY_ERROR
-            ).includes(configName)
-          ) {
-            hasErrorRule = true;
-          }
-          if (
-            getConfigsForRule(
-              ruleName,
-              configsToRules,
-              pluginPrefix,
-              SEVERITY_WARN
-            ).includes(configName)
-          ) {
-            hasWarnRule = true;
-          }
-          if (
-            getConfigsForRule(
-              ruleName,
-              configsToRules,
-              pluginPrefix,
-              SEVERITY_OFF
-            ).includes(configName)
-          ) {
-            hasOffRule = true;
-          }
-        }
-
-        const legendsForThisConfig = [];
-        if (hasErrorRule) {
-          legendsForThisConfig.push(
-            `${findConfigEmoji(configEmojis, configName, {
-              severity: SEVERITY_TYPE.error,
-            })} Enabled in the \`${configName}\` ${configLinkOrWord}.`
-          );
-        }
-        if (hasWarnRule) {
-          legendsForThisConfig.push(
-            `${findConfigEmoji(configEmojis, configName, {
-              severity: SEVERITY_TYPE.warn,
-            })} Warns in the \`${configName}\` ${configLinkOrWord}.`
-          );
-        }
-        if (hasOffRule) {
-          legendsForThisConfig.push(
-            `${findConfigEmoji(configEmojis, configName, {
-              severity: SEVERITY_TYPE.off,
-            })} Disabled in the \`${configName}\` ${configLinkOrWord}.`
-          );
-        }
-        return legendsForThisConfig;
-      })
-    );
-    return legends;
-  },
+  }) => [
+    getLegendForConfigColumnOfSeverity({
+      plugin,
+      configsToRules,
+      configEmojis,
+      pluginPrefix,
+      urlConfigs,
+      severityType: SEVERITY_TYPE.error,
+      ignoreConfig,
+    }),
+  ],
+  [COLUMN_TYPE.CONFIGS_OFF]: ({
+    plugin,
+    configsToRules,
+    configEmojis,
+    pluginPrefix,
+    urlConfigs,
+    ignoreConfig,
+  }) => [
+    getLegendForConfigColumnOfSeverity({
+      plugin,
+      configsToRules,
+      configEmojis,
+      pluginPrefix,
+      urlConfigs,
+      severityType: SEVERITY_TYPE.off,
+      ignoreConfig,
+    }),
+  ],
+  [COLUMN_TYPE.CONFIGS_WARN]: ({
+    plugin,
+    configsToRules,
+    configEmojis,
+    pluginPrefix,
+    urlConfigs,
+    ignoreConfig,
+  }) => [
+    getLegendForConfigColumnOfSeverity({
+      plugin,
+      configsToRules,
+      configEmojis,
+      pluginPrefix,
+      urlConfigs,
+      severityType: SEVERITY_TYPE.warn,
+      ignoreConfig,
+    }),
+  ],
 
   // Legends are included for each rule type present.
   [COLUMN_TYPE.TYPE]: ({ plugin }) => {
@@ -197,6 +134,79 @@ const LEGENDS: {
   [COLUMN_TYPE.REQUIRES_TYPE_CHECKING]: `${EMOJI_REQUIRES_TYPE_CHECKING} Requires type information.`,
 };
 
+function getLegendForConfigColumnOfSeverity({
+  plugin,
+  urlConfigs,
+  severityType,
+}: {
+  plugin: Plugin;
+  configsToRules: ConfigsToRules;
+  configEmojis: ConfigEmojis;
+  pluginPrefix: string;
+  ignoreConfig: string[];
+  severityType: SEVERITY_TYPE;
+  urlConfigs?: string;
+}): string {
+  /* istanbul ignore next -- this shouldn't happen */
+  if (!plugin.configs || !plugin.rules) {
+    throw new Error(
+      'Should not be attempting to display configs column when there are no configs/rules.'
+    );
+  }
+
+  // Add link to configs documentation if provided.
+  const configsLinkOrWord = urlConfigs
+    ? `[Configurations](${urlConfigs})`
+    : 'Configurations';
+
+  return `${EMOJI_CONFIG_FROM_SEVERITY[severityType]} ${configsLinkOrWord} ${SEVERITY_TYPE_TO_WORD[severityType]} in.`;
+}
+
+function getLegendsForIndividualConfigs({
+  plugin,
+  configsToRules,
+  configEmojis,
+  pluginPrefix,
+  urlConfigs,
+  ignoreConfig,
+}: {
+  plugin: Plugin;
+  configsToRules: ConfigsToRules;
+  configEmojis: ConfigEmojis;
+  pluginPrefix: string;
+  ignoreConfig: string[];
+  urlConfigs?: string;
+}): string[] {
+  /* istanbul ignore next -- this shouldn't happen */
+  if (!plugin.configs || !plugin.rules) {
+    throw new Error(
+      'Should not be attempting to display configs column when there are no configs/rules.'
+    );
+  }
+
+  // Add link to configs documentation if provided.
+  const configLinkOrWord = urlConfigs
+    ? `[configuration](${urlConfigs})`
+    : 'configuration';
+
+  const configNamesThatSetRuleToThisSeverity = getConfigsThatSetARule(
+    plugin,
+    configsToRules,
+    pluginPrefix,
+    ignoreConfig
+  );
+
+  return configNamesThatSetRuleToThisSeverity.flatMap((configName) => {
+    const emoji = findConfigEmoji(configEmojis, configName);
+    if (!emoji) {
+      // No legend for this config as it has no emoji.
+      return [];
+    }
+
+    return [`${emoji} Set in the \`${configName}\` ${configLinkOrWord}.`];
+  });
+}
+
 export function generateLegend(
   columns: Record<COLUMN_TYPE, boolean>,
   plugin: Plugin,
@@ -206,8 +216,8 @@ export function generateLegend(
   ignoreConfig: string[],
   urlConfigs?: string
 ) {
-  return (Object.entries(columns) as [COLUMN_TYPE, boolean][])
-    .flatMap(([columnType, enabled]) => {
+  const legends = (Object.entries(columns) as [COLUMN_TYPE, boolean][]).flatMap(
+    ([columnType, enabled]) => {
       if (!enabled) {
         // This column is turned off.
         return [];
@@ -227,6 +237,30 @@ export function generateLegend(
             ignoreConfig,
           })
         : [legendStrOrFn];
-    })
-    .join('\\\n'); // Back slash ensures these end up displayed on separate lines.
+    }
+  );
+
+  if (legends.some((legend) => legend.includes('Configurations'))) {
+    // Add legends for individual configs after the config column legend(s).
+    const legendsForIndividualConfigs = getLegendsForIndividualConfigs({
+      plugin,
+      configsToRules,
+      configEmojis,
+      pluginPrefix,
+      urlConfigs,
+      ignoreConfig,
+    });
+    const finalConfigHeaderLegendPosition = Math.max(
+      ...Object.values(SEVERITY_TYPE_TO_WORD).map((word) =>
+        legends.findIndex((legend) => legend.includes(word))
+      )
+    );
+    legends.splice(
+      finalConfigHeaderLegendPosition + 1,
+      0,
+      ...legendsForIndividualConfigs
+    );
+  }
+
+  return legends.join('\\\n'); // Back slash ensures these end up displayed on separate lines.
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -68,7 +68,9 @@ export enum NOTICE_TYPE {
  * Rule list columns.
  */
 export enum COLUMN_TYPE {
-  CONFIGS = 'configs',
+  CONFIGS_ERROR = 'configsError',
+  CONFIGS_OFF = 'configsOff',
+  CONFIGS_WARN = 'configsWarn',
   DEPRECATED = 'deprecated',
   DESCRIPTION = 'description',
   FIXABLE = 'fixable',

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -73,42 +73,7 @@ exports[`generator #generate Rule description needs to be formatted capitalizes 
 exports[`generator #generate Scoped plugin name determines the correct plugin prefix 1`] = `
 "# Disallow foo (\`@my-scope/no-foo\`)
 
-✅ This rule is enabled in the \`recommended\` config.
-
-<!-- end auto-generated rule header -->
-"
-`;
-
-exports[`generator #generate config emoji matches off/warn emoji superscript avoids superscript with double emoji 1`] = `
-"## Rules
-<!-- begin auto-generated rules list -->
-
-💼 Configurations enabled in.\\
-⚠️ Warns in the \`warning\` configuration.\\
-🚫 Disabled in the \`off\` configuration.
-
-| Name                           | Description            | 💼 |
-| :----------------------------- | :--------------------- | :- |
-| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | 🚫 |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ⚠️ |
-
-<!-- end auto-generated rules list -->
-"
-`;
-
-exports[`generator #generate config emoji matches off/warn emoji superscript avoids superscript with double emoji 2`] = `
-"# Description of no-foo (\`test/no-foo\`)
-
-⚠️ This rule _warns_ in the \`warning\` config.
-
-<!-- end auto-generated rule header -->
-"
-`;
-
-exports[`generator #generate config emoji matches off/warn emoji superscript avoids superscript with double emoji 3`] = `
-"# Description of no-bar (\`test/no-bar\`)
-
-🚫 This rule is _disabled_ in the \`off\` config.
+💼 This rule is enabled in the ✅ \`recommended\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -118,9 +83,10 @@ exports[`generator #generate config that extends another config generates the do
 "## Rules
 <!-- begin auto-generated rules list -->
 
-✅ Enabled in the \`recommended\` configuration.
+💼 Configurations enabled in.\\
+✅ Set in the \`recommended\` configuration.
 
-| Name                           | Description            | ✅  |
+| Name                           | Description            | 💼 |
 | :----------------------------- | :--------------------- | :- |
 | [no-bar](docs/rules/no-bar.md) | Description of no-bar. | ✅  |
 | [no-baz](docs/rules/no-baz.md) | Description of no-baz. | ✅  |
@@ -134,7 +100,7 @@ exports[`generator #generate config that extends another config generates the do
 exports[`generator #generate config that extends another config generates the documentation 2`] = `
 "# Description of no-foo (\`test/no-foo\`)
 
-✅ This rule is enabled in the \`recommended\` config.
+💼 This rule is enabled in the ✅ \`recommended\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -143,7 +109,7 @@ exports[`generator #generate config that extends another config generates the do
 exports[`generator #generate config that extends another config generates the documentation 3`] = `
 "# Description of no-bar (\`test/no-bar\`)
 
-✅ This rule is enabled in the \`recommended\` config.
+💼 This rule is enabled in the ✅ \`recommended\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -152,7 +118,7 @@ exports[`generator #generate config that extends another config generates the do
 exports[`generator #generate config that extends another config generates the documentation 4`] = `
 "# Description of no-baz (\`test/no-baz\`)
 
-✅ This rule is enabled in the \`recommended\` config.
+💼 This rule is enabled in the ✅ \`recommended\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -161,7 +127,7 @@ exports[`generator #generate config that extends another config generates the do
 exports[`generator #generate config that extends another config generates the documentation 5`] = `
 "# Description of no-biz (\`test/no-biz\`)
 
-✅ This rule is enabled in the \`recommended\` config.
+💼 This rule is enabled in the ✅ \`recommended\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -171,9 +137,10 @@ exports[`generator #generate config with overrides generates the documentation 1
 "## Rules
 <!-- begin auto-generated rules list -->
 
-✅ Enabled in the \`recommended\` configuration.
+💼 Configurations enabled in.\\
+✅ Set in the \`recommended\` configuration.
 
-| Name                           | Description            | ✅  |
+| Name                           | Description            | 💼 |
 | :----------------------------- | :--------------------- | :- |
 | [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅  |
 
@@ -184,7 +151,7 @@ exports[`generator #generate config with overrides generates the documentation 1
 exports[`generator #generate config with overrides generates the documentation 2`] = `
 "# Description of no-foo (\`test/no-foo\`)
 
-✅ This rule is enabled in the \`recommended\` config.
+💼 This rule is enabled in the ✅ \`recommended\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -194,9 +161,10 @@ exports[`generator #generate deprecated function-style rule generates the docume
 "## Rules
 <!-- begin auto-generated rules list -->
 
-✅ Enabled in the \`recommended\` configuration.
+💼 Configurations enabled in.\\
+✅ Set in the \`recommended\` configuration.
 
-| Name                           | ✅  |
+| Name                           | 💼 |
 | :----------------------------- | :- |
 | [no-foo](docs/rules/no-foo.md) | ✅  |
 
@@ -399,9 +367,10 @@ exports[`generator #generate one rule missing description generates the document
 exports[`generator #generate only a \`recommended\` config updates the documentation 1`] = `
 "<!-- begin auto-generated rules list -->
 
-✅ Enabled in the \`recommended\` configuration.
+💼 Configurations enabled in.\\
+✅ Set in the \`recommended\` configuration.
 
-| Name                           | Description  | ✅  |
+| Name                           | Description  | 💼 |
 | :----------------------------- | :----------- | :- |
 | [no-foo](docs/rules/no-foo.md) | Description. | ✅  |
 
@@ -411,7 +380,7 @@ exports[`generator #generate only a \`recommended\` config updates the documenta
 exports[`generator #generate only a \`recommended\` config updates the documentation 2`] = `
 "# Description (\`test/no-foo\`)
 
-✅ This rule is enabled in the \`recommended\` config.
+💼 This rule is enabled in the ✅ \`recommended\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -421,9 +390,10 @@ exports[`generator #generate rule config with options generates the documentatio
 "## Rules
 <!-- begin auto-generated rules list -->
 
-✅ Enabled in the \`recommended\` configuration.
+💼 Configurations enabled in.\\
+✅ Set in the \`recommended\` configuration.
 
-| Name                           | Description            | ✅  |
+| Name                           | Description            | 💼 |
 | :----------------------------- | :--------------------- | :- |
 | [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅  |
 
@@ -434,7 +404,7 @@ exports[`generator #generate rule config with options generates the documentatio
 exports[`generator #generate rule config with options generates the documentation 2`] = `
 "# Description of no-foo (\`test/no-foo\`)
 
-✅ This rule is enabled in the \`recommended\` config.
+💼 This rule is enabled in the ✅ \`recommended\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -443,7 +413,7 @@ exports[`generator #generate rule config with options generates the documentatio
 exports[`generator #generate rule doc without header marker but pre-existing header updates the documentation 1`] = `
 "# Description (\`test/no-foo\`)
 
-✅ This rule is enabled in the \`recommended\` config.
+💼 This rule is enabled in the ✅ \`recommended\` config.
 
 <!-- end auto-generated rule header -->
 Pre-existing notice about the rule being recommended.
@@ -493,9 +463,10 @@ exports[`generator #generate rule with no meta object generates the documentatio
 "## Rules
 <!-- begin auto-generated rules list -->
 
-✅ Enabled in the \`recommended\` configuration.
+💼 Configurations enabled in.\\
+✅ Set in the \`recommended\` configuration.
 
-| Name                           | ✅  |
+| Name                           | 💼 |
 | :----------------------------- | :- |
 | [no-foo](docs/rules/no-foo.md) | ✅  |
 
@@ -506,7 +477,7 @@ exports[`generator #generate rule with no meta object generates the documentatio
 exports[`generator #generate rule with no meta object generates the documentation 2`] = `
 "# test/no-foo
 
-✅ This rule is enabled in the \`recommended\` config.
+💼 This rule is enabled in the ✅ \`recommended\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -611,19 +582,19 @@ exports[`generator #generate rules that are disabled or set to warn generates th
 <!-- begin auto-generated rules list -->
 
 💼 Configurations enabled in.\\
-✅ Enabled in the \`recommended\` configuration.\\
-✅<sup>⚠️</sup> Warns in the \`recommended\` configuration.\\
-✅<sup>🚫</sup> Disabled in the \`recommended\` configuration.
+⚠️ Configurations set to warn in.\\
+🚫 Configurations disabled in.\\
+✅ Set in the \`recommended\` configuration.
 
-| Name                           | Description            | 💼                                         |
-| :----------------------------- | :--------------------- | :----------------------------------------- |
-| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | ![other][]<sup>🚫</sup> <br>✅<sup>🚫</sup> |
-| [no-baz](docs/rules/no-baz.md) | Description of no-baz. | ✅ <br>![other][]<sup>🚫</sup>              |
-| [no-bez](docs/rules/no-bez.md) | Description of no-bez. | ![other][]<sup>⚠️</sup>                    |
-| [no-biz](docs/rules/no-biz.md) | Description of no-biz. | ![other][]<sup>🚫</sup>                    |
-| [no-boz](docs/rules/no-boz.md) | Description of no-boz. | ✅<sup>⚠️</sup>                             |
-| [no-buz](docs/rules/no-buz.md) | Description of no-buz. | ![other][]<sup>⚠️</sup> <br>✅<sup>⚠️</sup> |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅<sup>🚫</sup>                             |
+| Name                           | Description            | 💼 | ⚠️           | 🚫           |
+| :----------------------------- | :--------------------- | :- | :----------- | :----------- |
+| [no-bar](docs/rules/no-bar.md) | Description of no-bar. |    |              | ![other][] ✅ |
+| [no-baz](docs/rules/no-baz.md) | Description of no-baz. | ✅  |              | ![other][]   |
+| [no-bez](docs/rules/no-bez.md) | Description of no-bez. |    | ![other][]   |              |
+| [no-biz](docs/rules/no-biz.md) | Description of no-biz. |    |              | ![other][]   |
+| [no-boz](docs/rules/no-boz.md) | Description of no-boz. |    | ✅            |              |
+| [no-buz](docs/rules/no-buz.md) | Description of no-buz. |    | ![other][] ✅ |              |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. |    |              | ✅            |
 
 <!-- end auto-generated rules list -->
 "
@@ -632,7 +603,7 @@ exports[`generator #generate rules that are disabled or set to warn generates th
 exports[`generator #generate rules that are disabled or set to warn generates the documentation 2`] = `
 "# Description of no-foo (\`test/no-foo\`)
 
-✅<sup>🚫</sup> This rule is _disabled_ in the \`recommended\` config.
+🚫 This rule is _disabled_ in the ✅ \`recommended\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -641,7 +612,7 @@ exports[`generator #generate rules that are disabled or set to warn generates th
 exports[`generator #generate rules that are disabled or set to warn generates the documentation 3`] = `
 "# Description of no-bar (\`test/no-bar\`)
 
-💼 This rule is _disabled_ in the following configs: \`other\`, ✅ \`recommended\`.
+🚫 This rule is _disabled_ in the following configs: \`other\`, ✅ \`recommended\`.
 
 <!-- end auto-generated rule header -->
 "
@@ -650,7 +621,7 @@ exports[`generator #generate rules that are disabled or set to warn generates th
 exports[`generator #generate rules that are disabled or set to warn generates the documentation 4`] = `
 "# Description of no-baz (\`test/no-baz\`)
 
-💼 This rule is enabled in the ✅ \`recommended\` config. This rule is _disabled_ in the \`other\` config.
+💼🚫 This rule is enabled in the ✅ \`recommended\` config. This rule is _disabled_ in the \`other\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -659,7 +630,7 @@ exports[`generator #generate rules that are disabled or set to warn generates th
 exports[`generator #generate rules that are disabled or set to warn generates the documentation 5`] = `
 "# Description of no-biz (\`test/no-biz\`)
 
-💼<sup>🚫</sup> This rule is _disabled_ in the \`other\` config.
+🚫 This rule is _disabled_ in the \`other\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -668,7 +639,7 @@ exports[`generator #generate rules that are disabled or set to warn generates th
 exports[`generator #generate rules that are disabled or set to warn generates the documentation 6`] = `
 "# Description of no-boz (\`test/no-boz\`)
 
-✅<sup>⚠️</sup> This rule _warns_ in the \`recommended\` config.
+⚠️ This rule _warns_ in the ✅ \`recommended\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -677,7 +648,7 @@ exports[`generator #generate rules that are disabled or set to warn generates th
 exports[`generator #generate rules that are disabled or set to warn generates the documentation 7`] = `
 "# Description of no-buz (\`test/no-buz\`)
 
-💼 This rule _warns_ in the following configs: \`other\`, ✅ \`recommended\`.
+⚠️ This rule _warns_ in the following configs: \`other\`, ✅ \`recommended\`.
 
 <!-- end auto-generated rule header -->
 "
@@ -686,7 +657,7 @@ exports[`generator #generate rules that are disabled or set to warn generates th
 exports[`generator #generate rules that are disabled or set to warn generates the documentation 8`] = `
 "# Description of no-bez (\`test/no-bez\`)
 
-💼<sup>⚠️</sup> This rule _warns_ in the \`other\` config.
+⚠️ This rule _warns_ in the \`other\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -696,13 +667,14 @@ exports[`generator #generate rules that are disabled or set to warn, only one co
 "## Rules
 <!-- begin auto-generated rules list -->
 
-✅<sup>⚠️</sup> Warns in the \`recommended\` configuration.\\
-✅<sup>🚫</sup> Disabled in the \`recommended\` configuration.
+⚠️ Configurations set to warn in.\\
+🚫 Configurations disabled in.\\
+✅ Set in the \`recommended\` configuration.
 
-| Name                           | Description            | ✅              |
-| :----------------------------- | :--------------------- | :------------- |
-| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | ✅<sup>🚫</sup> |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅<sup>⚠️</sup> |
+| Name                           | Description            | ⚠️ | 🚫 |
+| :----------------------------- | :--------------------- | :- | :- |
+| [no-bar](docs/rules/no-bar.md) | Description of no-bar. |    | ✅  |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅  |    |
 
 <!-- end auto-generated rules list -->
 "
@@ -711,7 +683,7 @@ exports[`generator #generate rules that are disabled or set to warn, only one co
 exports[`generator #generate rules that are disabled or set to warn, only one config present generates the documentation 2`] = `
 "# Description of no-foo (\`test/no-foo\`)
 
-✅<sup>⚠️</sup> This rule _warns_ in the \`recommended\` config.
+⚠️ This rule _warns_ in the ✅ \`recommended\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -720,7 +692,7 @@ exports[`generator #generate rules that are disabled or set to warn, only one co
 exports[`generator #generate rules that are disabled or set to warn, only one config present generates the documentation 3`] = `
 "# Description of no-bar (\`test/no-bar\`)
 
-✅<sup>🚫</sup> This rule is _disabled_ in the \`recommended\` config.
+🚫 This rule is _disabled_ in the ✅ \`recommended\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -730,13 +702,14 @@ exports[`generator #generate rules that are disabled or set to warn, two configs
 "## Rules
 <!-- begin auto-generated rules list -->
 
-💼 Configurations enabled in.\\
-✅<sup>⚠️</sup> Warns in the \`recommended\` configuration.\\
-⌨️<sup>🚫</sup> Disabled in the \`typescript\` configuration.
+⚠️ Configurations set to warn in.\\
+🚫 Configurations disabled in.\\
+✅ Set in the \`recommended\` configuration.\\
+⌨️ Set in the \`typescript\` configuration.
 
-| Name                           | Description            | 💼                                 |
-| :----------------------------- | :--------------------- | :--------------------------------- |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅<sup>⚠️</sup> <br>⌨️<sup>🚫</sup> |
+| Name                           | Description            | ⚠️ | 🚫 |
+| :----------------------------- | :--------------------- | :- | :- |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅  | ⌨️ |
 
 <!-- end auto-generated rules list -->
 "
@@ -745,7 +718,7 @@ exports[`generator #generate rules that are disabled or set to warn, two configs
 exports[`generator #generate rules that are disabled or set to warn, two configs present generates the documentation 2`] = `
 "# Description of no-foo (\`test/no-foo\`)
 
-💼 This rule _warns_ in the ✅ \`recommended\` config. This rule is _disabled_ in the ⌨️ \`typescript\` config.
+⚠️🚫 This rule _warns_ in the ✅ \`recommended\` config. This rule is _disabled_ in the ⌨️ \`typescript\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -754,10 +727,11 @@ exports[`generator #generate rules that are disabled or set to warn, two configs
 exports[`generator #generate shows column and notice for requiresTypeChecking updates the documentation 1`] = `
 "<!-- begin auto-generated rules list -->
 
-🌐 Enabled in the \`all\` configuration.\\
+💼 Configurations enabled in.\\
+🌐 Set in the \`all\` configuration.\\
 💭 Requires type information.
 
-| Name                           | Description            | 🌐 | 💭 |
+| Name                           | Description            | 💼 | 💭 |
 | :----------------------------- | :--------------------- | :- | :- |
 | [no-bar](docs/rules/no-bar.md) | Description of no-bar. |    | 💭 |
 | [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🌐 |    |
@@ -768,7 +742,7 @@ exports[`generator #generate shows column and notice for requiresTypeChecking up
 exports[`generator #generate shows column and notice for requiresTypeChecking updates the documentation 2`] = `
 "# Description of no-foo (\`test/no-foo\`)
 
-🌐 This rule is enabled in the \`all\` config.
+💼 This rule is enabled in the 🌐 \`all\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -922,17 +896,18 @@ exports[`generator #generate splitting list, with one sub-list having no rules e
 "## Rules
 <!-- begin auto-generated rules list -->
 
-✅ Enabled in the \`recommended\` configuration.
+💼 Configurations enabled in.\\
+✅ Set in the \`recommended\` configuration.
 
 ### bar
 
-| Name                           | ✅  |
+| Name                           | 💼 |
 | :----------------------------- | :- |
 | [no-bar](docs/rules/no-bar.md) |    |
 
 ### foo
 
-| Name                           | ✅  |
+| Name                           | 💼 |
 | :----------------------------- | :- |
 | [no-foo](docs/rules/no-foo.md) | ✅  |
 
@@ -965,9 +940,9 @@ Description.
 <!-- begin auto-generated rules list -->
 
 💼 Configurations enabled in.\\
-🌐 Enabled in the \`all\` configuration.\\
-✅ Enabled in the \`recommended\` configuration.\\
-🎨 Enabled in the \`style\` configuration.\\
+🌐 Set in the \`all\` configuration.\\
+✅ Set in the \`recommended\` configuration.\\
+🎨 Set in the \`style\` configuration.\\
 🔧 Automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\\
 💡 Manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
@@ -1077,7 +1052,7 @@ exports[`generator #generate with \`--url-configs\` option includes the config l
 <!-- begin auto-generated rules list -->
 
 💼 [Configurations](http://example.com/configs) enabled in.\\
-✅ Enabled in the \`recommended\` [configuration](http://example.com/configs).
+✅ Set in the \`recommended\` [configuration](http://example.com/configs).
 
 | Name                           | Description             | 💼                |
 | :----------------------------- | :---------------------- | :---------------- |
@@ -1091,7 +1066,7 @@ exports[`generator #generate with \`--url-configs\` option includes the config l
 exports[`generator #generate with \`--url-configs\` option includes the config link 2`] = `
 "# Description for no-foo (\`test/no-foo\`)
 
-✅ This rule is enabled in the \`recommended\` [config](http://example.com/configs).
+💼 This rule is enabled in the ✅ \`recommended\` [config](http://example.com/configs).
 
 <!-- end auto-generated rule header -->
 "
@@ -1110,9 +1085,10 @@ exports[`generator #generate with \`--url-configs\` option with only recommended
 "## Rules
 <!-- begin auto-generated rules list -->
 
-✅ Enabled in the \`recommended\` [configuration](http://example.com/configs).
+💼 [Configurations](http://example.com/configs) enabled in.\\
+✅ Set in the \`recommended\` [configuration](http://example.com/configs).
 
-| Name                           | Description             | ✅  |
+| Name                           | Description             | 💼 |
 | :----------------------------- | :---------------------- | :- |
 | [no-foo](docs/rules/no-foo.md) | Description for no-foo. | ✅  |
 
@@ -1123,7 +1099,7 @@ exports[`generator #generate with \`--url-configs\` option with only recommended
 exports[`generator #generate with \`--url-configs\` option with only recommended config includes the config link 2`] = `
 "# Description for no-foo (\`test/no-foo\`)
 
-✅ This rule is enabled in the \`recommended\` [config](http://example.com/configs).
+💼 This rule is enabled in the ✅ \`recommended\` [config](http://example.com/configs).
 
 <!-- end auto-generated rule header -->
 "
@@ -1189,36 +1165,13 @@ exports[`generator #generate with --config-emoji and removing default emoji for 
 "
 `;
 
-exports[`generator #generate with --config-emoji and using the general configs emoji for the sole config hides the generic config emoji legend to avoid two legends for the same emoji 1`] = `
-"## Rules
-<!-- begin auto-generated rules list -->
-
-💼 Enabled in the \`recommended\` configuration.
-
-| Name                           | Description             | 💼 |
-| :----------------------------- | :---------------------- | :- |
-| [no-foo](docs/rules/no-foo.md) | Description for no-foo. | 💼 |
-
-<!-- end auto-generated rules list -->
-"
-`;
-
-exports[`generator #generate with --config-emoji and using the general configs emoji for the sole config hides the generic config emoji legend to avoid two legends for the same emoji 2`] = `
-"# Description for no-foo (\`test/no-foo\`)
-
-💼 This rule is enabled in the \`recommended\` config.
-
-<!-- end auto-generated rule header -->
-"
-`;
-
 exports[`generator #generate with --config-emoji shows the correct emojis 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->
 
 💼 Configurations enabled in.\\
-🔥 Enabled in the \`recommended\` configuration.\\
-🎨 Enabled in the \`stylistic\` configuration.
+🔥 Set in the \`recommended\` configuration.\\
+🎨 Set in the \`stylistic\` configuration.
 
 | Name                           | Description             | 💼                         |
 | :----------------------------- | :---------------------- | :------------------------- |
@@ -1233,7 +1186,7 @@ exports[`generator #generate with --config-emoji shows the correct emojis 1`] = 
 exports[`generator #generate with --config-emoji shows the correct emojis 2`] = `
 "# Description for no-foo (\`test/no-foo\`)
 
-🔥 This rule is enabled in the \`recommended\` config.
+💼 This rule is enabled in the 🔥 \`recommended\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -1261,9 +1214,10 @@ exports[`generator #generate with --ignore-config hides the ignored config 1`] =
 "## Rules
 <!-- begin auto-generated rules list -->
 
-✅ Enabled in the \`recommended\` configuration.
+💼 Configurations enabled in.\\
+✅ Set in the \`recommended\` configuration.
 
-| Name                           | Description             | ✅  |
+| Name                           | Description             | 💼 |
 | :----------------------------- | :---------------------- | :- |
 | [no-foo](docs/rules/no-foo.md) | Description for no-foo. | ✅  |
 
@@ -1274,7 +1228,7 @@ exports[`generator #generate with --ignore-config hides the ignored config 1`] =
 exports[`generator #generate with --ignore-config hides the ignored config 2`] = `
 "# Description for no-foo (\`test/no-foo\`)
 
-✅ This rule is enabled in the \`recommended\` config.
+💼 This rule is enabled in the ✅ \`recommended\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -1341,9 +1295,10 @@ exports[`generator #generate with config that does not have any rules uses recom
 "## Rules
 <!-- begin auto-generated rules list -->
 
-✅ Enabled in the \`recommended\` configuration.
+💼 Configurations enabled in.\\
+✅ Set in the \`recommended\` configuration.
 
-| Name                           | Description             | ✅  |
+| Name                           | Description             | 💼 |
 | :----------------------------- | :---------------------- | :- |
 | [no-foo](docs/rules/no-foo.md) | Description for no-foo. | ✅  |
 
@@ -1354,7 +1309,7 @@ exports[`generator #generate with config that does not have any rules uses recom
 exports[`generator #generate with config that does not have any rules uses recommended config emoji since it is the only relevant config 2`] = `
 "# Description for no-foo (\`test/no-foo\`)
 
-✅ This rule is enabled in the \`recommended\` config.
+💼 This rule is enabled in the ✅ \`recommended\` config.
 
 <!-- end auto-generated rule header -->
 "

--- a/test/lib/generator-test.ts
+++ b/test/lib/generator-test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { readFileSync } from 'node:fs';
 import { jest } from '@jest/globals';
 import * as sinon from 'sinon';
-import { EMOJI_CONFIG } from '../../lib/emojis.js';
+import { EMOJI_CONFIG_ERROR } from '../../lib/emojis.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -2069,66 +2069,6 @@ describe('generator', function () {
       });
     });
 
-    describe('config emoji matches off/warn emoji superscript', function () {
-      beforeEach(function () {
-        mockFs({
-          'package.json': JSON.stringify({
-            name: 'eslint-plugin-test',
-            main: 'index.js',
-            type: 'module',
-          }),
-
-          'index.js': `
-            export default {
-              rules: {
-                'no-foo': {
-                  meta: { docs: { description: 'Description of no-foo.' }, },
-                  create(context) {},
-                },
-                'no-bar': {
-                  meta: { docs: { description: 'Description of no-bar.' }, },
-                  create(context) {},
-                },
-              },
-              configs: {
-                warning: {
-                  rules: {
-                    'test/no-foo': 1,
-                  }
-                },
-                off: {
-                  rules: {
-                    'test/no-bar': 0,
-                  }
-                }
-              }
-            };`,
-
-          'README.md': '## Rules\n',
-
-          'docs/rules/no-foo.md': '',
-          'docs/rules/no-bar.md': '',
-
-          // Needed for some of the test infrastructure to work.
-          node_modules: mockFs.load(
-            resolve(__dirname, '..', '..', 'node_modules')
-          ),
-        });
-      });
-
-      afterEach(function () {
-        mockFs.restore();
-        jest.resetModules();
-      });
-
-      it('avoids superscript with double emoji', async function () {
-        await generate('.', { configEmoji: ['off,🚫'] });
-        expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
-        expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
-        expect(readFileSync('docs/rules/no-bar.md', 'utf8')).toMatchSnapshot();
-      });
-    });
-
     describe('no rules with description', function () {
       beforeEach(function () {
         mockFs({
@@ -3047,51 +2987,7 @@ describe('generator', function () {
       });
     });
 
-    describe('with --config-emoji and using the general configs emoji for the sole config', function () {
-      beforeEach(function () {
-        mockFs({
-          'package.json': JSON.stringify({
-            name: 'eslint-plugin-test',
-            main: 'index.js',
-            type: 'module',
-          }),
-
-          'index.js': `
-            export default {
-              rules: {
-                'no-foo': { meta: { docs: { description: 'Description for no-foo.'} }, create(context) {} },
-              },
-              configs: {
-                recommended: { rules: { 'test/no-foo': 'error' } },
-              }
-            };`,
-
-          'README.md': '## Rules\n',
-
-          'docs/rules/no-foo.md': '',
-
-          // Needed for some of the test infrastructure to work.
-          node_modules: mockFs.load(
-            resolve(__dirname, '..', '..', 'node_modules')
-          ),
-        });
-      });
-
-      afterEach(function () {
-        mockFs.restore();
-        jest.resetModules();
-      });
-
-      it('hides the generic config emoji legend to avoid two legends for the same emoji', async function () {
-        await generate('.', {
-          configEmoji: [`recommended,${EMOJI_CONFIG}`],
-        });
-        expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
-        expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
-      });
-    });
-
-    describe('with --config-emoji and using the general configs emoji for a config but multiple configs present', function () {
+    describe('with --config-emoji and using a reserved emoji', function () {
       beforeEach(function () {
         mockFs({
           'package.json': JSON.stringify({
@@ -3129,9 +3025,9 @@ describe('generator', function () {
 
       it('throws an error', async function () {
         await expect(
-          generate('.', { configEmoji: [`recommended,${EMOJI_CONFIG}`] })
+          generate('.', { configEmoji: [`recommended,${EMOJI_CONFIG_ERROR}`] })
         ).rejects.toThrow(
-          `Cannot use the general configs emoji ${EMOJI_CONFIG} for an individual config when multiple configs are present.`
+          `Cannot specify reserved emoji ${EMOJI_CONFIG_ERROR}.`
         );
       });
     });


### PR DESCRIPTION
This is a substantial redesign of how we represent the configs that a rule belongs to in order to better account for the different error/warn/off severities that a config can set a rule to. This completely replaces the previous design of using emoji superscripts to represent different config severity levels which turned out to be too fragile (fixes #204). I consider this a substantial improvement.

In the readme rules list, there is now a separate config column for each severity level present. The rules list legends and rule doc notices are also affected. See the diffs from the snapshots in this PR. I have also manually tested this in a variety of repos.

Benefits:
* Improved aesthetics.
* Emoji placement is more consistent. A config's emoji will always be displayed next to its name.
* No more overloading the same emoji to mean different things depending on the context.
* Config column header emojis and rule doc notice leading emojis now depend solely on the config severities present and no longer depend on the number of involved configs. This is also more consistent with the convention for leading emojis of the consolidated fixable/suggestions notice.
* The implementation is simpler and I have refactored a bunch.

Notes:
* The default emoji for `warnings` configs has changed to 🚸 to avoid a conflict with the emoji which represents a config that sets a rule to warn (⚠️).
* We now disallow the use of reserved emojis to avoid that whole class of problems and confusion.
* This is breaking in that the 