### PR TITLE
Use TypeScript `satisfies` operator for option defaults

### DIFF
--- a/lib/options.ts
+++ b/lib/options.ts
@@ -56,7 +56,6 @@ export enum OPTION_TYPE {
 const DEFAULT_RULE_DOC_TITLE_FORMAT: RuleDocTitleFormat =
   'desc-parens-prefix-name'; // Using this variable ensures this default has the correct type (not just a plain string).
 
-// TODO: use TypeScript 4.9 satisfies keyword ([key in OPTION_TYPE]...) to ensure all options are included without losing type information.
 export const OPTION_DEFAULTS = {
   [OPTION_TYPE.CHECK]: false,
   [OPTION_TYPE.CONFIG_EMOJI]: [],
@@ -83,7 +82,8 @@ export const OPTION_DEFAULTS = {
     .join(','),
   [OPTION_TYPE.SPLIT_BY]: undefined,
   [OPTION_TYPE.URL_CONFIGS]: undefined,
-};
+  // eslint-disable-next-line prettier/prettier -- TODO: waiting on prettier support for TypeScript 4.9: https://github.com/prettier/prettier/issues/13516.
+} satisfies Record<OPTION_TYPE, unknown>; // Satisfies is used to ensure all options are included, but without losing type information.
 
 export type GenerateOptions = {
   check?: boolean;
@@ -99,6 +99,6 @@ export type GenerateOptions = {
   ruleDocSectionOptions?: boolean;
   ruleDocTitleFormat?: RuleDocTitleFormat;
   ruleListColumns?: string;
-  urlConfigs?: string;
   splitBy?: string;
+  urlConfigs?: string;
 };


### PR DESCRIPTION
<details>
<summary>Details</summary>



</details>

Throughout the codebase, we have objects which we use to define mappings. We typically want to ensure every value in an enum is mapped to some value and not forgotten (as could easily happen when implementing new notices, types, options, etc), so we use this syntax to ensure that any missing key in the object will cause a type error:

```js
const columns: {
    [key in COLUMN_TYPE]: string;
  } = {
    [COLUMN_TYPE.CONFIGS_ERROR]: '...',
    ...
};
```

This works fine when every key maps to the same type of value. 

But for our option defaults object, there are different types that each option can map to, including boolean, string, or array. When we want to access a particular option default, using the above syntax results in TypeScript thinking the option default could be any of boolean, string, or array, even though it actually has a known type.

The new TypeScript [satisfies](https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/#the-satisfies-operator) operator allows us to ensure the object contains all the right keys but without losing the known types for each particular entry in the object.

Waiting on prettier support for TypeScript 4.9: https://github.com/prettier/prettier/issues/13516.

To use this new syntax, you have to select "Select TypeScript Version" in VSCode and choose the workspace version, since VSCode doesn't ship with TypeScript 4.9 yet.