### PR TITLE
fix: remove extra closing quote from error message

### DIFF
--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -246,7 +246,7 @@ function generateRulesListMarkdownWithSplitBy(
   ]);
 
   if (values.size === 1 && DISABLED_VALUES.has([...values.values()][0])) {
-    throw new Error(`No rules found with --split-by property "${splitBy}"."`);
+    throw new Error(`No rules found with --split-by property "${splitBy}".`);
   }
 
   const parts: string[] = [];


### PR DESCRIPTION
I also removed the dot because it felt like an odd duck to me given the error continues down, i.e.

```
Error: No rules found with --split-by property "meta.docs.requiresTypeChecking".
    at generateRulesListMarkdownWithSplitBy (file:///home/runner/work/eslint-plugin-jest-extended/eslint-plugin-jest-extended/node_modules/eslint-doc-generator/dist/lib/rule-list.js:[10](https://github.com/jest-community/eslint-plugin-jest-extended/actions/runs/3555029745/jobs/5971494794#step:5:11)9:15)
    at updateRulesList (file:///home/runner/work/eslint-plugin-jest-extended/eslint-plugin-jest-extended/node_modules/eslint-doc-generator/dist/lib/rule-list.js:170:[11](https://github.com/jest-community/eslint-plugin-jest-extended/actions/runs/3555029745/jobs/5971494794#step:5:12))
    at generate (file:///home/runner/work/eslint-plugin-jest-extended/eslint-plugin-jest-extended/node_modules/eslint-doc-generator/dist/lib/generator.js:167:33)
    at async Command.<anonymous> (file:///home/runner/work/eslint-plugin-jest-extended/eslint-plugin-jest-extended/node_modules/eslint-doc-generator/dist/lib/cli.js:109:9)
    at async Command.parseAsync (/home/runner/work/eslint-plugin-jest-extended/eslint-plugin-jest-extended/node_modules/commander/lib/command.js:916:5)
    at async run (file:///home/runner/work/eslint-plugin-jest-extended/eslint-plugin-jest-extended/node_modules/eslint-doc-generator/dist/lib/cli.js:78:5)
```