### PR TITLE
test: require full function coverage

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -13,11 +13,18 @@ const jestConfig = {
     '^(\\.{1,2}/.*)\\.js$': '$1',
     '#(.*)': '<rootDir>/node_modules/$1',
   },
-  coveragePathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/test/'],
+  coveragePathIgnorePatterns: [
+    '<rootDir>/node_modules/',
+    '<rootDir>/test/',
+    // these files are created by the test suite in the in-memory fs,
+    // which test has access to and so counts in coverage by default
+    '<rootDir>/index.js',
+    '<rootDir>/index-foo.js',
+  ],
   coverageThreshold: {
     global: {
       branches: 100,
-      functions: 80, // TODO: Should be 100% but unclear what function is missing coverage.
+      functions: 100,
       lines: 100,
       statements: 100,
     },


### PR DESCRIPTION
This is also the reason why Jest always updates your snapshots locally instead of erroring about them being different, because Jest [can't actually load the original snapshots](https://github.com/tschaub/mock-fs#using-with-jest-snapshot-testing) but writes are apparently happening to the real disk - this isn't the end of the world because Jest automatically freezes snapshots when running in CI so you'll still get told if a snapshot needs updating and then that update will be in the diff for inspection.

(~also looks like linting is not applying to this file for some reason, but that's another PR~ ok so linting is, but its wanting different formatting than for all the other files? 🤔)

Fixes #26