### PR TITLE
Support absolute path for plugin root CLI argument

### DIFF
--- a/lib/package-json.ts
+++ b/lib/package-json.ts
@@ -1,4 +1,4 @@
-import { join, resolve, basename, dirname } from 'node:path';
+import { join, resolve, basename, dirname, isAbsolute } from 'node:path';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { importAbs } from './import.js';
 import { createRequire } from 'node:module';
@@ -8,7 +8,7 @@ import type { PackageJson } from 'type-fest';
 const require = createRequire(import.meta.url);
 
 export function getPluginRoot(path: string) {
-  return join(process.cwd(), path);
+  return isAbsolute(path) ? path : join(process.cwd(), path);
 }
 
 function loadPackageJson(path: string): PackageJson {

--- a/test/lib/generator-test.ts
+++ b/test/lib/generator-test.ts
@@ -4082,5 +4082,37 @@ describe('generator', function () {
         );
       });
     });
+
+    describe('passing absolute path for plugin root', function () {
+      beforeEach(function () {
+        mockFs({
+          '/eslint-plugin-test/package.json': JSON.stringify({
+            name: 'eslint-plugin-test',
+            exports: 'index.js',
+            type: 'module',
+          }),
+
+          '/eslint-plugin-test/index.js':
+            'export default { rules: {}, configs: {} };',
+
+          '/eslint-plugin-test/README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
+
+          // Needed for some of the test infrastructure to work.
+          node_modules: mockFs.load(
+            resolve(__dirname, '..', '..', 'node_modules')
+          ),
+        });
+      });
+
+      afterEach(function () {
+        mockFs.restore();
+        jest.resetModules();
+      });
+
+      it('finds the entry point', async function () {
+        await expect(generate('/eslint-plugin-test/')).resolves.toBeUndefined();
+      });
+    });
   });
 });


### PR DESCRIPTION
Previously, we only supported a relative path.

Previously supported:

```sh
eslint-doc-generator .
```

New support:

```sh
eslint-doc-generator /path/to/plugin
```

