### PR TITLE
Use arrays instead of CSV strings for config file types

### DIFF
--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -119,6 +119,8 @@ export async function generate(path: string, options?: GenerateOptions) {
     options?.pathRuleList,
     OPTION_DEFAULTS[OPTION_TYPE.PATH_RULE_LIST]
   );
+  const postprocess =
+    options?.postprocess ?? OPTION_DEFAULTS[OPTION_TYPE.POSTPROCESS];
   const ruleDocNotices = parseRuleDocNoticesOption(options?.ruleDocNotices);
   const ruleDocSectionExclude = stringOrArrayWithFallback(
     options?.ruleDocSectionExclude,
@@ -140,8 +142,6 @@ export async function generate(path: string, options?: GenerateOptions) {
     options?.urlConfigs ?? OPTION_DEFAULTS[OPTION_TYPE.URL_CONFIGS];
   const urlRuleDoc =
     options?.urlRuleDoc ?? OPTION_DEFAULTS[OPTION_TYPE.URL_RULE_DOC];
-  const postprocess =
-    options?.postprocess ?? OPTION_DEFAULTS[OPTION_TYPE.POSTPROCESS];
 
   // Gather details about rules.
   const details: RuleDetails[] = Object.entries(plugin.rules)

--- a/lib/option-parsers.ts
+++ b/lib/option-parsers.ts
@@ -15,13 +15,13 @@ import type { Plugin, ConfigEmojis } from './types.js';
  */
 export function parseConfigEmojiOptions(
   plugin: Plugin,
-  configEmoji?: string[]
+  configEmoji?: string[][]
 ): ConfigEmojis {
   const configsSeen = new Set<string>();
   const configsWithDefaultEmojiRemoved: string[] = [];
   const configEmojis =
     configEmoji?.flatMap((configEmojiItem) => {
-      const [config, emoji, ...extra] = configEmojiItem.split(',');
+      const [config, emoji, ...extra] = configEmojiItem;
 
       // Check for duplicate configs.
       if (configsSeen.has(config)) {
@@ -75,9 +75,9 @@ export function parseConfigEmojiOptions(
  * Parse the option, check for errors, and set defaults.
  */
 export function parseRuleListColumnsOption(
-  ruleListColumns: string | undefined
+  ruleListColumns: string[] | undefined
 ): COLUMN_TYPE[] {
-  const values = ruleListColumns ? ruleListColumns.split(',') : [];
+  const values = ruleListColumns ?? [];
   const VALUES_OF_TYPE = new Set(Object.values(COLUMN_TYPE).map(String));
 
   // Check for invalid.
@@ -105,9 +105,9 @@ export function parseRuleListColumnsOption(
  * Parse the option, check for errors, and set defaults.
  */
 export function parseRuleDocNoticesOption(
-  ruleDocNotices: string | undefined
+  ruleDocNotices: string[] | undefined
 ): NOTICE_TYPE[] {
-  const values = ruleDocNotices ? ruleDocNotices.split(',') : [];
+  const values = ruleDocNotices ?? [];
   const VALUES_OF_TYPE = new Set(Object.values(NOTICE_TYPE).map(String));
 
   // Check for invalid.

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -47,12 +47,12 @@ export const OPTION_DEFAULTS = {
   [OPTION_TYPE.INIT_RULE_DOCS]: false,
   [OPTION_TYPE.PATH_RULE_DOC]: join('docs', 'rules', '{name}.md'),
   [OPTION_TYPE.PATH_RULE_LIST]: 'README.md',
+  [OPTION_TYPE.POSTPROCESS]: (content: string) => content,
   [OPTION_TYPE.RULE_DOC_NOTICES]: Object.entries(
     NOTICE_TYPE_DEFAULT_PRESENCE_AND_ORDERING
   )
     .filter(([_col, enabled]) => enabled)
-    .map(([col]) => col)
-    .join(','),
+    .map(([col]) => col),
   [OPTION_TYPE.RULE_DOC_SECTION_EXCLUDE]: [],
   [OPTION_TYPE.RULE_DOC_SECTION_INCLUDE]: [],
   [OPTION_TYPE.RULE_DOC_SECTION_OPTIONS]: true,
@@ -61,10 +61,8 @@ export const OPTION_DEFAULTS = {
     COLUMN_TYPE_DEFAULT_PRESENCE_AND_ORDERING
   )
     .filter(([_col, enabled]) => enabled)
-    .map(([col]) => col)
-    .join(','),
+    .map(([col]) => col),
   [OPTION_TYPE.SPLIT_BY]: undefined,
   [OPTION_TYPE.URL_CONFIGS]: undefined,
   [OPTION_TYPE.URL_RULE_DOC]: undefined,
-  [OPTION_TYPE.POSTPROCESS]: (content: string) => content,
 } satisfies Record<OPTION_TYPE, unknown>; // Satisfies is used to ensure all options are included, but without losing type information.

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -91,6 +91,7 @@ export enum OPTION_TYPE {
   INIT_RULE_DOCS = 'initRuleDocs',
   PATH_RULE_DOC = 'pathRuleDoc',
   PATH_RULE_LIST = 'pathRuleList',
+  POSTPROCESS = 'postprocess',
   RULE_DOC_NOTICES = 'ruleDocNotices',
   RULE_DOC_SECTION_EXCLUDE = 'ruleDocSectionExclude',
   RULE_DOC_SECTION_INCLUDE = 'ruleDocSectionInclude',
@@ -100,7 +101,6 @@ export enum OPTION_TYPE {
   SPLIT_BY = 'splitBy',
   URL_CONFIGS = 'urlConfigs',
   URL_RULE_DOC = 'urlRuleDoc',
-  POSTPROCESS = 'postprocess',
 }
 
 // JSDocs for options should be kept in sync with README.md and the CLI runner in cli.ts.
@@ -111,11 +111,11 @@ export type GenerateOptions = {
   check?: boolean;
   /**
    * List of configs and their associated emojis.
-   * Format is `config-name,emoji`.
+   * Array of `[configName, emoji]`.
    * Default emojis are provided for common configs.
    * To remove a default emoji and rely on a badge instead, provide the config name without an emoji.
    */
-  configEmoji?: string[];
+  configEmoji?: string[][];
   /** Configs to ignore from being displayed. Often used for an `all` config. */
   ignoreConfig?: string[];
   /** Whether to ignore deprecated rules from being checked, displayed, or updated. Default: `false`. */
@@ -135,12 +135,12 @@ export type GenerateOptions = {
     pathToFile: string
   ) => string | Promise<string>;
   /**
-   * Ordered, comma-separated list of notices to display in rule doc.
+   * Ordered list of notices to display in rule doc.
    * Non-applicable notices will be hidden.
    * Choices: `configs`, `deprecated`, `fixable` (off by default), `fixableAndHasSuggestions`, `hasSuggestions` (off by default), `options` (off by default), `requiresTypeChecking`, `type` (off by default).
-   * Default: `deprecated,configs,fixableAndHasSuggestions,requiresTypeChecking`.
+   * Default: `['deprecated', 'configs', 'fixableAndHasSuggestions', 'requiresTypeChecking']`.
    */
-  ruleDocNotices?: string;
+  ruleDocNotices?: NOTICE_TYPE[];
   /** Disallowed sections in each rule doc. Exit with failure if present. */
   ruleDocSectionExclude?: string[];
   /** Required sections in each rule doc. Exit with failure if missing. */
@@ -150,12 +150,12 @@ export type GenerateOptions = {
   /** The format to use for rule doc titles. Default: `desc-parens-prefix-name`. */
   ruleDocTitleFormat?: RuleDocTitleFormat;
   /**
-   * Ordered, comma-separated list of columns to display in rule list.
+   * Ordered list of columns to display in rule list.
    * Empty columns will be hidden.
    * Choices: `configsError`, `configsOff`, `configsWarn`, `deprecated`, `description`, `fixable`, `fixableAndHasSuggestions` (off by default), `hasSuggestions`, `name`, `options` (off by default), `requiresTypeChecking`, `type` (off by default).
-   * Default: `name,description,configsError,configsWarn,configsOff,fixable,hasSuggestions,requiresTypeChecking,deprecated`.
+   * Default: `['name', 'description', 'configsError', 'configsWarn', 'configsOff', 'fixable', 'hasSuggestions', 'requiresTypeChecking', 'deprecated']`.
    */
-  ruleListColumns?: string;
+  ruleListColumns?: COLUMN_TYPE[];
   /**
    * Rule property to split the rules list by.
    * A separate list and header will be created for each value.

--- a/test/lib/__snapshots__/cli-test.ts.snap
+++ b/test/lib/__snapshots__/cli-test.ts.snap
@@ -6,8 +6,14 @@ exports[`cli all CLI options and all config files options merges correctly, with
   {
     "check": true,
     "configEmoji": [
-      "recommended-from-config-file,🚲",
-      "recommended-from-cli,🚲",
+      [
+        "recommended-from-config-file",
+        "🚲",
+      ],
+      [
+        "recommended-from-cli",
+        "🚲",
+      ],
     ],
     "ignoreConfig": [
       "ignoredConfigFromConfigFile1",
@@ -22,7 +28,10 @@ exports[`cli all CLI options and all config files options merges correctly, with
       "www.example.com/rule-list-from-config-file",
       "www.example.com/rule-list-from-cli",
     ],
-    "ruleDocNotices": "type",
+    "ruleDocNotices": [
+      "fixable",
+      "type",
+    ],
     "ruleDocSectionExclude": [
       "excludedSectionFromConfigFile1",
       "excludedSectionFromConfigFile2",
@@ -37,7 +46,11 @@ exports[`cli all CLI options and all config files options merges correctly, with
     ],
     "ruleDocSectionOptions": true,
     "ruleDocTitleFormat": "name",
-    "ruleListColumns": "type",
+    "ruleListColumns": [
+      "fixable",
+      "hasSuggestions",
+      "type",
+    ],
     "splitBy": "meta.docs.foo-from-cli",
     "urlConfigs": "https://example.com/configs-url-from-cli",
     "urlRuleDoc": "https://example.com/rule-doc-url-from-cli",
@@ -51,7 +64,10 @@ exports[`cli all CLI options, no config file options is called correctly 1`] = `
   {
     "check": true,
     "configEmoji": [
-      "recommended-from-cli,🚲",
+      [
+        "recommended-from-cli",
+        "🚲",
+      ],
     ],
     "ignoreConfig": [
       "ignoredConfigFromCli1",
@@ -63,7 +79,9 @@ exports[`cli all CLI options, no config file options is called correctly 1`] = `
     "pathRuleList": [
       "www.example.com/rule-list-from-cli",
     ],
-    "ruleDocNotices": "type",
+    "ruleDocNotices": [
+      "type",
+    ],
     "ruleDocSectionExclude": [
       "excludedSectionFromCli1",
       "excludedSectionFromCli2",
@@ -74,7 +92,9 @@ exports[`cli all CLI options, no config file options is called correctly 1`] = `
     ],
     "ruleDocSectionOptions": true,
     "ruleDocTitleFormat": "name",
-    "ruleListColumns": "type",
+    "ruleListColumns": [
+      "type",
+    ],
     "splitBy": "meta.docs.foo-from-cli",
     "urlConfigs": "https://example.com/configs-url-from-cli",
     "urlRuleDoc": "https://example.com/rule-doc-url-from-cli",
@@ -88,7 +108,10 @@ exports[`cli all config files options, no CLI options is called correctly 1`] = 
   {
     "check": true,
     "configEmoji": [
-      "recommended-from-config-file,🚲",
+      [
+        "recommended-from-config-file",
+        "🚲",
+      ],
     ],
     "ignoreConfig": [
       "ignoredConfigFromConfigFile1",
@@ -100,7 +123,9 @@ exports[`cli all config files options, no CLI options is called correctly 1`] = 
     "pathRuleList": [
       "www.example.com/rule-list-from-config-file",
     ],
-    "ruleDocNotices": "type",
+    "ruleDocNotices": [
+      "fixable",
+    ],
     "ruleDocSectionExclude": [
       "excludedSectionFromConfigFile1",
       "excludedSectionFromConfigFile2",
@@ -111,7 +136,10 @@ exports[`cli all config files options, no CLI options is called correctly 1`] = 
     ],
     "ruleDocSectionOptions": false,
     "ruleDocTitleFormat": "desc",
-    "ruleListColumns": "fixable,hasSuggestions",
+    "ruleListColumns": [
+      "fixable",
+      "hasSuggestions",
+    ],
     "splitBy": "meta.docs.foo-from-config-file",
     "urlConfigs": "https://example.com/configs-url-from-config-file",
     "urlRuleDoc": "https://example.com/rule-doc-url-from-config-file",
@@ -127,8 +155,10 @@ exports[`cli boolean option - false (explicit) is called correctly 1`] = `
     "ignoreConfig": [],
     "ignoreDeprecatedRules": false,
     "pathRuleList": [],
+    "ruleDocNotices": [],
     "ruleDocSectionExclude": [],
     "ruleDocSectionInclude": [],
+    "ruleListColumns": [],
   },
 ]
 `;
@@ -141,8 +171,10 @@ exports[`cli boolean option - true (explicit) is called correctly 1`] = `
     "ignoreConfig": [],
     "ignoreDeprecatedRules": true,
     "pathRuleList": [],
+    "ruleDocNotices": [],
     "ruleDocSectionExclude": [],
     "ruleDocSectionInclude": [],
+    "ruleListColumns": [],
   },
 ]
 `;
@@ -155,8 +187,10 @@ exports[`cli boolean option - true (implicit) is called correctly 1`] = `
     "ignoreConfig": [],
     "ignoreDeprecatedRules": true,
     "pathRuleList": [],
+    "ruleDocNotices": [],
     "ruleDocSectionExclude": [],
     "ruleDocSectionInclude": [],
+    "ruleListColumns": [],
   },
 ]
 `;
@@ -168,8 +202,10 @@ exports[`cli no options is called correctly 1`] = `
     "configEmoji": [],
     "ignoreConfig": [],
     "pathRuleList": [],
+    "ruleDocNotices": [],
     "ruleDocSectionExclude": [],
     "ruleDocSectionInclude": [],
+    "ruleListColumns": [],
   },
 ]
 `;
@@ -186,8 +222,10 @@ exports[`cli pathRuleList as array in config file and CLI merges correctly 1`] =
       "listFromCli1.md",
       "listFromCli2.md",
     ],
+    "ruleDocNotices": [],
     "ruleDocSectionExclude": [],
     "ruleDocSectionInclude": [],
+    "ruleListColumns": [],
   },
 ]
 `;

--- a/test/lib/cli-test.ts
+++ b/test/lib/cli-test.ts
@@ -5,7 +5,7 @@ import { OPTION_TYPE } from '../../lib/types.js';
 
 const configFileOptionsAll: { [key in OPTION_TYPE]: unknown } = {
   check: true,
-  configEmoji: ['recommended-from-config-file,🚲'],
+  configEmoji: [['recommended-from-config-file', '🚲']],
   ignoreConfig: [
     'ignoredConfigFromConfigFile1',
     'ignoredConfigFromConfigFile2',
@@ -15,7 +15,7 @@ const configFileOptionsAll: { [key in OPTION_TYPE]: unknown } = {
   pathRuleDoc: 'www.example.com/rule-doc-from-config-file',
   pathRuleList: 'www.example.com/rule-list-from-config-file',
   postprocess: (content: string) => content,
-  ruleDocNotices: 'type',
+  ruleDocNotices: ['fixable'],
   ruleDocSectionExclude: [
     'excludedSectionFromConfigFile1',
     'excludedSectionFromConfigFile2',
@@ -26,7 +26,7 @@ const configFileOptionsAll: { [key in OPTION_TYPE]: unknown } = {
   ],
   ruleDocSectionOptions: false,
   ruleDocTitleFormat: 'desc',
-  ruleListColumns: 'fixable,hasSuggestions',
+  ruleListColumns: ['fixable', 'hasSuggestions'],
   splitBy: 'meta.docs.foo-from-config-file',
   urlConfigs: 'https://example.com/configs-url-from-config-file',
   urlRuleDoc: 'https://example.com/rule-doc-url-from-config-file',
@@ -57,6 +57,8 @@ const cliOptionsAll: { [key in OPTION_TYPE]: string[] } = {
     '--path-rule-list',
     'www.example.com/rule-list-from-cli',
   ],
+
+  [OPTION_TYPE.POSTPROCESS]: [], // This option is not supported by the CLI.
 
   [OPTION_TYPE.RULE_DOC_NOTICES]: ['--rule-doc-notices', 'type'],
 
@@ -94,7 +96,6 @@ const cliOptionsAll: { [key in OPTION_TYPE]: string[] } = {
     '--url-rule-doc',
     'https://example.com/rule-doc-url-from-cli',
   ],
-  [OPTION_TYPE.POSTPROCESS]: [],
 };
 
 describe('cli', function () {

--- a/test/lib/generate/configs-test.ts
+++ b/test/lib/generate/configs-test.ts
@@ -482,7 +482,7 @@ describe('generate (configs)', function () {
     it('hides the ignored config', async function () {
       await generate('.', {
         ignoreConfig: ['configToIgnore'],
-        configEmoji: ['configToIgnore,😋'], // Ensure this config has an emoji that would normally display in the legend.
+        configEmoji: [['configToIgnore', '😋']], // Ensure this config has an emoji that would normally display in the legend.
       });
       expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
       expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();

--- a/test/lib/generate/option-config-emoji-test.ts
+++ b/test/lib/generate/option-config-emoji-test.ts
@@ -58,7 +58,10 @@ describe('generate (--config-emoji)', function () {
 
     it('shows the correct emojis', async function () {
       await generate('.', {
-        configEmoji: ['recommended,🔥', 'stylistic,🎨'],
+        configEmoji: [
+          ['recommended', '🔥'],
+          ['stylistic', '🎨'],
+        ],
       });
       expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
       expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
@@ -99,7 +102,7 @@ describe('generate (--config-emoji)', function () {
 
     it('throws an error', async function () {
       await expect(
-        generate('.', { configEmoji: ['foo,bar,baz'] })
+        generate('.', { configEmoji: [['foo', 'bar', 'baz']] })
       ).rejects.toThrow(
         'Invalid configEmoji option: foo,bar,baz. Expected format: config,emoji'
       );
@@ -138,7 +141,7 @@ describe('generate (--config-emoji)', function () {
 
     it('throws an error', async function () {
       await expect(
-        generate('.', { configEmoji: ['config-without-default-emoji'] })
+        generate('.', { configEmoji: [['config-without-default-emoji']] })
       ).rejects.toThrow(
         'Invalid configEmoji option: config-without-default-emoji. Expected format: config,emoji'
       );
@@ -180,7 +183,7 @@ describe('generate (--config-emoji)', function () {
 
     it('reverts to using a badge for the config', async function () {
       await generate('.', {
-        configEmoji: ['recommended'],
+        configEmoji: [['recommended']],
       });
       expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
       expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
@@ -220,7 +223,7 @@ describe('generate (--config-emoji)', function () {
 
     it('throws an error', async function () {
       await expect(
-        generate('.', { configEmoji: ['config-does-not-exist,🔥'] })
+        generate('.', { configEmoji: [['config-does-not-exist', '🔥']] })
       ).rejects.toThrow(
         'Invalid configEmoji option: config-does-not-exist config not found.'
       );
@@ -263,7 +266,7 @@ describe('generate (--config-emoji)', function () {
 
     it('throws an error', async function () {
       await expect(
-        generate('.', { configEmoji: [`recommended,${EMOJI_CONFIG_ERROR}`] })
+        generate('.', { configEmoji: [['recommended', EMOJI_CONFIG_ERROR]] })
       ).rejects.toThrow(`Cannot specify reserved emoji ${EMOJI_CONFIG_ERROR}.`);
     });
   });
@@ -303,7 +306,12 @@ describe('generate (--config-emoji)', function () {
 
     it('throws an error', async function () {
       await expect(
-        generate('.', { configEmoji: ['recommended,🔥', 'recommended,😋'] })
+        generate('.', {
+          configEmoji: [
+            ['recommended', '🔥'],
+            ['recommended', '😋'],
+          ],
+        })
       ).rejects.toThrow(
         'Duplicate config name in configEmoji options: recommended'
       );

--- a/test/lib/generate/option-rule-list-columns-test.ts
+++ b/test/lib/generate/option-rule-list-columns-test.ts
@@ -4,6 +4,7 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readFileSync } from 'node:fs';
 import { jest } from '@jest/globals';
+import { COLUMN_TYPE } from '../../../lib/types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -50,7 +51,11 @@ describe('generate (--rule-list-columns)', function () {
 
     it('shows the right columns and legend', async function () {
       await generate('.', {
-        ruleListColumns: 'hasSuggestions,fixable,name',
+        ruleListColumns: [
+          COLUMN_TYPE.HAS_SUGGESTIONS,
+          COLUMN_TYPE.FIXABLE,
+          COLUMN_TYPE.NAME,
+        ],
       });
       expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
       expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
@@ -111,7 +116,10 @@ describe('generate (--rule-list-columns)', function () {
 
     it('shows the right columns and legend', async function () {
       await generate('.', {
-        ruleListColumns: 'name,fixableAndHasSuggestions',
+        ruleListColumns: [
+          COLUMN_TYPE.NAME,
+          COLUMN_TYPE.FIXABLE_AND_HAS_SUGGESTIONS,
+        ],
       });
       expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
     });
@@ -149,7 +157,8 @@ describe('generate (--rule-list-columns)', function () {
 
     it('throws an error', async function () {
       await expect(
-        generate('.', { ruleListColumns: 'name,non-existent' })
+        // @ts-expect-error -- testing non-existent column type
+        generate('.', { ruleListColumns: [COLUMN_TYPE.NAME, 'non-existent'] })
       ).rejects.toThrow('Invalid ruleListColumns option: non-existent');
     });
   });
@@ -186,7 +195,7 @@ describe('generate (--rule-list-columns)', function () {
 
     it('throws an error', async function () {
       await expect(
-        generate('.', { ruleListColumns: 'name,name' })
+        generate('.', { ruleListColumns: [COLUMN_TYPE.NAME, COLUMN_TYPE.NAME] })
       ).rejects.toThrow('Duplicate value detected in ruleListColumns option.');
     });
   });

--- a/test/lib/generate/rule-options-test.ts
+++ b/test/lib/generate/rule-options-test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { readFileSync } from 'node:fs';
 import { jest } from '@jest/globals';
 import * as sinon from 'sinon';
+import { COLUMN_TYPE, NOTICE_TYPE } from '../../../lib/types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -357,8 +358,8 @@ describe('generate (rule options)', function () {
 
     it('displays the column and notice', async function () {
       await generate('.', {
-        ruleListColumns: 'name,options',
-        ruleDocNotices: 'options',
+        ruleListColumns: [COLUMN_TYPE.NAME, COLUMN_TYPE.OPTIONS],
+        ruleDocNotices: [NOTICE_TYPE.OPTIONS],
       });
       expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
       expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();

--- a/test/lib/generate/rule-type-test.ts
+++ b/test/lib/generate/rule-type-test.ts
@@ -4,6 +4,7 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readFileSync } from 'node:fs';
 import { jest } from '@jest/globals';
+import { COLUMN_TYPE } from '../../../lib/types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -86,7 +87,9 @@ describe('generate (rule type)', function () {
     });
 
     it('displays the type', async function () {
-      await generate('.', { ruleListColumns: 'name,type' });
+      await generate('.', {
+        ruleListColumns: [COLUMN_TYPE.NAME, COLUMN_TYPE.TYPE],
+      });
       expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
       expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
       expect(readFileSync('docs/rules/no-bar.md', 'utf8')).toMatchSnapshot();
@@ -127,7 +130,9 @@ describe('generate (rule type)', function () {
     });
 
     it('hides the type column and notice', async function () {
-      await generate('.', { ruleListColumns: 'name,type' });
+      await generate('.', {
+        ruleListColumns: [COLUMN_TYPE.NAME, COLUMN_TYPE.TYPE],
+      });
       expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
       expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
     });


### PR DESCRIPTION
| Type | Before Type | Before Example | After Type | After Example |
| --- | --- | --- | --- | --- | 
| configEmoji | string[] | `'my-config,😋'` | string[][] | `['my-config', '😋']` |
| ruleDocNotices | string | `'fixableAndHasSuggestions,deprecated'` | NOTICE_TYPE[] | `['fixableAndHasSuggestions', 'deprecated']` |
| ruleListColumns | string | `'name,type'` | COLUMN_TYPE[] | `['name', 'type']` |

Using actual arrays of the proper enum types is much safer, cleaner, and more elegant vs. having the user provide CSV strings. Actual arrays are easier to work with in JS/JSON objects and avoid hacks like using `.join(',')`. This also enables us to specify the actual enum types which provide the user with additional type information / type-checking capability.