### PR TITLE
Add `--path-rule-doc` and `--path-rule-list` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ And how it looks:
 | `--config-emoji` | Custom emoji to use for a config. Format is `config-name,emoji`. Default emojis are provided for [common configs](./lib/emojis.ts). To remove a default emoji and rely on a [badge](#badge) instead, provide the config name without an emoji. Option can be repeated. |
 | `--ignore-config` | Config to ignore from being displayed. Often used for an `all` config. Option can be repeated. |
 | `--ignore-deprecated-rules` | Whether to ignore deprecated rules from being checked, displayed, or updated (default: `false`). |
+| `--path-rule-doc` | Path to markdown file for each rule doc. Use `{name}` placeholder for the rule name (default: `docs/rules/{name}.md`). |
+| `--path-rule-list` | Path to markdown file with a rules section where the rules table list should live (default: `README.md`). |
 | `--rule-doc-notices` | Ordered, comma-separated list of notices to display in rule doc. Non-applicable notices will be hidden. Choices: `configs`, `deprecated`, `fixable`, `fixableAndHasSuggestions`, `hasSuggestions`, `requiresTypeChecking`, `type` (off by default). A consolidated notice called `fixableAndHasSuggestions` automatically replaces `fixable` and `hasSuggestions` when applicable. Default: `deprecated,configs,fixable,fixableAndHasSuggestions,hasSuggestions,requiresTypeChecking`. |
 | `--rule-doc-section-exclude` | Disallowed section in each rule doc. Exit with failure if present. Option can be repeated. |
 | `--rule-doc-section-include` | Required section in each rule doc. Exit with failure if missing. Option can be repeated. |

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -61,6 +61,16 @@ export function run() {
       false
     )
     .option(
+      '--path-rule-doc <path>',
+      '(optional) Path to markdown file for each rule doc. Use `{name}` placeholder for the rule name.',
+      'docs/rules/{name}.md'
+    )
+    .option(
+      '--path-rule-list <path>',
+      '(optional) Path to markdown file with a rules section where the rules table list should live.',
+      'README.md'
+    )
+    .option(
       '--rule-doc-notices <notices>',
       `(optional) Ordered, comma-separated list of notices to display in rule doc. Non-applicable notices will be hidden. A consolidated notice called \`fixableAndHasSuggestions\` automatically replaces \`fixable\` and \`hasSuggestions\` when applicable. (choices: "${Object.values(
         NOTICE_TYPE
@@ -122,6 +132,8 @@ export function run() {
         configEmoji?: string[];
         ignoreConfig: string[];
         ignoreDeprecatedRules?: boolean;
+        pathRuleDoc: string;
+        pathRuleList: string;
         ruleDocNotices: string;
         ruleDocSectionExclude: string[];
         ruleDocSectionInclude: string[];
@@ -137,6 +149,8 @@ export function run() {
         configEmoji: options.configEmoji,
         ignoreConfig: options.ignoreConfig,
         ignoreDeprecatedRules: options.ignoreDeprecatedRules,
+        pathRuleDoc: options.pathRuleDoc,
+        pathRuleList: options.pathRuleList,
         ruleDocNotices: options.ruleDocNotices,
         ruleDocSectionExclude: options.ruleDocSectionExclude,
         ruleDocSectionInclude: options.ruleDocSectionInclude,

--- a/lib/package-json.ts
+++ b/lib/package-json.ts
@@ -1,4 +1,4 @@
-import { join, resolve, extname } from 'node:path';
+import { join, resolve, extname, basename, dirname } from 'node:path';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { importAbs } from './import.js';
 import type { Plugin } from './types.js';
@@ -100,10 +100,9 @@ export function getPluginPrefix(path: string): string {
 /**
  * Resolve the path to a file but with the exact filename-casing present on disk.
  */
-export function getPathWithExactFileNameCasing(
-  dir: string,
-  fileNameToSearch: string
-) {
+export function getPathWithExactFileNameCasing(path: string) {
+  const dir = dirname(path);
+  const fileNameToSearch = basename(path);
   const filenames = readdirSync(dir, { withFileTypes: true });
   for (const dirent of filenames) {
     if (

--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -121,6 +121,7 @@ function buildRuleRow(
   rule: RuleDetails,
   configsToRules: ConfigsToRules,
   pluginPrefix: string,
+  pathRuleDoc: string,
   configEmojis: ConfigEmojis,
   ignoreConfig: string[]
 ): string[] {
@@ -158,7 +159,10 @@ function buildRuleRow(
     [COLUMN_TYPE.HAS_SUGGESTIONS]: rule.hasSuggestions
       ? EMOJI_HAS_SUGGESTIONS
       : '',
-    [COLUMN_TYPE.NAME]: `[${rule.name}](docs/rules/${rule.name}.md)`,
+    [COLUMN_TYPE.NAME]: `[${rule.name}](${pathRuleDoc.replace(
+      /{name}/g,
+      rule.name
+    )})`,
     [COLUMN_TYPE.REQUIRES_TYPE_CHECKING]: rule.requiresTypeChecking
       ? EMOJI_REQUIRES_TYPE_CHECKING
       : '',
@@ -178,6 +182,7 @@ function generateRulesListMarkdown(
   details: RuleDetails[],
   configsToRules: ConfigsToRules,
   pluginPrefix: string,
+  pathRuleDoc: string,
   configEmojis: ConfigEmojis,
   ignoreConfig: string[]
 ): string {
@@ -208,6 +213,7 @@ function generateRulesListMarkdown(
             rule,
             configsToRules,
             pluginPrefix,
+            pathRuleDoc,
             configEmojis,
             ignoreConfig
           )
@@ -226,6 +232,7 @@ function generateRulesListMarkdownWithSplitBy(
   plugin: Plugin,
   configsToRules: ConfigsToRules,
   pluginPrefix: string,
+  pathRuleDoc: string,
   configEmojis: ConfigEmojis,
   ignoreConfig: string[],
   splitBy: string
@@ -263,6 +270,7 @@ function generateRulesListMarkdownWithSplitBy(
         rulesForThisValue,
         configsToRules,
         pluginPrefix,
+        pathRuleDoc,
         configEmojis,
         ignoreConfig
       )
@@ -293,6 +301,7 @@ function generateRulesListMarkdownWithSplitBy(
         rulesForThisValue,
         configsToRules,
         pluginPrefix,
+        pathRuleDoc,
         configEmojis,
         ignoreConfig
       )
@@ -308,6 +317,7 @@ export function updateRulesList(
   plugin: Plugin,
   configsToRules: ConfigsToRules,
   pluginPrefix: string,
+  pathRuleDoc: string,
   pathToReadme: string,
   pathToPlugin: string,
   configEmojis: ConfigEmojis,
@@ -380,6 +390,7 @@ export function updateRulesList(
         plugin,
         configsToRules,
         pluginPrefix,
+        pathRuleDoc,
         configEmojis,
         ignoreConfig,
         splitBy
@@ -389,6 +400,7 @@ export function updateRulesList(
         details,
         configsToRules,
         pluginPrefix,
+        pathRuleDoc,
         configEmojis,
         ignoreConfig
       );

--- a/test/lib/__snapshots__/generator-test.ts.snap
+++ b/test/lib/__snapshots__/generator-test.ts.snap
@@ -157,6 +157,23 @@ exports[`generator #generate config with overrides generates the documentation 2
 "
 `;
 
+exports[`generator #generate custom path to rule docs and rules list generates the documentation 1`] = `
+"<!-- begin auto-generated rules list -->
+
+| Name                             |
+| :------------------------------- |
+| [no-foo](rules/no-foo/no-foo.md) |
+
+<!-- end auto-generated rules list -->"
+`;
+
+exports[`generator #generate custom path to rule docs and rules list generates the documentation 2`] = `
+"# test/no-foo
+
+<!-- end auto-generated rule header -->
+"
+`;
+
 exports[`generator #generate deprecated function-style rule generates the documentation 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->


### PR DESCRIPTION
Allow customizing where the documentation lives.

Fixes #77.