### PR TITLE
Use `readonly` for external/array types

### DIFF
--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -57,7 +57,7 @@ function expectContent(
 function expectSectionHeader(
   ruleName: string,
   contents: string,
-  possibleHeaders: string[],
+  possibleHeaders: readonly string[],
   expected: boolean
 ) {
   const found = possibleHeaders.some((header) =>
@@ -84,7 +84,7 @@ function expectSectionHeader(
   }
 }
 
-function stringOrArrayWithFallback<T extends string | string[]>(
+function stringOrArrayWithFallback<T extends string | readonly string[]>(
   stringOrArray: undefined | T,
   fallback: T
 ): T {
@@ -145,7 +145,7 @@ export async function generate(path: string, options?: GenerateOptions) {
     options?.urlRuleDoc ?? OPTION_DEFAULTS[OPTION_TYPE.URL_RULE_DOC];
 
   // Gather details about rules.
-  const details: RuleDetails[] = Object.entries(plugin.rules)
+  const details: readonly RuleDetails[] = Object.entries(plugin.rules)
     .map(([name, rule]): RuleDetails => {
       return typeof rule === 'object'
         ? // Object-style rule.
@@ -177,6 +177,9 @@ export async function generate(path: string, options?: GenerateOptions) {
     .filter(
       // Filter out deprecated rules from being checked, displayed, or updated if the option is set.
       (details) => !ignoreDeprecatedRules || !details.deprecated
+    )
+    .sort(({ name: a }, { name: b }) =>
+      a.toLowerCase().localeCompare(b.toLowerCase())
     );
 
   // Update rule doc for each rule.

--- a/lib/option-parsers.ts
+++ b/lib/option-parsers.ts
@@ -15,7 +15,7 @@ import type { Plugin, ConfigEmojis } from './types.js';
  */
 export function parseConfigEmojiOptions(
   plugin: Plugin,
-  configEmoji?: string[][]
+  configEmoji?: readonly string[][]
 ): ConfigEmojis {
   const configsSeen = new Set<string>();
   const configsWithDefaultEmojiRemoved: string[] = [];
@@ -75,9 +75,9 @@ export function parseConfigEmojiOptions(
  * Parse the option, check for errors, and set defaults.
  */
 export function parseRuleListColumnsOption(
-  ruleListColumns: string[] | undefined
-): COLUMN_TYPE[] {
-  const values = ruleListColumns ?? [];
+  ruleListColumns: readonly string[] | undefined
+): readonly COLUMN_TYPE[] {
+  const values = [...(ruleListColumns ?? [])];
   const VALUES_OF_TYPE = new Set(Object.values(COLUMN_TYPE).map(String));
 
   // Check for invalid.
@@ -98,16 +98,16 @@ export function parseRuleListColumnsOption(
     );
   }
 
-  return values as COLUMN_TYPE[];
+  return values as readonly COLUMN_TYPE[];
 }
 
 /**
  * Parse the option, check for errors, and set defaults.
  */
 export function parseRuleDocNoticesOption(
-  ruleDocNotices: string[] | undefined
-): NOTICE_TYPE[] {
-  const values = ruleDocNotices ?? [];
+  ruleDocNotices: readonly string[] | undefined
+): readonly NOTICE_TYPE[] {
+  const values = [...(ruleDocNotices ?? [])];
   const VALUES_OF_TYPE = new Set(Object.values(NOTICE_TYPE).map(String));
 
   // Check for invalid.
@@ -128,5 +128,5 @@ export function parseRuleDocNoticesOption(
     );
   }
 
-  return values as NOTICE_TYPE[];
+  return values as readonly NOTICE_TYPE[];
 }

--- a/lib/package-json.ts
+++ b/lib/package-json.ts
@@ -43,13 +43,8 @@ export async function loadPlugin(path: string): Promise<Plugin> {
     ) {
       // Check various properties on the `exports` object.
       // https://nodejs.org/api/packages.html#conditional-exports
-      const propertiesToCheck: (keyof PackageJson.ExportConditions)[] = [
-        '.',
-        'node',
-        'import',
-        'require',
-        'default',
-      ];
+      const propertiesToCheck: readonly (keyof PackageJson.ExportConditions)[] =
+        ['.', 'node', 'import', 'require', 'default'];
       for (const prop of propertiesToCheck) {
         // @ts-expect-error -- The union type for the object is causing trouble.
         const value = exports[prop];

--- a/lib/plugin-config-resolution.ts
+++ b/lib/plugin-config-resolution.ts
@@ -33,7 +33,7 @@ async function resolveConfigRules(config: Config): Promise<Rules> {
 }
 
 async function resolveConfigExtends(
-  extendItems: string[] | string
+  extendItems: readonly string[] | string
 ): Promise<Rules> {
   const rules: Rules = {};
   for (const extend of Array.isArray(extendItems)

--- a/lib/plugin-configs.ts
+++ b/lib/plugin-configs.ts
@@ -10,7 +10,7 @@ export function getConfigsThatSetARule(
   plugin: Plugin,
   configsToRules: ConfigsToRules,
   pluginPrefix: string,
-  ignoreConfig: string[],
+  ignoreConfig: readonly string[],
   severityType?: SEVERITY_TYPE
 ) {
   /* istanbul ignore next -- this shouldn't happen */

--- a/lib/rule-doc-notices.ts
+++ b/lib/rule-doc-notices.ts
@@ -37,7 +37,7 @@ function severityToTerminology(severity: SEVERITY_TYPE) {
 }
 
 function configsToNoticeSentence(
-  configs: string[],
+  configs: readonly string[],
   severity: SEVERITY_TYPE,
   configsLinkOrWord: string,
   configLinkOrWord: string,
@@ -75,9 +75,9 @@ const RULE_NOTICES: {
     | undefined
     | ((data: {
         ruleName: string;
-        configsError: string[];
-        configsWarn: string[];
-        configsOff: string[];
+        configsError: readonly string[];
+        configsWarn: readonly string[];
+        configsOff: readonly string[];
         configEmojis: ConfigEmojis;
         fixable: boolean;
         hasSuggestions: boolean;
@@ -228,10 +228,10 @@ const RULE_NOTICES: {
  */
 function getNoticesForRule(
   rule: RuleModule,
-  configsError: string[],
-  configsWarn: string[],
-  configsOff: string[],
-  ruleDocNotices: NOTICE_TYPE[]
+  configsError: readonly string[],
+  configsWarn: readonly string[],
+  configsOff: readonly string[],
+  ruleDocNotices: readonly NOTICE_TYPE[]
 ) {
   const notices: {
     [key in NOTICE_TYPE]: boolean;
@@ -272,8 +272,8 @@ function getRuleNoticeLines(
   pathPlugin: string,
   pathRuleDoc: string,
   configEmojis: ConfigEmojis,
-  ignoreConfig: string[],
-  ruleDocNotices: NOTICE_TYPE[],
+  ignoreConfig: readonly string[],
+  ruleDocNotices: readonly NOTICE_TYPE[],
   urlConfigs?: string,
   urlRuleDoc?: string
 ) {
@@ -429,8 +429,8 @@ export function generateRuleHeaderLines(
   pathPlugin: string,
   pathRuleDoc: string,
   configEmojis: ConfigEmojis,
-  ignoreConfig: string[],
-  ruleDocNotices: NOTICE_TYPE[],
+  ignoreConfig: readonly string[],
+  ruleDocNotices: readonly NOTICE_TYPE[],
   ruleDocTitleFormat: RuleDocTitleFormat,
   urlConfigs?: string,
   urlRuleDoc?: string

--- a/lib/rule-list-columns.ts
+++ b/lib/rule-list-columns.ts
@@ -17,7 +17,9 @@ import type { RuleDetails, ConfigsToRules, Plugin } from './types.js';
  * An object containing the column header for each column (as a string or function to generate the string).
  */
 export const COLUMN_HEADER: {
-  [key in COLUMN_TYPE]: string | ((data: { details: RuleDetails[] }) => string);
+  [key in COLUMN_TYPE]:
+    | string
+    | ((data: { details: readonly RuleDetails[] }) => string);
 } = {
   [COLUMN_TYPE.NAME]: ({ details }) => {
     const ruleNames = details.map((detail) => detail.name);
@@ -65,11 +67,11 @@ export const COLUMN_HEADER: {
  */
 export function getColumns(
   plugin: Plugin,
-  details: RuleDetails[],
+  details: readonly RuleDetails[],
   configsToRules: ConfigsToRules,
-  ruleListColumns: COLUMN_TYPE[],
+  ruleListColumns: readonly COLUMN_TYPE[],
   pluginPrefix: string,
-  ignoreConfig: string[]
+  ignoreConfig: readonly string[]
 ): Record<COLUMN_TYPE, boolean> {
   const columns: {
     [key in COLUMN_TYPE]: boolean;

--- a/lib/rule-list-legend.ts
+++ b/lib/rule-list-legend.ts
@@ -34,16 +34,16 @@ const LEGEND_HAS_SUGGESTIONS = `${EMOJI_HAS_SUGGESTIONS} Manually fixable by [ed
  */
 const LEGENDS: {
   [key in COLUMN_TYPE]:
-    | string[]
+    | readonly string[]
     | undefined // For no legend.
     | ((data: {
         plugin: Plugin;
         configsToRules: ConfigsToRules;
         configEmojis: ConfigEmojis;
         pluginPrefix: string;
-        ignoreConfig: string[];
+        ignoreConfig: readonly string[];
         urlConfigs?: string;
-      }) => string[]);
+      }) => readonly string[]);
 } = {
   [COLUMN_TYPE.CONFIGS_ERROR]: ({
     plugin,
@@ -155,7 +155,7 @@ function getLegendForConfigColumnOfSeverity({
   configsToRules: ConfigsToRules;
   configEmojis: ConfigEmojis;
   pluginPrefix: string;
-  ignoreConfig: string[];
+  ignoreConfig: readonly string[];
   severityType: SEVERITY_TYPE;
   urlConfigs?: string;
 }): string {
@@ -186,9 +186,9 @@ function getLegendsForIndividualConfigs({
   configsToRules: ConfigsToRules;
   configEmojis: ConfigEmojis;
   pluginPrefix: string;
-  ignoreConfig: string[];
+  ignoreConfig: readonly string[];
   urlConfigs?: string;
-}): string[] {
+}): readonly string[] {
   /* istanbul ignore next -- this shouldn't happen */
   if (!plugin.configs || !plugin.rules) {
     throw new Error(
@@ -225,32 +225,32 @@ export function generateLegend(
   configsToRules: ConfigsToRules,
   configEmojis: ConfigEmojis,
   pluginPrefix: string,
-  ignoreConfig: string[],
+  ignoreConfig: readonly string[],
   urlConfigs?: string
 ) {
-  const legends = (Object.entries(columns) as [COLUMN_TYPE, boolean][]).flatMap(
-    ([columnType, enabled]) => {
-      if (!enabled) {
-        // This column is turned off.
-        return [];
-      }
-      const legendArrayOrFn = LEGENDS[columnType];
-      if (!legendArrayOrFn) {
-        // No legend specified for this column.
-        return [];
-      }
-      return typeof legendArrayOrFn === 'function'
-        ? legendArrayOrFn({
-            plugin,
-            configsToRules,
-            configEmojis,
-            pluginPrefix,
-            urlConfigs,
-            ignoreConfig,
-          })
-        : legendArrayOrFn;
+  const legends = (
+    Object.entries(columns) as readonly [COLUMN_TYPE, boolean][]
+  ).flatMap(([columnType, enabled]) => {
+    if (!enabled) {
+      // This column is turned off.
+      return [];
     }
-  );
+    const legendArrayOrFn = LEGENDS[columnType];
+    if (!legendArrayOrFn) {
+      // No legend specified for this column.
+      return [];
+    }
+    return typeof legendArrayOrFn === 'function'
+      ? legendArrayOrFn({
+          plugin,
+          configsToRules,
+          configEmojis,
+          pluginPrefix,
+          urlConfigs,
+          ignoreConfig,
+        })
+      : legendArrayOrFn;
+  });
 
   if (legends.some((legend) => legend.includes('Configurations'))) {
     // Add legends for individual configs after the config column legend(s).

--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -60,7 +60,7 @@ function getConfigurationColumnValueForRule(
   configsToRules: ConfigsToRules,
   pluginPrefix: string,
   configEmojis: ConfigEmojis,
-  ignoreConfig: string[],
+  ignoreConfig: readonly string[],
   severityType: SEVERITY_TYPE
 ): string {
   const configsToRulesWithoutIgnored = Object.fromEntries(
@@ -88,9 +88,9 @@ function buildRuleRow(
   pathRuleDoc: string,
   pathRuleList: string,
   configEmojis: ConfigEmojis,
-  ignoreConfig: string[],
+  ignoreConfig: readonly string[],
   urlRuleDoc?: string
-): string[] {
+): readonly string[] {
   const columns: {
     [key in COLUMN_TYPE]: string | (() => string);
   } = {
@@ -162,18 +162,18 @@ function buildRuleRow(
 
 function generateRulesListMarkdown(
   columns: Record<COLUMN_TYPE, boolean>,
-  details: RuleDetails[],
+  details: readonly RuleDetails[],
   configsToRules: ConfigsToRules,
   pluginPrefix: string,
   pathPlugin: string,
   pathRuleDoc: string,
   pathRuleList: string,
   configEmojis: ConfigEmojis,
-  ignoreConfig: string[],
+  ignoreConfig: readonly string[],
   urlRuleDoc?: string
 ): string {
   const listHeaderRow = (
-    Object.entries(columns) as [COLUMN_TYPE, boolean][]
+    Object.entries(columns) as readonly [COLUMN_TYPE, boolean][]
   ).flatMap(([columnType, enabled]) => {
     if (!enabled) {
       return [];
@@ -189,24 +189,20 @@ function generateRulesListMarkdown(
   return markdownTable(
     [
       listHeaderRow,
-      ...details
-        .sort(({ name: a }, { name: b }) =>
-          a.toLowerCase().localeCompare(b.toLowerCase())
-        )
-        .map((rule: RuleDetails) =>
-          buildRuleRow(
-            columns,
-            rule,
-            configsToRules,
-            pluginPrefix,
-            pathPlugin,
-            pathRuleDoc,
-            pathRuleList,
-            configEmojis,
-            ignoreConfig,
-            urlRuleDoc
-          )
+      ...details.map((rule: RuleDetails) => [
+        ...buildRuleRow(
+          columns,
+          rule,
+          configsToRules,
+          pluginPrefix,
+          pathPlugin,
+          pathRuleDoc,
+          pathRuleList,
+          configEmojis,
+          ignoreConfig,
+          urlRuleDoc
         ),
+      ]),
     ],
     { align: 'l' } // Left-align headers.
   );
@@ -217,7 +213,7 @@ function generateRulesListMarkdown(
  */
 function generateRulesListMarkdownWithRuleListSplit(
   columns: Record<COLUMN_TYPE, boolean>,
-  details: RuleDetails[],
+  details: readonly RuleDetails[],
   plugin: Plugin,
   configsToRules: ConfigsToRules,
   pluginPrefix: string,
@@ -225,7 +221,7 @@ function generateRulesListMarkdownWithRuleListSplit(
   pathRuleDoc: string,
   pathRuleList: string,
   configEmojis: ConfigEmojis,
-  ignoreConfig: string[],
+  ignoreConfig: readonly string[],
   ruleListSplit: string,
   headerLevel: number,
   urlRuleDoc?: string
@@ -323,7 +319,7 @@ function generateRulesListMarkdownWithRuleListSplit(
 }
 
 export function updateRulesList(
-  details: RuleDetails[],
+  details: readonly RuleDetails[],
   markdown: string,
   plugin: Plugin,
   configsToRules: ConfigsToRules,
@@ -332,8 +328,8 @@ export function updateRulesList(
   pathRuleList: string,
   pathPlugin: string,
   configEmojis: ConfigEmojis,
-  ignoreConfig: string[],
-  ruleListColumns: COLUMN_TYPE[],
+  ignoreConfig: readonly string[],
+  ruleListColumns: readonly COLUMN_TYPE[],
   ruleListSplit?: string,
   urlConfigs?: string,
   urlRuleDoc?: string

--- a/lib/rule-options.ts
+++ b/lib/rule-options.ts
@@ -7,7 +7,7 @@ import type { JSONSchema } from '@typescript-eslint/utils';
  */
 export function getAllNamedOptions(
   jsonSchema: JSONSchema.JSONSchema4
-): string[] {
+): readonly string[] {
   if (!jsonSchema) {
     return [];
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -3,7 +3,7 @@ import type { TSESLint, JSONSchema } from '@typescript-eslint/utils';
 
 // Standard ESLint types.
 
-export type RuleModule = TSESLint.RuleModule<string, unknown[]>;
+export type RuleModule = TSESLint.RuleModule<string, readonly unknown[]>;
 
 export type Rules = TSESLint.Linter.RulesRecord;
 
@@ -49,7 +49,7 @@ export interface RuleDetails {
 /**
  * Some configs may have an emoji defined.
  */
-export type ConfigEmojis = { config: string; emoji: string }[];
+export type ConfigEmojis = readonly { config: string; emoji: string }[];
 
 /**
  * Rule doc notices.
@@ -108,29 +108,29 @@ export enum OPTION_TYPE {
 /** The type for the config file (e.g. `.eslint-doc-generatorrc.js`) and internal `generate()` function. */
 export type GenerateOptions = {
   /** Whether to check for and fail if there is a diff. No output will be written. Typically used during CI. Default: `false`. */
-  check?: boolean;
+  readonly check?: boolean;
   /**
    * List of configs and their associated emojis.
    * Array of `[configName, emoji]`.
    * Default emojis are provided for common configs.
    * To remove a default emoji and rely on a badge instead, provide the config name without an emoji.
    */
-  configEmoji?: string[][];
+  readonly configEmoji?: readonly string[][];
   /** Configs to ignore from being displayed. Often used for an `all` config. */
-  ignoreConfig?: string[];
+  readonly ignoreConfig?: readonly string[];
   /** Whether to ignore deprecated rules from being checked, displayed, or updated. Default: `false`. */
-  ignoreDeprecatedRules?: boolean;
+  readonly ignoreDeprecatedRules?: boolean;
   /** Whether to create rule doc files if they don't yet exist. Default: `false`. */
-  initRuleDocs?: boolean;
+  readonly initRuleDocs?: boolean;
   /** Path to markdown file for each rule doc. Use `{name}` placeholder for the rule name. Default: `docs/rules/{name}.md`. */
-  pathRuleDoc?: string;
+  readonly pathRuleDoc?: string;
   /** Path to markdown file(s) where the rules table list should live. Default: `README.md`. */
-  pathRuleList?: string | string[];
+  readonly pathRuleList?: string | readonly string[];
   /**
    * Function to be called with the generated content and file path for each processed file.
    * Useful for applying custom transformations such as formatting with tools like prettier.
    */
-  postprocess?: (
+  readonly postprocess?: (
     content: string,
     pathToFile: string
   ) => string | Promise<string>;
@@ -140,34 +140,34 @@ export type GenerateOptions = {
    * Choices: `configs`, `deprecated`, `fixable` (off by default), `fixableAndHasSuggestions`, `hasSuggestions` (off by default), `options` (off by default), `requiresTypeChecking`, `type` (off by default).
    * Default: `['deprecated', 'configs', 'fixableAndHasSuggestions', 'requiresTypeChecking']`.
    */
-  ruleDocNotices?: NOTICE_TYPE[];
+  readonly ruleDocNotices?: readonly NOTICE_TYPE[];
   /** Disallowed sections in each rule doc. Exit with failure if present. */
-  ruleDocSectionExclude?: string[];
+  readonly ruleDocSectionExclude?: readonly string[];
   /** Required sections in each rule doc. Exit with failure if missing. */
-  ruleDocSectionInclude?: string[];
+  readonly ruleDocSectionInclude?: readonly string[];
   /** Whether to require an "Options" or "Config" rule doc section and mention of any named options for rules with options. Default: `true`. */
-  ruleDocSectionOptions?: boolean;
+  readonly ruleDocSectionOptions?: boolean;
   /** The format to use for rule doc titles. Default: `desc-parens-prefix-name`. */
-  ruleDocTitleFormat?: RuleDocTitleFormat;
+  readonly ruleDocTitleFormat?: RuleDocTitleFormat;
   /**
    * Ordered list of columns to display in rule list.
    * Empty columns will be hidden.
    * Choices: `configsError`, `configsOff`, `configsWarn`, `deprecated`, `description`, `fixable`, `fixableAndHasSuggestions` (off by default), `hasSuggestions`, `name`, `options` (off by default), `requiresTypeChecking`, `type` (off by default).
    * Default: `['name', 'description', 'configsError', 'configsWarn', 'configsOff', 'fixable', 'hasSuggestions', 'requiresTypeChecking', 'deprecated']`.
    */
-  ruleListColumns?: COLUMN_TYPE[];
+  readonly ruleListColumns?: readonly COLUMN_TYPE[];
   /**
    * Rule property to split the rules list by.
    * A separate list and header will be created for each value.
    * Example: `meta.type`.
    */
-  ruleListSplit?: string;
+  readonly ruleListSplit?: string;
   /** Link to documentation about the ESLint configurations exported by the plugin. */
-  urlConfigs?: string;
+  readonly urlConfigs?: string;
   /**
    * Link to documentation for each rule.
    * Useful when it differs from the rule doc path on disk (e.g. custom documentation site in use).
    * Use `{name}` placeholder for the rule name.
    */
-  urlRuleDoc?: string;
+  readonly urlRuleDoc?: string;
 };

--- a/test/lib/cli-test.ts
+++ b/test/lib/cli-test.ts
@@ -32,7 +32,7 @@ const configFileOptionsAll: { [key in OPTION_TYPE]: unknown } = {
   urlRuleDoc: 'https://example.com/rule-doc-url-from-config-file',
 };
 
-const cliOptionsAll: { [key in OPTION_TYPE]: string[] } = {
+const cliOptionsAll: { [key in OPTION_TYPE]: readonly string[] } = {
   [OPTION_TYPE.CHECK]: ['--check'],
 
   [OPTION_TYPE.CONFIG_EMOJI]: ['--config-emoji', 'recommended-from-cli,🚲'],


### PR DESCRIPTION
Use TypeScript `readonly` keyword in many places. This prevents us from modifying certain properties/data, kind of like the ESLint [no-param-reassign](https://eslint.org/docs/latest/rules/no-param-reassign) rule. It's best practice to avoid modifying input data like user-provided options.

* Use `readonly` keyword on all internal array types
* Use `readonly` keyword on all our public `GenerateOptions` option types
* Perform a few minor refactorings to avoid mutating affected data

If using `readonly` ends up causing any issues, we can relax some of this later.

https://www.typescriptlang.org/docs/handbook/2/classes.html#readonly
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#a-new-syntax-for-readonlyarray