### PR TITLE
Export type for config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,10 @@ There are a few ways to create a config file:
 
 Config files support all the [CLI options](#configuration-options) but in camelCase. CLI options take precedence over config file options.
 
-Example:
+Example `.eslint-doc-generatorrc.js`:
 
 ```js
-// .eslint-doc-generatorrc.js
+/** @type {import('eslint-doc-generator').GenerateOptions} */
 module.exports = {
   ignoreConfig: ['all'],
 };

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,0 +1,4 @@
+// Exported as part of this package's Node API.
+// Type exports controlled by `types` in package.json, non-type exports controlled by `exports` in package.json.
+
+export type { GenerateOptions } from './types.js';

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "license": "ISC",
   "author": "Bryan Mishkin",
   "type": "module",
+  "types": "./dist/lib/index.js",
   "bin": {
     "eslint-doc-generator": "./dist/bin/eslint-doc-generator.js"
   },


### PR DESCRIPTION
I was also considering renaming this type to `Options`, `ConfigFile`, `ConfigOptions`, `OptionsType`, etc. I haven't settled on a clear winner so I'll leave as-is. We can rename in a future breaking change if we decide on a better name.

- [x] Ensure this actually works
- [x] Document usage in readme

Fixes #261.