### PR TITLE
Target `ES2020` for TypeScript output

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "declaration": true,
     "experimentalDecorators": true,
     "lib": [
-      "es2022"
+      "ES2020"
     ],
     "module": "ES2020",
     "moduleResolution": "node",
@@ -22,7 +22,7 @@
         "types/*"
       ]
     },
-    "target": "es2021",
+    "target": "es2020",
     "types": [
       "node",
       "@types/jest"


### PR DESCRIPTION
We support Node 14 which supports all ES2020 features but not all of ES2021/ES2022. Once we drop Node 14 support, we can raise this to ES2022.

https://kangax.github.io/compat-table/es2016plus/