### PR TITLE
Add test that external rules are ignored

### DIFF
--- a/test/lib/generate/__snapshots__/configs-test.ts.snap
+++ b/test/lib/generate/__snapshots__/configs-test.ts.snap
@@ -264,3 +264,18 @@ exports[`generate (configs) with config that does not have any rules uses recomm
 <!-- end auto-generated rule header -->
 "
 `;
+
+exports[`generate (configs) with external rules in config ignores external rules 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+💼 Configurations enabled in.\\
+✅ Set in the \`recommended\` configuration.
+
+| Name                           | Description             | 💼 |
+| :----------------------------- | :---------------------- | :- |
+| [no-foo](docs/rules/no-foo.md) | Description for no-foo. | ✅  |
+
+<!-- end auto-generated rules list -->
+"
+`;


### PR DESCRIPTION
This tool is entirely focused on documenting rules contained inside an ESLint plugin. There's no representation of external rules that may be enabled in one of a plugin's configs.

This just adds a test that we ignore such rules.

Note: this behavior might change if we implement: https://github.com/bmish/eslint-doc-generator/issues/250

