### PR TITLE
Tweak rule doc examples

### DIFF
--- a/docs/examples/eslint-plugin-test/docs/rules/prefer-bar.md
+++ b/docs/examples/eslint-plugin-test/docs/rules/prefer-bar.md
@@ -17,7 +17,3 @@ Description of the rule would normally go here.
 ## Examples
 
 Examples would normally go here.
-
-## Options
-
-Config options would normally go here.

--- a/docs/examples/eslint-plugin-test/docs/rules/require-baz.md
+++ b/docs/examples/eslint-plugin-test/docs/rules/require-baz.md
@@ -17,7 +17,3 @@ Description of the rule would normally go here.
 ## Examples
 
 Examples would normally go here.
-
-## Options
-
-Config options would normally go here.


### PR DESCRIPTION
These two example rules don't have options so remove their options sections.