### PR TITLE
Add prefix to link name for readme config badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,14 +103,14 @@ While config emojis are the recommended representations of configs that a rule b
 Here's a badge for a custom `fun` config that displays in blue:
 
 ```md
-[fun]: https://img.shields.io/badge/-fun-blue.svg
+[badge-fun]: https://img.shields.io/badge/-fun-blue.svg
 ```
 
 And how it looks:
 
-![fun][]
+![badge-fun][]
 
-[fun]: https://img.shields.io/badge/-fun-blue.svg
+[badge-fun]: https://img.shields.io/badge/-fun-blue.svg
 
 ## Configuration options
 

--- a/lib/configs.ts
+++ b/lib/configs.ts
@@ -94,7 +94,7 @@ export function findConfigEmoji(
   )?.emoji;
   if (!emoji) {
     if (options?.fallback === 'badge') {
-      emoji = `![${configName}][]`;
+      emoji = `![badge-${configName}][]`;
     } else {
       // No fallback.
       return undefined; // eslint-disable-line unicorn/no-useless-undefined

--- a/test/lib/generate/__snapshots__/config-emoji-test.ts.snap
+++ b/test/lib/generate/__snapshots__/config-emoji-test.ts.snap
@@ -8,11 +8,11 @@ exports[`generate (--config-emoji) basic shows the correct emojis 1`] = `
 🔥 Set in the \`recommended\` configuration.\\
 🎨 Set in the \`stylistic\` configuration.
 
-| Name                           | Description             | 💼                         |
-| :----------------------------- | :---------------------- | :------------------------- |
-| [no-bar](docs/rules/no-bar.md) | Description for no-bar. | 🔥 🎨                      |
-| [no-baz](docs/rules/no-baz.md) | Description for no-boz. | ![configWithoutEmoji][] 🎨 |
-| [no-foo](docs/rules/no-foo.md) | Description for no-foo. | 🔥                         |
+| Name                           | Description             | 💼                               |
+| :----------------------------- | :---------------------- | :------------------------------- |
+| [no-bar](docs/rules/no-bar.md) | Description for no-bar. | 🔥 🎨                            |
+| [no-baz](docs/rules/no-baz.md) | Description for no-boz. | ![badge-configWithoutEmoji][] 🎨 |
+| [no-foo](docs/rules/no-foo.md) | Description for no-foo. | 🔥                               |
 
 <!-- end auto-generated rules list -->
 "
@@ -51,9 +51,9 @@ exports[`generate (--config-emoji) removing default emoji for a config reverts t
 
 💼 Configurations enabled in.
 
-| Name                           | Description             | 💼               |
-| :----------------------------- | :---------------------- | :--------------- |
-| [no-foo](docs/rules/no-foo.md) | Description for no-foo. | ![recommended][] |
+| Name                           | Description             | 💼                     |
+| :----------------------------- | :---------------------- | :--------------------- |
+| [no-foo](docs/rules/no-foo.md) | Description for no-foo. | ![badge-recommended][] |
 
 <!-- end auto-generated rules list -->
 "
@@ -74,9 +74,9 @@ exports[`generate (--config-emoji) with one config that does not have emoji show
 
 💼 Configurations enabled in.
 
-| Name                           | Description             | 💼                      |
-| :----------------------------- | :---------------------- | :---------------------- |
-| [no-foo](docs/rules/no-foo.md) | Description for no-foo. | ![configWithoutEmoji][] |
+| Name                           | Description             | 💼                            |
+| :----------------------------- | :---------------------- | :---------------------------- |
+| [no-foo](docs/rules/no-foo.md) | Description for no-foo. | ![badge-configWithoutEmoji][] |
 
 <!-- end auto-generated rules list -->
 "

--- a/test/lib/generate/__snapshots__/configs-test.ts.snap
+++ b/test/lib/generate/__snapshots__/configs-test.ts.snap
@@ -79,15 +79,15 @@ exports[`generate (configs) rules that are disabled or set to warn generates the
 🚫 Configurations disabled in.\\
 ✅ Set in the \`recommended\` configuration.
 
-| Name                           | Description            | 💼 | ⚠️           | 🚫           |
-| :----------------------------- | :--------------------- | :- | :----------- | :----------- |
-| [no-bar](docs/rules/no-bar.md) | Description of no-bar. |    |              | ![other][] ✅ |
-| [no-baz](docs/rules/no-baz.md) | Description of no-baz. | ✅  |              | ![other][]   |
-| [no-bez](docs/rules/no-bez.md) | Description of no-bez. |    | ![other][]   |              |
-| [no-biz](docs/rules/no-biz.md) | Description of no-biz. |    |              | ![other][]   |
-| [no-boz](docs/rules/no-boz.md) | Description of no-boz. |    | ✅            |              |
-| [no-buz](docs/rules/no-buz.md) | Description of no-buz. |    | ![other][] ✅ |              |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. |    |              | ✅            |
+| Name                           | Description            | 💼 | ⚠️                 | 🚫                 |
+| :----------------------------- | :--------------------- | :- | :----------------- | :----------------- |
+| [no-bar](docs/rules/no-bar.md) | Description of no-bar. |    |                    | ![badge-other][] ✅ |
+| [no-baz](docs/rules/no-baz.md) | Description of no-baz. | ✅  |                    | ![badge-other][]   |
+| [no-bez](docs/rules/no-bez.md) | Description of no-bez. |    | ![badge-other][]   |                    |
+| [no-biz](docs/rules/no-biz.md) | Description of no-biz. |    |                    | ![badge-other][]   |
+| [no-boz](docs/rules/no-boz.md) | Description of no-boz. |    | ✅                  |                    |
+| [no-buz](docs/rules/no-buz.md) | Description of no-buz. |    | ![badge-other][] ✅ |                    |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. |    |                    | ✅                  |
 
 <!-- end auto-generated rules list -->
 "

--- a/test/lib/generate/__snapshots__/sorting-test.ts.snap
+++ b/test/lib/generate/__snapshots__/sorting-test.ts.snap
@@ -6,11 +6,11 @@ exports[`generate (sorting) sorting rules and configs case-insensitive sorts cor
 
 💼 Configurations enabled in.
 
-| Name                 | 💼                   |
-| :------------------- | :------------------- |
-| [a](docs/rules/a.md) | ![a][] ![B][] ![c][] |
-| [B](docs/rules/B.md) |                      |
-| [c](docs/rules/c.md) |                      |
+| Name                 | 💼                                     |
+| :------------------- | :------------------------------------- |
+| [a](docs/rules/a.md) | ![badge-a][] ![badge-B][] ![badge-c][] |
+| [B](docs/rules/B.md) |                                        |
+| [c](docs/rules/c.md) |                                        |
 
 <!-- end auto-generated rules list -->
 "

--- a/test/lib/generate/__snapshots__/url-configs-test.ts.snap
+++ b/test/lib/generate/__snapshots__/url-configs-test.ts.snap
@@ -7,10 +7,10 @@ exports[`generate (--url-configs) basic includes the config link 1`] = `
 💼 [Configurations](http://example.com/configs) enabled in.\\
 ✅ Set in the \`recommended\` [configuration](http://example.com/configs).
 
-| Name                           | Description             | 💼                |
-| :----------------------------- | :---------------------- | :---------------- |
-| [no-bar](docs/rules/no-bar.md) | Description for no-bar. | ![customConfig][] |
-| [no-foo](docs/rules/no-foo.md) | Description for no-foo. | ✅                 |
+| Name                           | Description             | 💼                      |
+| :----------------------------- | :---------------------- | :---------------------- |
+| [no-bar](docs/rules/no-bar.md) | Description for no-bar. | ![badge-customConfig][] |
+| [no-foo](docs/rules/no-foo.md) | Description for no-foo. | ✅                       |
 
 <!-- end auto-generated rules list -->
 "


### PR DESCRIPTION
Fixes #258.

Anyone using badges to represent configs in the readme (instead of emojis) will need to migrate from (with `recommended` config as an example):

```md
[recommended]: https://img.shields.io/badge/-recommended-blue.svg
```
to:

```
[badge-recommended]: https://img.shields.io/badge/-recommended-blue.svg
```