### PR TITLE
ci: check TypeScript with CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
+        language: [ 'javascript', 'typescript' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 


### PR DESCRIPTION
So apparently `typescript` is different from `javascript` in CodeQL config, and [for best coverage you should include both](https://github.com/octokit/webhooks.js/pull/694#discussion_r908960821) (personally I think the docs really don't give that impression, but this came from GitHub staff and it doesn't hurt so 🤷)