### PR TITLE
Split `configs` rule doc notice into separate lines by severity

### DIFF
--- a/docs/examples/eslint-plugin-test/docs/rules/prefer-bar.md
+++ b/docs/examples/eslint-plugin-test/docs/rules/prefer-bar.md
@@ -1,6 +1,8 @@
 # Enforce using bar (`test/prefer-bar`)
 
-💼⚠️ This rule is enabled in the ✅ `recommended` config. This rule _warns_ in the 🎨 `stylistic` config.
+💼 This rule is enabled in the ✅ `recommended` config.
+
+⚠️ This rule _warns_ in the 🎨 `stylistic` config.
 
 💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 

--- a/lib/rule-doc-notices.ts
+++ b/lib/rule-doc-notices.ts
@@ -23,6 +23,7 @@ import { getLinkToRule, getUrlToRule } from './rule-link.js';
 import { toSentenceCase, removeTrailingPeriod } from './string.js';
 
 function severityToTerminology(severity: SEVERITY_TYPE) {
+  // Italics is used to draw attention to non-error severities since they are less common.
   switch (severity) {
     case SEVERITY_TYPE.error:
       return 'is enabled';
@@ -54,9 +55,9 @@ function configsToNoticeSentence(
   const term = severityToTerminology(severity);
   const sentence =
     configs.length > 1
-      ? `This rule ${term} in the following ${configsLinkOrWord}: ${csv}.`
+      ? `${EMOJI_CONFIG_FROM_SEVERITY[severity]} This rule ${term} in the following ${configsLinkOrWord}: ${csv}.`
       : configs.length === 1
-      ? `This rule ${term} in the ${csv} ${configLinkOrWord}.`
+      ? `${EMOJI_CONFIG_FROM_SEVERITY[severity]} This rule ${term} in the ${csv} ${configLinkOrWord}.`
       : undefined;
 
   return sentence;
@@ -115,18 +116,6 @@ const RULE_NOTICES: {
       );
     }
 
-    // Use the emoji(s) for the severity levels this rule is set to in various configs.
-    const emojis: string[] = [];
-    if (configsError.length > 0) {
-      emojis.push(EMOJI_CONFIG_FROM_SEVERITY[SEVERITY_TYPE.error]);
-    }
-    if (configsWarn.length > 0) {
-      emojis.push(EMOJI_CONFIG_FROM_SEVERITY[SEVERITY_TYPE.warn]);
-    }
-    if (configsOff.length > 0) {
-      emojis.push(EMOJI_CONFIG_FROM_SEVERITY[SEVERITY_TYPE.off]);
-    }
-
     const sentences = [
       configsToNoticeSentence(
         configsError,
@@ -151,9 +140,9 @@ const RULE_NOTICES: {
       ),
     ]
       .filter(Boolean)
-      .join(' ');
+      .join('\n\n');
 
-    return `${emojis.join('')} ${sentences}`;
+    return sentences;
   },
 
   // Deprecated notice has optional "replaced by" rules list.

--- a/test/lib/generate/__snapshots__/configs-test.ts.snap
+++ b/test/lib/generate/__snapshots__/configs-test.ts.snap
@@ -114,7 +114,9 @@ exports[`generate (configs) rules that are disabled or set to warn generates the
 exports[`generate (configs) rules that are disabled or set to warn generates the documentation 4`] = `
 "# Description of no-baz (\`test/no-baz\`)
 
-💼🚫 This rule is enabled in the ✅ \`recommended\` config. This rule is _disabled_ in the \`other\` config.
+💼 This rule is enabled in the ✅ \`recommended\` config.
+
+🚫 This rule is _disabled_ in the \`other\` config.
 
 <!-- end auto-generated rule header -->
 "
@@ -211,7 +213,9 @@ exports[`generate (configs) rules that are disabled or set to warn, two configs 
 exports[`generate (configs) rules that are disabled or set to warn, two configs present generates the documentation 2`] = `
 "# Description of no-foo (\`test/no-foo\`)
 
-⚠️🚫 This rule _warns_ in the ✅ \`recommended\` config. This rule is _disabled_ in the ⌨️ \`typescript\` config.
+⚠️ This rule _warns_ in the ✅ \`recommended\` config.
+
+🚫 This rule is _disabled_ in the ⌨️ \`typescript\` config.
 
 <!-- end auto-generated rule header -->
 "


### PR DESCRIPTION
Split onto separate lines for clarity. A rule that is enabled/disabled/warn by multiple configs is a relatively uncommon situation to begin with.

Fixes #310.

**Before:**

💼🚫 This rule is enabled in the ✅ \`recommended\` config. This rule is _disabled_ in the \`other\` config.

**After:**

⚠️ This rule _warns_ in the ✅ \`recommended\` config.

🚫 This rule is _disabled_ in the ⌨️ \`typescript\` config.
