### PR TITLE
Add test for variation of scoped plugin name

### DIFF
--- a/lib/package-json.ts
+++ b/lib/package-json.ts
@@ -85,7 +85,7 @@ export function getPluginPrefix(path: string): string {
   }
   return pluginPackageJson.name.endsWith('/eslint-plugin')
     ? pluginPackageJson.name.split('/')[0] // Scoped plugin name like @my-scope/eslint-plugin.
-    : pluginPackageJson.name.replace('eslint-plugin-', ''); // Unscoped name like eslint-plugin-foo.
+    : pluginPackageJson.name.replace('eslint-plugin-', ''); // Unscoped name like eslint-plugin-foo or scoped name like @my-scope/eslint-plugin-foo.
 }
 
 /**

--- a/test/lib/generate/__snapshots__/package-json-test.ts.snap
+++ b/test/lib/generate/__snapshots__/package-json-test.ts.snap
@@ -32,6 +32,28 @@ exports[`generate (package.json) Scoped plugin name determines the correct plugi
 "
 `;
 
+exports[`generate (package.json) Scoped plugin with custom plugin name determines the correct plugin prefix 1`] = `
+"<!-- begin auto-generated rules list -->
+
+💼 Configurations enabled in.\\
+✅ Set in the \`recommended\` configuration.
+
+| Name                           | Description   | 💼 |
+| :----------------------------- | :------------ | :- |
+| [no-foo](docs/rules/no-foo.md) | disallow foo. | ✅  |
+
+<!-- end auto-generated rules list -->"
+`;
+
+exports[`generate (package.json) Scoped plugin with custom plugin name determines the correct plugin prefix 2`] = `
+"# Disallow foo (\`@my-scope/foo/no-foo\`)
+
+💼 This rule is enabled in the ✅ \`recommended\` config.
+
+<!-- end auto-generated rule header -->
+"
+`;
+
 exports[`generate (package.json) plugin entry point in JSON format generates the documentation 1`] = `
 "<!-- begin auto-generated rules list -->
 


### PR DESCRIPTION
Turns out we support this correctly already. Just adding a test for it.

Fixes #255.