### PR TITLE
Always display plugin prefix in deprecated rule replacement rule name

### DIFF
--- a/docs/examples/eslint-plugin-test/docs/rules/require-baz.md
+++ b/docs/examples/eslint-plugin-test/docs/rules/require-baz.md
@@ -1,6 +1,6 @@
 # Require using baz (`test/require-baz`)
 
-❌ This rule is deprecated. It was replaced by [`prefer-bar`](prefer-bar.md).
+❌ This rule is deprecated. It was replaced by [`test/prefer-bar`](prefer-bar.md).
 
 🚫 This rule is _disabled_ in the ⌨️ `typescript` config.
 

--- a/lib/rule-doc-notices.ts
+++ b/lib/rule-doc-notices.ts
@@ -181,6 +181,7 @@ const RULE_NOTICES: {
         pathRuleDoc,
         urlCurrentPage,
         true,
+        true,
         urlRuleDoc
       )
     );

--- a/lib/rule-link.ts
+++ b/lib/rule-link.ts
@@ -68,10 +68,12 @@ export function getLinkToRule(
   pathRuleDoc: string,
   urlCurrentPage: string,
   includeBackticks: boolean,
+  includePrefix: boolean,
   urlRuleDoc?: string
 ) {
-  // Ignore plugin prefix if it's included in rule name.
-  // While we could display the prefix if we wanted, it definitely cannot be part of the link.
+  const ruleNameWithPluginPrefix = ruleName.startsWith(`${pluginPrefix}/`)
+    ? ruleName
+    : `${pluginPrefix}/${ruleName}`;
   const ruleNameWithoutPluginPrefix = ruleName.startsWith(`${pluginPrefix}/`)
     ? ruleName.slice(pluginPrefix.length + 1)
     : ruleName;
@@ -83,7 +85,7 @@ export function getLinkToRule(
     urlCurrentPage,
     urlRuleDoc
   );
-  return `[${includeBackticks ? '`' : ''}${ruleNameWithoutPluginPrefix}${
-    includeBackticks ? '`' : ''
-  }](${urlToRule})`;
+  return `[${includeBackticks ? '`' : ''}${
+    includePrefix ? ruleNameWithPluginPrefix : ruleNameWithoutPluginPrefix
+  }${includeBackticks ? '`' : ''}](${urlToRule})`;
 }

--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -136,6 +136,7 @@ function buildRuleRow(
         pathRuleDoc,
         pathRuleList,
         false,
+        false,
         urlRuleDoc
       );
     },

--- a/test/lib/generate/__snapshots__/option-url-rule-doc-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-url-rule-doc-test.ts.snap
@@ -18,7 +18,7 @@ exports[`generate (--url-rule-doc) basic uses the right URLs 1`] = `
 exports[`generate (--url-rule-doc) basic uses the right URLs 2`] = `
 "# Description for no-foo (\`test/no-foo\`)
 
-❌ This rule is deprecated. It was replaced by [\`no-bar\`](https://example.com/rule-docs/no-bar/).
+❌ This rule is deprecated. It was replaced by [\`test/no-bar\`](https://example.com/rule-docs/no-bar/).
 
 <!-- end auto-generated rule header -->
 "

--- a/test/lib/generate/__snapshots__/rule-deprecation-test.ts.snap
+++ b/test/lib/generate/__snapshots__/rule-deprecation-test.ts.snap
@@ -18,7 +18,7 @@ exports[`generate (deprecated rules) several deprecated rules updates the docume
 exports[`generate (deprecated rules) several deprecated rules updates the documentation 2`] = `
 "# Description (\`test/no-foo\`)
 
-❌ This rule is deprecated. It was replaced by [\`no-bar\`](../../docs/rules/no-bar.md).
+❌ This rule is deprecated. It was replaced by [\`test/no-bar\`](../../docs/rules/no-bar.md).
 
 <!-- end auto-generated rule header -->
 "
@@ -65,7 +65,7 @@ exports[`generate (deprecated rules) using prefix ahead of replacement rule name
 exports[`generate (deprecated rules) using prefix ahead of replacement rule name uses correct replacement rule link 2`] = `
 "# Description (\`test/no-foo\`)
 
-❌ This rule is deprecated. It was replaced by [\`no-bar\`](../../docs/rules/no-bar.md).
+❌ This rule is deprecated. It was replaced by [\`test/no-bar\`](../../docs/rules/no-bar.md).
 
 <!-- end auto-generated rule header -->
 "
@@ -94,7 +94,7 @@ exports[`generate (deprecated rules) with --path-rule-doc has the correct links,
 exports[`generate (deprecated rules) with --path-rule-doc has the correct links, especially replacement rule link 2`] = `
 "# Description (\`test/category/no-foo\`)
 
-❌ This rule is deprecated. It was replaced by [\`category/no-bar\`](../../../docs/category/no-bar/README.md).
+❌ This rule is deprecated. It was replaced by [\`test/category/no-bar\`](../../../docs/category/no-bar/README.md).
 
 <!-- end auto-generated rule header -->
 "
@@ -103,7 +103,7 @@ exports[`generate (deprecated rules) with --path-rule-doc has the correct links,
 exports[`generate (deprecated rules) with --path-rule-doc has the correct links, especially replacement rule link 3`] = `
 "# Description (\`test/category/no-bar\`)
 
-❌ This rule is deprecated. It was replaced by [\`category/no-foo\`](../../../docs/category/no-foo/README.md).
+❌ This rule is deprecated. It was replaced by [\`test/category/no-foo\`](../../../docs/category/no-foo/README.md).
 
 <!-- end auto-generated rule header -->
 "
@@ -125,7 +125,7 @@ exports[`generate (deprecated rules) with nested rule names has the correct link
 exports[`generate (deprecated rules) with nested rule names has the correct links, especially replacement rule link 2`] = `
 "# Description (\`test/category/no-foo\`)
 
-❌ This rule is deprecated. It was replaced by [\`category/no-bar\`](../../../docs/rules/category/no-bar.md).
+❌ This rule is deprecated. It was replaced by [\`test/category/no-bar\`](../../../docs/rules/category/no-bar.md).
 
 <!-- end auto-generated rule header -->
 "
@@ -134,7 +134,7 @@ exports[`generate (deprecated rules) with nested rule names has the correct link
 exports[`generate (deprecated rules) with nested rule names has the correct links, especially replacement rule link 3`] = `
 "# Description (\`test/category/no-bar\`)
 
-❌ This rule is deprecated. It was replaced by [\`category/no-foo\`](../../../docs/rules/category/no-foo.md).
+❌ This rule is deprecated. It was replaced by [\`test/category/no-foo\`](../../../docs/rules/category/no-foo.md).
 
 <!-- end auto-generated rule header -->
 "


### PR DESCRIPTION
Always display the prefix, regardless of whether the user specified the prefix in `meta.replacedBy`. Previously, we never displayed it.


Fixes #293.

Related: #297