### PR TITLE
Ensure deprecated rule replacement link respects `--path-rule-doc`

### DIFF
--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -200,6 +200,8 @@ export async function generate(path: string, options?: GenerateOptions) {
       plugin,
       configsToRules,
       pluginPrefix,
+      path,
+      pathRuleDoc,
       configEmojis,
       ignoreConfig,
       ruleDocNotices,

--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -14,10 +14,9 @@ import { getColumns, COLUMN_HEADER } from './rule-list-columns.js';
 import { findSectionHeader, findFinalHeaderLevel } from './markdown.js';
 import { getPluginRoot } from './package-json.js';
 import { generateLegend } from './rule-list-legend.js';
-import { relative, join, sep } from 'node:path';
+import { relative } from 'node:path';
 import { COLUMN_TYPE, SEVERITY_TYPE } from './types.js';
 import { markdownTable } from 'markdown-table';
-import camelCase from 'camelcase';
 import type {
   Plugin,
   RuleDetails,
@@ -26,18 +25,8 @@ import type {
 } from './types.js';
 import { EMOJIS_TYPE, RULE_TYPE } from './rule-type.js';
 import { hasOptions } from './rule-options.js';
-import { replaceRulePlaceholder, goUpLevel, pathToUrl } from './rule-link.js';
-import { countOccurrencesInString } from './string.js';
-
-// Example: theWeatherIsNice => The Weather Is Nice
-function camelCaseStringToTitle(str: string) {
-  const text = str.replace(/([A-Z])/gu, ' $1');
-  return text.charAt(0).toUpperCase() + text.slice(1);
-}
-
-function isCamelCase(str: string) {
-  return camelCase(str) === str;
-}
+import { getLinkToRule } from './rule-link.js';
+import { camelCaseStringToTitle, isCamelCase } from './string.js';
 
 function getPropertyFromRule(
   plugin: Plugin,
@@ -140,22 +129,15 @@ function buildRuleRow(
       ? EMOJI_HAS_SUGGESTIONS
       : '',
     [COLUMN_TYPE.NAME]() {
-      // Determine the relative path to the plugin root from the current rule list file so that the rule link can account for this.
-      const nestingDepthOfCurrentRuleList = countOccurrencesInString(
-        relative(pathPlugin, pathRuleList),
-        sep
-      );
-      const relativePathPluginRoot = goUpLevel(nestingDepthOfCurrentRuleList);
-      return `[${rule.name}](${
+      return getLinkToRule(
+        rule.name,
+        pluginPrefix,
+        pathPlugin,
+        pathRuleDoc,
+        pathRuleList,
+        false,
         urlRuleDoc
-          ? replaceRulePlaceholder(urlRuleDoc, rule.name)
-          : pathToUrl(
-              join(
-                relativePathPluginRoot,
-                replaceRulePlaceholder(pathRuleDoc, rule.name)
-              )
-            )
-      })`;
+      );
     },
     [COLUMN_TYPE.OPTIONS]: hasOptions(rule.schema) ? EMOJI_OPTIONS : '',
     [COLUMN_TYPE.REQUIRES_TYPE_CHECKING]: rule.requiresTypeChecking

--- a/lib/string.ts
+++ b/lib/string.ts
@@ -1,3 +1,27 @@
+import camelCase from 'camelcase';
+
 export function countOccurrencesInString(str: string, substring: string) {
   return str.split(substring).length - 1;
+}
+
+export function toSentenceCase(str: string) {
+  return str.replace(/^\w/u, function (txt) {
+    return txt.charAt(0).toUpperCase() + txt.slice(1).toLowerCase();
+  });
+}
+
+export function removeTrailingPeriod(str: string) {
+  return str.replace(/\.$/u, '');
+}
+
+/**
+ * Example: theWeatherIsNice => The Weather Is Nice
+ */
+export function camelCaseStringToTitle(str: string) {
+  const text = str.replace(/([A-Z])/gu, ' $1');
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+export function isCamelCase(str: string) {
+  return camelCase(str) === str;
 }

--- a/test/lib/generate/__snapshots__/rule-deprecation-test.ts.snap
+++ b/test/lib/generate/__snapshots__/rule-deprecation-test.ts.snap
@@ -18,7 +18,7 @@ exports[`generate (deprecated rules) several deprecated rules updates the docume
 exports[`generate (deprecated rules) several deprecated rules updates the documentation 2`] = `
 "# Description (\`test/no-foo\`)
 
-❌ This rule is deprecated. It was replaced by [\`no-bar\`](no-bar.md).
+❌ This rule is deprecated. It was replaced by [\`no-bar\`](../../docs/rules/no-bar.md).
 
 <!-- end auto-generated rule header -->
 "
@@ -65,7 +65,7 @@ exports[`generate (deprecated rules) using prefix ahead of replacement rule name
 exports[`generate (deprecated rules) using prefix ahead of replacement rule name uses correct replacement rule link 2`] = `
 "# Description (\`test/no-foo\`)
 
-❌ This rule is deprecated. It was replaced by [\`no-bar\`](no-bar.md).
+❌ This rule is deprecated. It was replaced by [\`no-bar\`](../../docs/rules/no-bar.md).
 
 <!-- end auto-generated rule header -->
 "
@@ -73,6 +73,37 @@ exports[`generate (deprecated rules) using prefix ahead of replacement rule name
 
 exports[`generate (deprecated rules) using prefix ahead of replacement rule name uses correct replacement rule link 3`] = `
 "# Description (\`test/no-bar\`)
+
+<!-- end auto-generated rule header -->
+"
+`;
+
+exports[`generate (deprecated rules) with --path-rule-doc has the correct links, especially replacement rule link 1`] = `
+"<!-- begin auto-generated rules list -->
+
+❌ Deprecated.
+
+| Name                                              | Description  | ❌  |
+| :------------------------------------------------ | :----------- | :- |
+| [category/no-bar](docs/category/no-bar/README.md) | Description. | ❌  |
+| [category/no-foo](docs/category/no-foo/README.md) | Description. | ❌  |
+
+<!-- end auto-generated rules list -->"
+`;
+
+exports[`generate (deprecated rules) with --path-rule-doc has the correct links, especially replacement rule link 2`] = `
+"# Description (\`test/category/no-foo\`)
+
+❌ This rule is deprecated. It was replaced by [\`category/no-bar\`](../../../docs/category/no-bar/README.md).
+
+<!-- end auto-generated rule header -->
+"
+`;
+
+exports[`generate (deprecated rules) with --path-rule-doc has the correct links, especially replacement rule link 3`] = `
+"# Description (\`test/category/no-bar\`)
+
+❌ This rule is deprecated. It was replaced by [\`category/no-foo\`](../../../docs/category/no-foo/README.md).
 
 <!-- end auto-generated rule header -->
 "
@@ -94,7 +125,7 @@ exports[`generate (deprecated rules) with nested rule names has the correct link
 exports[`generate (deprecated rules) with nested rule names has the correct links, especially replacement rule link 2`] = `
 "# Description (\`test/category/no-foo\`)
 
-❌ This rule is deprecated. It was replaced by [\`category/no-bar\`](../category/no-bar.md).
+❌ This rule is deprecated. It was replaced by [\`category/no-bar\`](../../../docs/rules/category/no-bar.md).
 
 <!-- end auto-generated rule header -->
 "
@@ -103,7 +134,7 @@ exports[`generate (deprecated rules) with nested rule names has the correct link
 exports[`generate (deprecated rules) with nested rule names has the correct links, especially replacement rule link 3`] = `
 "# Description (\`test/category/no-bar\`)
 
-❌ This rule is deprecated. It was replaced by [\`category/no-foo\`](../category/no-foo.md).
+❌ This rule is deprecated. It was replaced by [\`category/no-foo\`](../../../docs/rules/category/no-foo.md).
 
 <!-- end auto-generated rule header -->
 "


### PR DESCRIPTION
Ensure the link to the deprecated rule replacement rule link respects `--path-rule-doc`.

It's tricky to create the right relative link to a rule as it depends on the current URL. Extract this logic into a general helper function for creating a link to a rule.
