### PR TITLE
Implement config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ And how it looks:
 
 ## Configuration options
 
+These can be provided as CLI options or as [config file](#configuration-file) options.
+
 | Name | Description |
 | :-- | :-- |
 | `--check` | Whether to check for and fail if there is a diff. No output will be written. Typically used during CI. |
@@ -143,6 +145,24 @@ Where `no-foo` is the rule name, `Disallow use of foo` is the rule description, 
 | `desc-parens-prefix-name` (default) | `# Disallow use of foo (test/no-foo)` |
 | `name` | `# no-foo` |
 `prefix-name` | `# test/no-foo` |
+
+### Configuration file
+
+There are a few ways to create a config file:
+
+- An object exported by `.eslint-doc-generatorrc.js`, `.eslint-doc-generatorrc.json`, or any other config file format/name supported by [cosmiconfig](https://github.com/davidtheclark/cosmiconfig#searchplaces)
+- An object under the `eslint-doc-generator` key in `package.json`
+
+Config files support all the [CLI options](#configuration-options) but in camelCase. CLI options take precedence over config file options.
+
+Example:
+
+```js
+// .eslint-doc-generatorrc.js
+module.exports = {
+  ignoreConfig: ['all'],
+};
+```
 
 ## Compatibility
 

--- a/bin/eslint-doc-generator.ts
+++ b/bin/eslint-doc-generator.ts
@@ -2,9 +2,10 @@
 /* eslint node/shebang:"off" -- shebang needed so compiled code gets interpreted as JS */
 
 import { run } from '../lib/cli.js';
+import { generate } from '../lib/generator.js';
 
 try {
-  run();
+  run(process.argv, (path, options) => generate(path, options));
 } catch (error) {
   if (error instanceof Error) {
     console.error(error.message);

--- a/lib/configs.ts
+++ b/lib/configs.ts
@@ -1,8 +1,3 @@
-import {
-  EMOJI_CONFIGS,
-  EMOJI_CONFIG_ERROR,
-  RESERVED_EMOJIS,
-} from './emojis.js';
 import { SEVERITY_TYPE_TO_SET } from './types.js';
 import type {
   Plugin,
@@ -77,57 +72,6 @@ export function getConfigsForRule(
   return configNames.sort((a, b) =>
     a.toLowerCase().localeCompare(b.toLowerCase())
   );
-}
-
-/**
- * Parse the options, check for errors, and set defaults.
- */
-export function parseConfigEmojiOptions(
-  plugin: Plugin,
-  configEmoji?: string[]
-): ConfigEmojis {
-  const configsWithDefaultEmojiRemoved: string[] = [];
-  const configEmojis =
-    configEmoji?.flatMap((configEmojiItem) => {
-      const [config, emoji, ...extra] = configEmojiItem.split(',');
-
-      if (config && !emoji && Object.keys(EMOJI_CONFIGS).includes(config)) {
-        // User wants to remove the default emoji for this config.
-        configsWithDefaultEmojiRemoved.push(config);
-        return [];
-      }
-
-      if (!config || !emoji || extra.length > 0) {
-        throw new Error(
-          `Invalid configEmoji option: ${configEmojiItem}. Expected format: config,emoji`
-        );
-      }
-
-      if (plugin.configs?.[config] === undefined) {
-        throw new Error(
-          `Invalid configEmoji option: ${config} config not found.`
-        );
-      }
-
-      if (RESERVED_EMOJIS.includes(emoji)) {
-        throw new Error(`Cannot specify reserved emoji ${EMOJI_CONFIG_ERROR}.`);
-      }
-
-      return [{ config, emoji }];
-    }) || [];
-
-  // Add default emojis for the common configs for which the user hasn't already specified an emoji.
-  for (const [config, emoji] of Object.entries(EMOJI_CONFIGS)) {
-    if (configsWithDefaultEmojiRemoved.includes(config)) {
-      // Skip the default emoji for this config.
-      continue;
-    }
-    if (!configEmojis.some((configEmoji) => configEmoji.config === config)) {
-      configEmojis.push({ config, emoji });
-    }
-  }
-
-  return configEmojis;
 }
 
 /**

--- a/lib/option-parsers.ts
+++ b/lib/option-parsers.ts
@@ -1,0 +1,132 @@
+import {
+  COLUMN_TYPE_DEFAULT_PRESENCE_AND_ORDERING,
+  NOTICE_TYPE_DEFAULT_PRESENCE_AND_ORDERING,
+} from './options.js';
+import { COLUMN_TYPE, NOTICE_TYPE } from './types.js';
+import {
+  EMOJI_CONFIGS,
+  EMOJI_CONFIG_ERROR,
+  RESERVED_EMOJIS,
+} from './emojis.js';
+import type { Plugin, ConfigEmojis } from './types.js';
+
+/**
+ * Parse the options, check for errors, and set defaults.
+ */
+export function parseConfigEmojiOptions(
+  plugin: Plugin,
+  configEmoji?: string[]
+): ConfigEmojis {
+  const configsSeen = new Set<string>();
+  const configsWithDefaultEmojiRemoved: string[] = [];
+  const configEmojis =
+    configEmoji?.flatMap((configEmojiItem) => {
+      const [config, emoji, ...extra] = configEmojiItem.split(',');
+
+      // Check for duplicate configs.
+      if (configsSeen.has(config)) {
+        throw new Error(
+          `Duplicate config name in configEmoji options: ${config}`
+        );
+      } else {
+        configsSeen.add(config);
+      }
+
+      if (config && !emoji && Object.keys(EMOJI_CONFIGS).includes(config)) {
+        // User wants to remove the default emoji for this config.
+        configsWithDefaultEmojiRemoved.push(config);
+        return [];
+      }
+
+      if (!config || !emoji || extra.length > 0) {
+        throw new Error(
+          `Invalid configEmoji option: ${configEmojiItem}. Expected format: config,emoji`
+        );
+      }
+
+      if (plugin.configs?.[config] === undefined) {
+        throw new Error(
+          `Invalid configEmoji option: ${config} config not found.`
+        );
+      }
+
+      if (RESERVED_EMOJIS.includes(emoji)) {
+        throw new Error(`Cannot specify reserved emoji ${EMOJI_CONFIG_ERROR}.`);
+      }
+
+      return [{ config, emoji }];
+    }) || [];
+
+  // Add default emojis for the common configs for which the user hasn't already specified an emoji.
+  for (const [config, emoji] of Object.entries(EMOJI_CONFIGS)) {
+    if (configsWithDefaultEmojiRemoved.includes(config)) {
+      // Skip the default emoji for this config.
+      continue;
+    }
+    if (!configEmojis.some((configEmoji) => configEmoji.config === config)) {
+      configEmojis.push({ config, emoji });
+    }
+  }
+
+  return configEmojis;
+}
+
+/**
+ * Parse the option, check for errors, and set defaults.
+ */
+export function parseRuleListColumnsOption(
+  ruleListColumns: string | undefined
+): COLUMN_TYPE[] {
+  const values = ruleListColumns ? ruleListColumns.split(',') : [];
+  const VALUES_OF_TYPE = new Set(Object.values(COLUMN_TYPE).map(String));
+
+  // Check for invalid.
+  const invalid = values.find((val) => !VALUES_OF_TYPE.has(val));
+  if (invalid) {
+    throw new Error(`Invalid ruleListColumns option: ${invalid}`);
+  }
+  if (values.length !== new Set(values).size) {
+    throw new Error('Duplicate value detected in ruleListColumns option.');
+  }
+
+  if (values.length === 0) {
+    // Use default presence and ordering.
+    values.push(
+      ...Object.entries(COLUMN_TYPE_DEFAULT_PRESENCE_AND_ORDERING)
+        .filter(([_type, enabled]) => enabled)
+        .map(([type]) => type)
+    );
+  }
+
+  return values as COLUMN_TYPE[];
+}
+
+/**
+ * Parse the option, check for errors, and set defaults.
+ */
+export function parseRuleDocNoticesOption(
+  ruleDocNotices: string | undefined
+): NOTICE_TYPE[] {
+  const values = ruleDocNotices ? ruleDocNotices.split(',') : [];
+  const VALUES_OF_TYPE = new Set(Object.values(NOTICE_TYPE).map(String));
+
+  // Check for invalid.
+  const invalid = values.find((val) => !VALUES_OF_TYPE.has(val));
+  if (invalid) {
+    throw new Error(`Invalid ruleDocNotices option: ${invalid}`);
+  }
+  if (values.length !== new Set(values).size) {
+    throw new Error('Duplicate value detected in ruleDocNotices option.');
+  }
+
+  if (values.length === 0) {
+    // Use default presence and ordering.
+    values.push(
+      ...Object.entries(NOTICE_TYPE_DEFAULT_PRESENCE_AND_ORDERING)
+        .filter(([_type, enabled]) => enabled)
+        .map(([type]) => type)
+    );
+  }
+
+  return values as NOTICE_TYPE[];
+}

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -1,63 +1,98 @@
-import { COLUMN_TYPE_DEFAULT_PRESENCE_AND_ORDERING } from './rule-list-columns.js';
-import { NOTICE_TYPE_DEFAULT_PRESENCE_AND_ORDERING } from './rule-notices.js';
+import { RuleDocTitleFormat } from './rule-doc-title-format.js';
 import { COLUMN_TYPE, NOTICE_TYPE } from './types.js';
 
-/**
- * Parse the option, check for errors, and set defaults.
- */
-export function parseRuleListColumnsOption(
-  ruleListColumns: string | undefined
-): COLUMN_TYPE[] {
-  const values = ruleListColumns ? ruleListColumns.split(',') : [];
-  const VALUES_OF_TYPE = new Set(Object.values(COLUMN_TYPE).map(String));
+export const COLUMN_TYPE_DEFAULT_PRESENCE_AND_ORDERING: {
+  [key in COLUMN_TYPE]: boolean;
+} = {
+  // Object keys ordered in display order.
+  // Object values indicate whether the column is displayed by default.
+  [COLUMN_TYPE.NAME]: true,
+  [COLUMN_TYPE.DESCRIPTION]: true,
+  [COLUMN_TYPE.CONFIGS_ERROR]: true,
+  [COLUMN_TYPE.CONFIGS_WARN]: true,
+  [COLUMN_TYPE.CONFIGS_OFF]: true,
+  [COLUMN_TYPE.FIXABLE]: true,
+  [COLUMN_TYPE.HAS_SUGGESTIONS]: true,
+  [COLUMN_TYPE.REQUIRES_TYPE_CHECKING]: true,
+  [COLUMN_TYPE.TYPE]: false,
+  [COLUMN_TYPE.DEPRECATED]: true,
+};
 
-  // Check for invalid.
-  const invalid = values.find((val) => !VALUES_OF_TYPE.has(val));
-  if (invalid) {
-    throw new Error(`Invalid ruleListColumns option: ${invalid}`);
-  }
-  if (values.length !== new Set(values).size) {
-    throw new Error('Duplicate value detected in ruleListColumns option.');
-  }
+export const NOTICE_TYPE_DEFAULT_PRESENCE_AND_ORDERING: {
+  [key in NOTICE_TYPE]: boolean;
+} = {
+  // Object keys ordered in display order.
+  // Object values indicate whether the column is displayed by default.
+  [NOTICE_TYPE.DEPRECATED]: true, // Most important.
+  [NOTICE_TYPE.CONFIGS]: true,
+  [NOTICE_TYPE.FIXABLE]: true,
+  [NOTICE_TYPE.FIXABLE_AND_HAS_SUGGESTIONS]: true, // Potentially replaces FIXABLE and HAS_SUGGESTIONS.
+  [NOTICE_TYPE.HAS_SUGGESTIONS]: true,
+  [NOTICE_TYPE.REQUIRES_TYPE_CHECKING]: true,
+  [NOTICE_TYPE.TYPE]: false,
+};
 
-  if (values.length === 0) {
-    // Use default presence and ordering.
-    values.push(
-      ...Object.entries(COLUMN_TYPE_DEFAULT_PRESENCE_AND_ORDERING)
-        .filter(([_type, enabled]) => enabled)
-        .map(([type]) => type)
-    );
-  }
-
-  return values as COLUMN_TYPE[];
+export enum OPTION_TYPE {
+  CHECK = 'check',
+  CONFIG_EMOJI = 'configEmoji',
+  IGNORE_CONFIG = 'ignoreConfig',
+  IGNORE_DEPRECATED_RULES = 'ignoreDeprecatedRules',
+  PATH_RULE_DOC = 'pathRuleDoc',
+  PATH_RULE_LIST = 'pathRuleList',
+  RULE_DOC_NOTICES = 'ruleDocNotices',
+  RULE_DOC_SECTION_EXCLUDE = 'ruleDocSectionExclude',
+  RULE_DOC_SECTION_INCLUDE = 'ruleDocSectionInclude',
+  RULE_DOC_SECTION_OPTIONS = 'ruleDocSectionOptions',
+  RULE_DOC_TITLE_FORMAT = 'ruleDocTitleFormat',
+  RULE_LIST_COLUMNS = 'ruleListColumns',
+  SPLIT_BY = 'splitBy',
+  URL_CONFIGS = 'urlConfigs',
 }
 
-/**
- * Parse the option, check for errors, and set defaults.
- */
-export function parseRuleDocNoticesOption(
-  ruleDocNotices: string | undefined
-): NOTICE_TYPE[] {
-  const values = ruleDocNotices ? ruleDocNotices.split(',') : [];
-  const VALUES_OF_TYPE = new Set(Object.values(NOTICE_TYPE).map(String));
+const DEFAULT_RULE_DOC_TITLE_FORMAT: RuleDocTitleFormat =
+  'desc-parens-prefix-name'; // Using this variable ensures this default has the correct type (not just a plain string).
 
-  // Check for invalid.
-  const invalid = values.find((val) => !VALUES_OF_TYPE.has(val));
-  if (invalid) {
-    throw new Error(`Invalid ruleDocNotices option: ${invalid}`);
-  }
-  if (values.length !== new Set(values).size) {
-    throw new Error('Duplicate value detected in ruleDocNotices option.');
-  }
+// TODO: use TypeScript 4.9 satisfies keyword ([key in OPTION_TYPE]...) to ensure all options are included without losing type information.
+export const OPTION_DEFAULTS = {
+  [OPTION_TYPE.CHECK]: false,
+  [OPTION_TYPE.CONFIG_EMOJI]: [],
+  [OPTION_TYPE.IGNORE_CONFIG]: [],
+  [OPTION_TYPE.IGNORE_DEPRECATED_RULES]: false,
+  [OPTION_TYPE.PATH_RULE_DOC]: 'docs/rules/{name}.md',
+  [OPTION_TYPE.PATH_RULE_LIST]: 'README.md',
+  [OPTION_TYPE.RULE_DOC_NOTICES]: Object.entries(
+    NOTICE_TYPE_DEFAULT_PRESENCE_AND_ORDERING
+  )
+    .filter(([_col, enabled]) => enabled)
+    .map(([col]) => col)
+    .join(','),
+  [OPTION_TYPE.RULE_DOC_SECTION_EXCLUDE]: [],
+  [OPTION_TYPE.RULE_DOC_SECTION_INCLUDE]: [],
+  [OPTION_TYPE.RULE_DOC_SECTION_OPTIONS]: true,
+  [OPTION_TYPE.RULE_DOC_TITLE_FORMAT]: DEFAULT_RULE_DOC_TITLE_FORMAT,
+  [OPTION_TYPE.RULE_LIST_COLUMNS]: Object.entries(
+    COLUMN_TYPE_DEFAULT_PRESENCE_AND_ORDERING
+  )
+    .filter(([_col, enabled]) => enabled)
+    .map(([col]) => col)
+    .join(','),
+  [OPTION_TYPE.SPLIT_BY]: undefined,
+  [OPTION_TYPE.URL_CONFIGS]: undefined,
+};
 
-  if (values.length === 0) {
-    // Use default presence and ordering.
-    values.push(
-      ...Object.entries(NOTICE_TYPE_DEFAULT_PRESENCE_AND_ORDERING)
-        .filter(([_type, enabled]) => enabled)
-        .map(([type]) => type)
-    );
-  }
-
-  return values as NOTICE_TYPE[];
-}
+export type GenerateOptions = {
+  check?: boolean;
+  configEmoji?: string[];
+  ignoreConfig?: string[];
+  ignoreDeprecatedRules?: boolean;
+  pathRuleDoc?: string;
+  pathRuleList?: string;
+  ruleDocNotices?: string;
+  ruleDocSectionExclude?: string[];
+  ruleDocSectionInclude?: string[];
+  ruleDocSectionOptions?: boolean;
+  ruleDocTitleFormat?: RuleDocTitleFormat;
+  ruleListColumns?: string;
+  urlConfigs?: string;
+  splitBy?: string;
+};

--- a/lib/rule-doc-title-format.ts
+++ b/lib/rule-doc-title-format.ts
@@ -7,6 +7,3 @@ export const RULE_DOC_TITLE_FORMATS = [
 ] as const;
 
 export type RuleDocTitleFormat = typeof RULE_DOC_TITLE_FORMATS[number];
-
-export const RULE_DOC_TITLE_FORMAT_DEFAULT: RuleDocTitleFormat =
-  'desc-parens-prefix-name';

--- a/lib/rule-list-columns.ts
+++ b/lib/rule-list-columns.ts
@@ -11,23 +11,6 @@ import { COLUMN_TYPE, SEVERITY_TYPE } from './types.js';
 import { getConfigsThatSetARule } from './configs.js';
 import type { RuleDetails, ConfigsToRules, Plugin } from './types.js';
 
-export const COLUMN_TYPE_DEFAULT_PRESENCE_AND_ORDERING: {
-  [key in COLUMN_TYPE]: boolean;
-} = {
-  // Object keys ordered in display order.
-  // Object values indicate whether the column is displayed by default.
-  [COLUMN_TYPE.NAME]: true,
-  [COLUMN_TYPE.DESCRIPTION]: true,
-  [COLUMN_TYPE.CONFIGS_ERROR]: true,
-  [COLUMN_TYPE.CONFIGS_WARN]: true,
-  [COLUMN_TYPE.CONFIGS_OFF]: true,
-  [COLUMN_TYPE.FIXABLE]: true,
-  [COLUMN_TYPE.HAS_SUGGESTIONS]: true,
-  [COLUMN_TYPE.REQUIRES_TYPE_CHECKING]: true,
-  [COLUMN_TYPE.TYPE]: false,
-  [COLUMN_TYPE.DEPRECATED]: true,
-};
-
 /**
  * An object containing the column header for each column (as a string or function to generate the string).
  */

--- a/lib/rule-notices.ts
+++ b/lib/rule-notices.ts
@@ -16,24 +16,7 @@ import {
   NOTICE_TYPE,
 } from './types.js';
 import { RULE_TYPE, RULE_TYPE_MESSAGES_NOTICES } from './rule-type.js';
-import {
-  RuleDocTitleFormat,
-  RULE_DOC_TITLE_FORMAT_DEFAULT,
-} from './rule-doc-title-format.js';
-
-export const NOTICE_TYPE_DEFAULT_PRESENCE_AND_ORDERING: {
-  [key in NOTICE_TYPE]: boolean;
-} = {
-  // Object keys ordered in display order.
-  // Object values indicate whether the column is displayed by default.
-  [NOTICE_TYPE.DEPRECATED]: true, // Most important.
-  [NOTICE_TYPE.CONFIGS]: true,
-  [NOTICE_TYPE.FIXABLE]: true,
-  [NOTICE_TYPE.FIXABLE_AND_HAS_SUGGESTIONS]: true, // Potentially replaces FIXABLE and HAS_SUGGESTIONS.
-  [NOTICE_TYPE.HAS_SUGGESTIONS]: true,
-  [NOTICE_TYPE.REQUIRES_TYPE_CHECKING]: true,
-  [NOTICE_TYPE.TYPE]: false,
-};
+import { RuleDocTitleFormat } from './rule-doc-title-format.js';
 
 function severityToTerminology(severity: SEVERITY_TYPE) {
   switch (severity) {
@@ -372,14 +355,13 @@ function makeTitle(
   name: string,
   description: string | undefined,
   pluginPrefix: string,
-  ruleDocTitleFormat?: RuleDocTitleFormat
+  ruleDocTitleFormat: RuleDocTitleFormat
 ) {
   const descriptionFormatted = description
     ? removeTrailingPeriod(toSentenceCase(description))
     : undefined;
 
-  let ruleDocTitleFormatWithFallback: RuleDocTitleFormat =
-    ruleDocTitleFormat ?? RULE_DOC_TITLE_FORMAT_DEFAULT;
+  let ruleDocTitleFormatWithFallback: RuleDocTitleFormat = ruleDocTitleFormat;
 
   if (ruleDocTitleFormatWithFallback.includes('desc') && !description) {
     // If format includes the description but the rule is missing a description,
@@ -433,7 +415,7 @@ export function generateRuleHeaderLines(
   configEmojis: ConfigEmojis,
   ignoreConfig: string[],
   ruleDocNotices: NOTICE_TYPE[],
-  ruleDocTitleFormat?: RuleDocTitleFormat,
+  ruleDocTitleFormat: RuleDocTitleFormat,
   urlConfigs?: string
 ): string {
   return [

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,11 @@
       "license": "ISC",
       "dependencies": {
         "@typescript-eslint/utils": "^5.38.1",
+        "ajv": "^8.11.2",
         "camelcase": "^7.0.0",
         "commander": "^9.4.0",
+        "cosmiconfig": "^7.1.0",
+        "deepmerge": "^4.2.2",
         "jest-diff": "^29.2.1",
         "markdown-table": "^3.0.2",
         "type-fest": "^3.0.0"
@@ -68,7 +71,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
       "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
-      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.18.6"
       },
@@ -302,7 +304,6 @@
       "version": "7.19.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
       "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -334,7 +335,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
       "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
@@ -348,7 +348,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -360,7 +359,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -374,7 +372,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -382,14 +379,12 @@
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -398,7 +393,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -407,7 +401,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -695,6 +688,26 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -1701,8 +1714,7 @@
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-      "dev": true
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "node_modules/@types/prettier": {
       "version": "2.7.1",
@@ -2168,13 +2180,13 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
       },
       "funding": {
@@ -3258,10 +3270,9 @@
       "dev": true
     },
     "node_modules/cosmiconfig": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
-      "dev": true,
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
       "dependencies": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -3277,7 +3288,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -3465,7 +3475,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3727,7 +3736,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -4554,6 +4562,26 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/espree": {
       "version": "9.4.0",
@@ -5840,8 +5868,7 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "node_modules/is-bigint": {
       "version": "1.0.4",
@@ -7019,8 +7046,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -7060,13 +7086,12 @@
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -7219,8 +7244,7 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/linkify-it": {
       "version": "4.0.1",
@@ -8623,6 +8647,22 @@
         "npm": ">=6.0.0"
       }
     },
+    "node_modules/npm-package-json-lint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/npm-package-json-lint/node_modules/is-plain-obj": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
@@ -8634,6 +8674,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/npm-package-json-lint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/npm-package-json-lint/node_modules/semver": {
       "version": "7.3.7",
@@ -10137,6 +10183,22 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/release-it/node_modules/cosmiconfig": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/release-it/node_modules/execa": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
@@ -10242,6 +10304,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/release-it/node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/release-it/node_modules/path-key": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
@@ -10307,6 +10387,14 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12000,7 +12088,6 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -12068,7 +12155,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
       "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.18.6"
       }
@@ -12243,8 +12329,7 @@
     "@babel/helper-validator-identifier": {
       "version": "7.19.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
-      "dev": true
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w=="
     },
     "@babel/helper-validator-option": {
       "version": "7.18.6",
@@ -12267,7 +12352,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
       "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
@@ -12278,7 +12362,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -12287,7 +12370,6 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -12298,7 +12380,6 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -12306,26 +12387,22 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-          "dev": true
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-          "dev": true
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -12538,6 +12615,24 @@
         "js-yaml": "^4.1.0",
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        }
       }
     },
     "@gar/promisify": {
@@ -13358,8 +13453,7 @@
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-      "dev": true
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "@types/prettier": {
       "version": "2.7.1",
@@ -13660,13 +13754,13 @@
       }
     },
     "ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
       }
     },
@@ -14445,10 +14539,9 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
-      "dev": true,
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
       "requires": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -14461,7 +14554,6 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
           "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
@@ -14592,8 +14684,7 @@
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "defaults": {
       "version": "1.0.3",
@@ -14788,7 +14879,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -14996,6 +15086,24 @@
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        }
       }
     },
     "eslint-config-prettier": {
@@ -16315,8 +16423,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "is-bigint": {
       "version": "1.0.4",
@@ -17171,8 +17278,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -17203,13 +17309,12 @@
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -17331,8 +17436,7 @@
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "linkify-it": {
       "version": "4.0.1",
@@ -18304,10 +18408,28 @@
         "validate-npm-package-name": "^3.0.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
         "is-plain-obj": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
           "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
         },
         "semver": {
@@ -19383,6 +19505,19 @@
           "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
           "dev": true
         },
+        "cosmiconfig": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+          "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+          "dev": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.2.1",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.10.0"
+          }
+        },
         "execa": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
@@ -19447,6 +19582,18 @@
           "dev": true,
           "requires": {
             "mimic-fn": "^4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
           }
         },
         "path-key": {
@@ -19515,6 +19662,11 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "requireindex": {
       "version": "1.2.0",
@@ -20758,8 +20910,7 @@
     "yaml": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yargs": {
       "version": "17.5.1",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,11 @@
   },
   "dependencies": {
     "@typescript-eslint/utils": "^5.38.1",
+    "ajv": "^8.11.2",
     "camelcase": "^7.0.0",
     "commander": "^9.4.0",
+    "cosmiconfig": "^7.1.0",
+    "deepmerge": "^4.2.2",
     "jest-diff": "^29.2.1",
     "markdown-table": "^3.0.2",
     "type-fest": "^3.0.0"

--- a/test/lib/__snapshots__/cli-test.ts.snap
+++ b/test/lib/__snapshots__/cli-test.ts.snap
@@ -1,0 +1,158 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`cli all CLI options and all config files options merges correctly, with CLI options taking precedence 1`] = `
+[
+  ".",
+  {
+    "check": true,
+    "configEmoji": [
+      "recommended-from-config-file,🚲",
+      "recommended-from-cli,🚲",
+    ],
+    "ignoreConfig": [
+      "ignoredConfigFromConfigFile1",
+      "ignoredConfigFromConfigFile2",
+      "ignoredConfigFromCli1",
+      "ignoredConfigFromCli2",
+    ],
+    "ignoreDeprecatedRules": true,
+    "pathRuleDoc": "www.example.com/rule-doc-from-cli",
+    "pathRuleList": "www.example.com/rule-list-from-cli",
+    "ruleDocNotices": "type",
+    "ruleDocSectionExclude": [
+      "excludedSectionFromConfigFile1",
+      "excludedSectionFromConfigFile2",
+      "excludedSectionFromCli1",
+      "excludedSectionFromCli2",
+    ],
+    "ruleDocSectionInclude": [
+      "includedSectionFromConfigFile1",
+      "includedSectionFromConfigFile2",
+      "includedSectionFromCli1",
+      "includedSectionFromCli2",
+    ],
+    "ruleDocSectionOptions": true,
+    "ruleDocTitleFormat": "name",
+    "ruleListColumns": "type",
+    "splitBy": "meta.docs.foo-from-cli",
+    "urlConfigs": "www.example.com/configs-from-cli",
+  },
+]
+`;
+
+exports[`cli all CLI options, no config file options is called correctly 1`] = `
+[
+  ".",
+  {
+    "check": true,
+    "configEmoji": [
+      "recommended-from-cli,🚲",
+    ],
+    "ignoreConfig": [
+      "ignoredConfigFromCli1",
+      "ignoredConfigFromCli2",
+    ],
+    "ignoreDeprecatedRules": true,
+    "pathRuleDoc": "www.example.com/rule-doc-from-cli",
+    "pathRuleList": "www.example.com/rule-list-from-cli",
+    "ruleDocNotices": "type",
+    "ruleDocSectionExclude": [
+      "excludedSectionFromCli1",
+      "excludedSectionFromCli2",
+    ],
+    "ruleDocSectionInclude": [
+      "includedSectionFromCli1",
+      "includedSectionFromCli2",
+    ],
+    "ruleDocSectionOptions": true,
+    "ruleDocTitleFormat": "name",
+    "ruleListColumns": "type",
+    "splitBy": "meta.docs.foo-from-cli",
+    "urlConfigs": "www.example.com/configs-from-cli",
+  },
+]
+`;
+
+exports[`cli all config files options, no CLI options is called correctly 1`] = `
+[
+  ".",
+  {
+    "check": true,
+    "configEmoji": [
+      "recommended-from-config-file,🚲",
+    ],
+    "ignoreConfig": [
+      "ignoredConfigFromConfigFile1",
+      "ignoredConfigFromConfigFile2",
+    ],
+    "ignoreDeprecatedRules": true,
+    "pathRuleDoc": "www.example.com/rule-doc-from-config-file",
+    "pathRuleList": "www.example.com/rule-list-from-config-file",
+    "ruleDocNotices": "type",
+    "ruleDocSectionExclude": [
+      "excludedSectionFromConfigFile1",
+      "excludedSectionFromConfigFile2",
+    ],
+    "ruleDocSectionInclude": [
+      "includedSectionFromConfigFile1",
+      "includedSectionFromConfigFile2",
+    ],
+    "ruleDocSectionOptions": false,
+    "ruleDocTitleFormat": "desc",
+    "ruleListColumns": "fixable,hasSuggestions",
+    "splitBy": "meta.docs.foo-from-config-file",
+    "urlConfigs": "www.example.com/configs-from-config-file",
+  },
+]
+`;
+
+exports[`cli boolean option - false (explicit) is called correctly 1`] = `
+[
+  ".",
+  {
+    "configEmoji": [],
+    "ignoreConfig": [],
+    "ignoreDeprecatedRules": false,
+    "ruleDocSectionExclude": [],
+    "ruleDocSectionInclude": [],
+  },
+]
+`;
+
+exports[`cli boolean option - true (explicit) is called correctly 1`] = `
+[
+  ".",
+  {
+    "configEmoji": [],
+    "ignoreConfig": [],
+    "ignoreDeprecatedRules": true,
+    "ruleDocSectionExclude": [],
+    "ruleDocSectionInclude": [],
+  },
+]
+`;
+
+exports[`cli boolean option - true (implicit) is called correctly 1`] = `
+[
+  ".",
+  {
+    "configEmoji": [],
+    "ignoreConfig": [],
+    "ignoreDeprecatedRules": true,
+    "ruleDocSectionExclude": [],
+    "ruleDocSectionInclude": [],
+  },
+]
+`;
+
+exports[`cli no options is called correctly 1`] = `
+[
+  ".",
+  {
+    "configEmoji": [],
+    "ignoreConfig": [],
+    "ruleDocSectionExclude": [],
+    "ruleDocSectionInclude": [],
+  },
+]
+`;

--- a/test/lib/cli-test.ts
+++ b/test/lib/cli-test.ts
@@ -1,0 +1,301 @@
+import * as sinon from 'sinon';
+import { run } from '../../lib/cli.js';
+import mockFs from 'mock-fs';
+import { OPTION_TYPE } from '../../lib/options.js';
+
+const configFileOptionsAll: { [key in OPTION_TYPE]: unknown } = {
+  check: true,
+  configEmoji: ['recommended-from-config-file,🚲'],
+  ignoreConfig: [
+    'ignoredConfigFromConfigFile1',
+    'ignoredConfigFromConfigFile2',
+  ],
+  ignoreDeprecatedRules: true,
+  pathRuleDoc: 'www.example.com/rule-doc-from-config-file',
+  pathRuleList: 'www.example.com/rule-list-from-config-file',
+  ruleDocNotices: 'type',
+  ruleDocSectionExclude: [
+    'excludedSectionFromConfigFile1',
+    'excludedSectionFromConfigFile2',
+  ],
+  ruleDocSectionInclude: [
+    'includedSectionFromConfigFile1',
+    'includedSectionFromConfigFile2',
+  ],
+  ruleDocSectionOptions: false,
+  ruleDocTitleFormat: 'desc',
+  ruleListColumns: 'fixable,hasSuggestions',
+  splitBy: 'meta.docs.foo-from-config-file',
+  urlConfigs: 'www.example.com/configs-from-config-file',
+};
+
+const cliOptionsAll: { [key in OPTION_TYPE]: string[] } = {
+  [OPTION_TYPE.CHECK]: ['--check'],
+
+  [OPTION_TYPE.CONFIG_EMOJI]: ['--config-emoji', 'recommended-from-cli,🚲'],
+
+  [OPTION_TYPE.IGNORE_CONFIG]: [
+    '--ignore-config',
+    'ignoredConfigFromCli1',
+    '--ignore-config',
+    'ignoredConfigFromCli2',
+  ],
+
+  [OPTION_TYPE.IGNORE_DEPRECATED_RULES]: ['--ignore-deprecated-rules', 'true'],
+
+  [OPTION_TYPE.PATH_RULE_DOC]: [
+    '--path-rule-doc',
+    'www.example.com/rule-doc-from-cli',
+  ],
+
+  [OPTION_TYPE.PATH_RULE_LIST]: [
+    '--path-rule-list',
+    'www.example.com/rule-list-from-cli',
+  ],
+
+  [OPTION_TYPE.RULE_DOC_NOTICES]: ['--rule-doc-notices', 'type'],
+
+  [OPTION_TYPE.RULE_DOC_SECTION_EXCLUDE]: [
+    '--rule-doc-section-exclude',
+    'excludedSectionFromCli1',
+    '--rule-doc-section-exclude',
+    'excludedSectionFromCli2',
+  ],
+
+  [OPTION_TYPE.RULE_DOC_SECTION_INCLUDE]: [
+    '--rule-doc-section-include',
+    'includedSectionFromCli1',
+    '--rule-doc-section-include',
+    'includedSectionFromCli2',
+  ],
+
+  [OPTION_TYPE.RULE_DOC_SECTION_OPTIONS]: [
+    '--rule-doc-section-options',
+    'true',
+  ],
+
+  [OPTION_TYPE.RULE_DOC_TITLE_FORMAT]: ['--rule-doc-title-format', 'name'],
+
+  [OPTION_TYPE.RULE_LIST_COLUMNS]: ['--rule-list-columns', 'type'],
+
+  [OPTION_TYPE.SPLIT_BY]: ['--split-by', 'meta.docs.foo-from-cli'],
+
+  [OPTION_TYPE.URL_CONFIGS]: [
+    '--url-configs',
+    'www.example.com/configs-from-cli',
+  ],
+};
+
+describe('cli', function () {
+  describe('no options', function () {
+    it('is called correctly', async function () {
+      const stub = sinon.stub().resolves();
+      await run(
+        [
+          'node', // Path to node.
+          'eslint-doc-generator.js', // Path to this binary.
+        ],
+        stub
+      );
+      expect(stub.callCount).toBe(1);
+      expect(stub.firstCall.args).toMatchSnapshot();
+    });
+  });
+
+  describe('all CLI options, no config file options', function () {
+    it('is called correctly', async function () {
+      const stub = sinon.stub().resolves();
+      await run(
+        [
+          'node', // Path to node.
+          'eslint-doc-generator.js', // Path to this binary.
+
+          ...Object.values(cliOptionsAll).flat(),
+        ],
+        stub
+      );
+      expect(stub.callCount).toBe(1);
+      expect(stub.firstCall.args).toMatchSnapshot();
+    });
+  });
+
+  describe('all config files options, no CLI options', function () {
+    beforeEach(function () {
+      mockFs({
+        'package.json': JSON.stringify({
+          name: 'eslint-plugin-test',
+          main: 'index.js',
+          type: 'module',
+          version: '1.0.0',
+        }),
+
+        '.eslint-doc-generatorrc.json': JSON.stringify(configFileOptionsAll),
+      });
+    });
+
+    afterEach(function () {
+      mockFs.restore();
+    });
+
+    it('is called correctly', async function () {
+      const stub = sinon.stub().resolves();
+      await run(
+        [
+          'node', // Path to node.
+          'eslint-doc-generator.js', // Path to this binary.
+        ],
+        stub
+      );
+      expect(stub.callCount).toBe(1);
+      expect(stub.firstCall.args).toMatchSnapshot();
+    });
+  });
+
+  describe('all CLI options and all config files options', function () {
+    beforeEach(function () {
+      mockFs({
+        'package.json': JSON.stringify({
+          name: 'eslint-plugin-test',
+          main: 'index.js',
+          type: 'module',
+          version: '1.0.0',
+        }),
+
+        '.eslint-doc-generatorrc.json': JSON.stringify(configFileOptionsAll),
+      });
+    });
+
+    afterEach(function () {
+      mockFs.restore();
+    });
+
+    it('merges correctly, with CLI options taking precedence', async function () {
+      const stub = sinon.stub().resolves();
+      await run(
+        [
+          'node', // Path to node.
+          'eslint-doc-generator.js', // Path to this binary.
+
+          ...Object.values(cliOptionsAll).flat(),
+        ],
+        stub
+      );
+      expect(stub.callCount).toBe(1);
+      expect(stub.firstCall.args).toMatchSnapshot();
+    });
+  });
+
+  describe('boolean option - false (explicit)', function () {
+    it('is called correctly', async function () {
+      const stub = sinon.stub().resolves();
+      await run(
+        [
+          'node', // Path to node.
+          'eslint-doc-generator.js', // Path to this binary.
+
+          '--ignore-deprecated-rules',
+          'false',
+        ],
+        stub
+      );
+      expect(stub.callCount).toBe(1);
+      expect(stub.firstCall.args).toMatchSnapshot();
+    });
+  });
+
+  describe('boolean option - true (explicit)', function () {
+    it('is called correctly', async function () {
+      const stub = sinon.stub().resolves();
+      await run(
+        [
+          'node', // Path to node.
+          'eslint-doc-generator.js', // Path to this binary.
+
+          '--ignore-deprecated-rules',
+          'true',
+        ],
+        stub
+      );
+      expect(stub.callCount).toBe(1);
+      expect(stub.firstCall.args).toMatchSnapshot();
+    });
+  });
+
+  describe('boolean option - true (implicit)', function () {
+    it('is called correctly', async function () {
+      const stub = sinon.stub().resolves();
+      await run(
+        [
+          'node', // Path to node.
+          'eslint-doc-generator.js', // Path to this binary.
+
+          '--ignore-deprecated-rules',
+        ],
+        stub
+      );
+      expect(stub.callCount).toBe(1);
+      expect(stub.firstCall.args).toMatchSnapshot();
+    });
+  });
+
+  describe('missing package.json `version` field', function () {
+    beforeEach(function () {
+      mockFs({
+        'package.json': JSON.stringify({
+          name: 'eslint-plugin-test',
+          main: 'index.js',
+          type: 'module',
+        }),
+      });
+    });
+
+    afterEach(function () {
+      mockFs.restore();
+    });
+
+    it('throws an error', async function () {
+      const stub = sinon.stub().resolves();
+      await expect(
+        run(
+          [
+            'node', // Path to node.
+            'eslint-doc-generator.js', // Path to this binary.
+          ],
+          stub
+        )
+      ).rejects.toThrow('Could not find package.json `version`.');
+    });
+  });
+
+  describe('invalid config file', function () {
+    beforeEach(function () {
+      mockFs({
+        'package.json': JSON.stringify({
+          name: 'eslint-plugin-test',
+          main: 'index.js',
+          type: 'module',
+          version: '1.0.0',
+        }),
+
+        '.eslint-doc-generatorrc.json': '{ "unknown": true }', // Doesn't match schema.
+      });
+    });
+
+    afterEach(function () {
+      mockFs.restore();
+    });
+
+    it('throws an error', async function () {
+      const stub = sinon.stub().resolves();
+      await expect(
+        run(
+          [
+            'node', // Path to node.
+            'eslint-doc-generator.js', // Path to this binary.
+          ],
+          stub
+        )
+      ).rejects.toThrow('config file must NOT have additional properties');
+    });
+  });
+});

--- a/test/lib/generator-test.ts
+++ b/test/lib/generator-test.ts
@@ -3196,6 +3196,50 @@ describe('generator', function () {
       });
     });
 
+    describe('with --config-emoji and duplicate config name', function () {
+      beforeEach(function () {
+        mockFs({
+          'package.json': JSON.stringify({
+            name: 'eslint-plugin-test',
+            main: 'index.js',
+            type: 'module',
+          }),
+
+          'index.js': `
+            export default {
+              rules: {
+                'no-foo': { meta: { docs: { description: 'Description for no-foo.'} }, create(context) {} },
+              },
+              configs: {
+                recommended: { rules: { 'test/no-foo': 'error' } },
+              }
+            };`,
+
+          'README.md': '## Rules\n',
+
+          'docs/rules/no-foo.md': '',
+
+          // Needed for some of the test infrastructure to work.
+          node_modules: mockFs.load(
+            resolve(__dirname, '..', '..', 'node_modules')
+          ),
+        });
+      });
+
+      afterEach(function () {
+        mockFs.restore();
+        jest.resetModules();
+      });
+
+      it('throws an error', async function () {
+        await expect(
+          generate('.', { configEmoji: ['recommended,🔥', 'recommended,😋'] })
+        ).rejects.toThrow(
+          'Duplicate config name in configEmoji options: recommended'
+        );
+      });
+    });
+
     describe('with one config that does not have emoji', function () {
       beforeEach(function () {
         mockFs({


### PR DESCRIPTION
Fixes #95.

TODO:

- [x] Add tests
- [x] Use a JSON schema (ajv) to validate config file  
- [x] Fix boolean options
- [x] Throw error when duplicate `--config-emoji`