### PR TITLE
Allow content above rule doc title

### DIFF
--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -162,9 +162,8 @@ export async function generate(path: string, options?: GenerateOptions) {
       (details) => !ignoreDeprecatedRules || !details.deprecated
     );
 
-  let initializedRuleDoc = false;
-
   // Update rule doc for each rule.
+  let initializedRuleDoc = false;
   for (const { name, description, schema } of details) {
     const pathToDoc = join(path, pathRuleDoc).replace(/{name}/g, name);
 
@@ -243,6 +242,12 @@ export async function generate(path: string, options?: GenerateOptions) {
     }
   }
 
+  if (initRuleDocs && !initializedRuleDoc) {
+    throw new Error(
+      '--init-rule-docs was enabled, but no rule doc file needed to be created.'
+    );
+  }
+
   // Find the README.
   const pathToReadme = getPathWithExactFileNameCasing(join(path, pathRuleList));
   if (!pathToReadme || !existsSync(pathToReadme)) {
@@ -281,11 +286,5 @@ export async function generate(path: string, options?: GenerateOptions) {
     }
   } else {
     writeFileSync(pathToReadme, readmeContentsNew, 'utf8');
-  }
-
-  if (initRuleDocs && !initializedRuleDoc) {
-    throw new Error(
-      '--init-rule-docs was enabled, but no rule doc file needed to be created.'
-    );
   }
 }

--- a/test/lib/generate/__snapshots__/comment-markers-test.ts.snap
+++ b/test/lib/generate/__snapshots__/comment-markers-test.ts.snap
@@ -46,6 +46,24 @@ exports[`generate (comment markers) no existing comment markers - minimal doc co
 "
 `;
 
+exports[`generate (comment markers) no existing comment markers - rule doc with YAML-formatted metadata (front matter) above title updates the documentation 1`] = `
+"---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "plugin/rule-name"
+description: "disallow foo"
+since: "v0.12.0"
+---
+# Description (\`test/no-foo\`)
+
+💼 This rule is enabled in the ✅ \`recommended\` config.
+
+<!-- end auto-generated rule header -->
+Pre-existing notice about the rule being recommended.
+## Rule details
+Details."
+`;
+
 exports[`generate (comment markers) no existing comment markers - with no blank lines in existing content generates the documentation 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->
@@ -92,6 +110,39 @@ exports[`generate (comment markers) no existing comment markers - with one blank
 <!-- end auto-generated rule header -->
 
 Existing rule doc content."
+`;
+
+exports[`generate (comment markers) rule doc with YAML-formatted metadata (front matter) above title and comment marker updates the documentation 1`] = `
+"---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "plugin/rule-name"
+description: "disallow foo"
+since: "v0.12.0"
+---
+# Description (\`test/no-foo\`)
+
+💼 This rule is enabled in the ✅ \`recommended\` config.
+
+<!-- end auto-generated rule header -->
+## Rule details
+Details."
+`;
+
+exports[`generate (comment markers) rule doc with YAML-formatted metadata (front matter) and nothing else updates the documentation 1`] = `
+"---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "plugin/rule-name"
+description: "disallow foo"
+since: "v0.12.0"
+---
+# Description (\`test/no-foo\`)
+
+💼 This rule is enabled in the ✅ \`recommended\` config.
+
+<!-- end auto-generated rule header -->
+"
 `;
 
 exports[`generate (comment markers) rule doc without header marker but pre-existing header updates the documentation 1`] = `

--- a/test/lib/generate/comment-markers-test.ts
+++ b/test/lib/generate/comment-markers-test.ts
@@ -260,6 +260,55 @@ describe('generate (comment markers)', function () {
     });
   });
 
+  describe('no existing comment markers - rule doc with YAML-formatted metadata (front matter) above title', function () {
+    beforeEach(function () {
+      mockFs({
+        'package.json': JSON.stringify({
+          name: 'eslint-plugin-test',
+          exports: 'index.js',
+          type: 'module',
+        }),
+
+        'index.js': `
+          export default {
+            rules: { 'no-foo': { meta: { docs: { description: 'Description.' }, }, create(context) {} }, },
+            configs: { recommended: { rules: { 'test/no-foo': 'error', } } }
+          };`,
+
+        'README.md': '## Rules\n',
+
+        // YAML-formatted metadata (front matter) content above title.
+        'docs/rules/no-foo.md': outdent`
+          ---
+          pageClass: "rule-details"
+          sidebarDepth: 0
+          title: "plugin/rule-name"
+          description: "disallow foo"
+          since: "v0.12.0"
+          ---
+          # Some pre-existing title.
+          Pre-existing notice about the rule being recommended.
+          ## Rule details
+          Details.
+        `,
+
+        // Needed for some of the test infrastructure to work.
+        node_modules: mockFs.load(PATH_NODE_MODULES),
+      });
+    });
+
+    afterEach(function () {
+      mockFs.restore();
+      jest.resetModules();
+    });
+
+    it('updates the documentation', async function () {
+      await generate('.');
+
+      expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
+    });
+  });
+
   describe('README missing rule list markers but with rules section', function () {
     beforeEach(function () {
       mockFs({
@@ -357,19 +406,8 @@ describe('generate (comment markers)', function () {
 
         'index.js': `
           export default {
-            rules: {
-              'no-foo': {
-                meta: { docs: { description: 'Description.' }, },
-                create(context) {}
-              },
-            },
-            configs: {
-              recommended: {
-                rules: {
-                  'test/no-foo': 'error',
-                }
-              }
-            }
+            rules: { 'no-foo': { meta: { docs: { description: 'Description.' }, }, create(context) {} }, },
+            configs: { recommended: { rules: { 'test/no-foo': 'error', } } }
           };`,
 
         'README.md':
@@ -380,6 +418,101 @@ describe('generate (comment markers)', function () {
           Pre-existing notice about the rule being recommended.
           ## Rule details
           Details.
+        `,
+
+        // Needed for some of the test infrastructure to work.
+        node_modules: mockFs.load(PATH_NODE_MODULES),
+      });
+    });
+
+    afterEach(function () {
+      mockFs.restore();
+      jest.resetModules();
+    });
+
+    it('updates the documentation', async function () {
+      await generate('.');
+
+      expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
+    });
+  });
+
+  describe('rule doc with YAML-formatted metadata (front matter) above title and comment marker', function () {
+    beforeEach(function () {
+      mockFs({
+        'package.json': JSON.stringify({
+          name: 'eslint-plugin-test',
+          exports: 'index.js',
+          type: 'module',
+        }),
+
+        'index.js': `
+          export default {
+            rules: { 'no-foo': { meta: { docs: { description: 'Description.' }, }, create(context) {} }, },
+            configs: { recommended: { rules: { 'test/no-foo': 'error', } } }
+          };`,
+
+        'README.md': '## Rules\n',
+
+        // YAML-formatted metadata (front matter) above title.
+        'docs/rules/no-foo.md': outdent`
+          ---
+          pageClass: "rule-details"
+          sidebarDepth: 0
+          title: "plugin/rule-name"
+          description: "disallow foo"
+          since: "v0.12.0"
+          ---
+          # Outdated title.
+          Outdated content.
+          <!-- end auto-generated rule header -->
+          ## Rule details
+          Details.
+        `,
+
+        // Needed for some of the test infrastructure to work.
+        node_modules: mockFs.load(PATH_NODE_MODULES),
+      });
+    });
+
+    afterEach(function () {
+      mockFs.restore();
+      jest.resetModules();
+    });
+
+    it('updates the documentation', async function () {
+      await generate('.');
+
+      expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
+    });
+  });
+
+  describe('rule doc with YAML-formatted metadata (front matter) and nothing else', function () {
+    beforeEach(function () {
+      mockFs({
+        'package.json': JSON.stringify({
+          name: 'eslint-plugin-test',
+          exports: 'index.js',
+          type: 'module',
+        }),
+
+        'index.js': `
+          export default {
+            rules: { 'no-foo': { meta: { docs: { description: 'Description.' }, }, create(context) {} }, },
+            configs: { recommended: { rules: { 'test/no-foo': 'error', } } }
+          };`,
+
+        'README.md': '## Rules\n',
+
+        // YAML-formatted metadata (front matter) only.
+        'docs/rules/no-foo.md': outdent`
+          ---
+          pageClass: "rule-details"
+          sidebarDepth: 0
+          title: "plugin/rule-name"
+          description: "disallow foo"
+          since: "v0.12.0"
+          ---
         `,
 
         // Needed for some of the test infrastructure to work.

--- a/test/lib/generate/configs-test.ts
+++ b/test/lib/generate/configs-test.ts
@@ -407,12 +407,7 @@ describe('generate (configs)', function () {
 
         'index.js': `
           export default {
-            rules: {
-              'no-foo': {
-                meta: { docs: { description: 'Description.' }, },
-                create(context) {}
-              },
-            },
+            rules: { 'no-foo': { meta: { docs: { description: 'Description.' }, }, create(context) {} }, },
             configs: {
               recommended: {
                 rules: {


### PR DESCRIPTION
Allow content (including YAML-formatted metadata / front matter) above the auto-generated rule doc header/title.

Fixes #253.