### PR TITLE
Add test code coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # eslint-doc-generator
 
-[![npm version][npm-image]][npm-url]
+[![npm version][npm-image]][npm-url] ![test coverage](https://img.shields.io/badge/test%20coverage-100%25-green)
 
 Automatic documentation generator for [ESLint](https://eslint.org/) plugins and rules.
 


### PR DESCRIPTION
We enforce 100% test coverage:

https://github.com/bmish/eslint-doc-generator/blob/dc9ba5f4b1cc0a9143d5f87bf60cc9bd60edc4eb/jest.config.cjs#L17

For now, I'm just adding a static badge to advertise this.

There are ways to add a dynamic badge but they are a bit inconvenient: https://github.com/bmish/eslint-doc-generator/pull/242 

Fixes #31.