### PR TITLE
fix: correct path to types

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "ISC",
   "author": "Bryan Mishkin",
   "type": "module",
-  "types": "./dist/lib/index.js",
+  "types": "./dist/lib/index.d.ts",
   "bin": {
     "eslint-doc-generator": "./dist/bin/eslint-doc-generator.js"
   },


### PR DESCRIPTION
The js file is empty (so no exports), so I think this is correct.

https://www.runpkg.com/?eslint-doc-generator@0.27.0/dist/lib/index.js
https://www.runpkg.com/?eslint-doc-generator@0.27.0/dist/lib/index.d.ts

(at least the current version doesn't work in IntelliJ)