### PR TITLE
ci: harden workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   build:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
 
     - name: Use Node.js version ${{ matrix.node-version }}
       uses: actions/setup-node@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
These are arguably minor in the schema of things, but still good to have for public projects:
  * by default `GITHUB_TOKEN` is allowed to do pretty much anything, including "writing", so I've added a `permissions` block at the top-level of the workflow that restricts the token to just being able to read the repo contents since that is all it needs
  * by default `actions/checkout` leaves the git credentials it uses to checkout the repo in place, which can be used by subsequent steps
