### PR TITLE
Fully utilize `readonly` modifier for nested array types

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -40,8 +40,8 @@ function collectCSV(
  * */
 function collectCSVNested(
   value: string,
-  previous: readonly string[][]
-): readonly string[][] {
+  previous: readonly (readonly string[])[]
+): readonly (readonly string[])[] {
   return [...previous, value.split(',')];
 }
 

--- a/lib/option-parsers.ts
+++ b/lib/option-parsers.ts
@@ -15,7 +15,7 @@ import type { Plugin, ConfigEmojis } from './types.js';
  */
 export function parseConfigEmojiOptions(
   plugin: Plugin,
-  configEmoji?: readonly string[][]
+  configEmoji?: readonly (readonly string[])[]
 ): ConfigEmojis {
   const configsSeen = new Set<string>();
   const configsWithDefaultEmojiRemoved: string[] = [];

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -115,7 +115,7 @@ export type GenerateOptions = {
    * Default emojis are provided for common configs.
    * To remove a default emoji and rely on a badge instead, provide the config name without an emoji.
    */
-  readonly configEmoji?: readonly string[][];
+  readonly configEmoji?: readonly (readonly string[])[];
   /** Configs to ignore from being displayed. Often used for an `all` config. */
   readonly ignoreConfig?: readonly string[];
   /** Whether to ignore deprecated rules from being checked, displayed, or updated. Default: `false`. */


### PR DESCRIPTION
Follow-up to #303.

Related: https://github.com/microsoft/TypeScript/issues/30755