### PR TITLE
Enable unicode regexp flag

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -32,6 +32,7 @@ module.exports = {
     'unicorn/no-array-reduce': 'off',
     'unicorn/no-nested-ternary': 'off',
     'unicorn/prevent-abbreviations': 'off',
+    'require-unicode-regexp': 'error',
   },
   overrides: [
     {

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -41,8 +41,8 @@ function expectContent(
   // in case escaping is needed where the content is referenced.
   const hasContent =
     contents.includes(content) ||
-    contents.includes(content.replace(/"/g, '\\"')) ||
-    contents.includes(content.replace(/'/g, "\\'"));
+    contents.includes(content.replace(/"/gu, '\\"')) ||
+    contents.includes(content.replace(/'/gu, "\\'"));
   if (hasContent !== expected) {
     console.error(
       `\`${ruleName}\` rule doc should ${

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -42,7 +42,7 @@ export function findSectionHeader(
   str: string
 ): string | undefined {
   // Get all the matching strings.
-  const regexp = new RegExp(`## .*${str}.*\n`, 'gi');
+  const regexp = new RegExp(`## .*${str}.*\n`, 'giu');
   const sectionPotentialMatches = [...markdown.matchAll(regexp)].map(
     (match) => match[0]
   );

--- a/lib/rule-doc-notices.ts
+++ b/lib/rule-doc-notices.ts
@@ -376,13 +376,13 @@ function getRuleNoticeLines(
 }
 
 function toSentenceCase(str: string) {
-  return str.replace(/^\w/, function (txt) {
+  return str.replace(/^\w/u, function (txt) {
     return txt.charAt(0).toUpperCase() + txt.slice(1).toLowerCase();
   });
 }
 
 function removeTrailingPeriod(str: string) {
-  return str.replace(/\.$/, '');
+  return str.replace(/\.$/u, '');
 }
 
 function makeRuleDocTitle(

--- a/lib/rule-link.ts
+++ b/lib/rule-link.ts
@@ -1,7 +1,7 @@
 import { join, sep } from 'node:path';
 
 export function replaceRulePlaceholder(pathOrUrl: string, ruleName: string) {
-  return pathOrUrl.replace(/{name}/g, ruleName);
+  return pathOrUrl.replace(/\{name\}/gu, ruleName);
 }
 
 /**

--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -31,7 +31,7 @@ import { countOccurrencesInString } from './string.js';
 
 // Example: theWeatherIsNice => The Weather Is Nice
 function camelCaseStringToTitle(str: string) {
-  const text = str.replace(/([A-Z])/g, ' $1');
+  const text = str.replace(/([A-Z])/gu, ' $1');
   return text.charAt(0).toUpperCase() + text.slice(1);
 }
 


### PR DESCRIPTION
I was looking over the codebase to see how easy it might be to implement a feature, and noticed you're not using the `u` flag and had some regexps that it helps with (`{name}`), and figured it'd make a good first contribution :)

(I won't be offended if you don't want to land this either)