### PR TITLE
Avoid recreating read-only array when passing to markdown-table

### DIFF
--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -189,8 +189,8 @@ function generateRulesListMarkdown(
   return markdownTable(
     [
       listHeaderRow,
-      ...details.map((rule: RuleDetails) => [
-        ...buildRuleRow(
+      ...details.map((rule: RuleDetails) =>
+        buildRuleRow(
           columns,
           rule,
           configsToRules,
@@ -201,8 +201,8 @@ function generateRulesListMarkdown(
           configEmojis,
           ignoreConfig,
           urlRuleDoc
-        ),
-      ]),
+        )
+      ),
     ],
     { align: 'l' } // Left-align headers.
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "cosmiconfig": "^8.0.0",
         "deepmerge": "^4.2.2",
         "jest-diff": "^29.2.1",
-        "markdown-table": "^3.0.2",
+        "markdown-table": "^3.0.3",
         "type-fest": "^3.0.0"
       },
       "bin": {
@@ -8559,9 +8559,9 @@
       }
     },
     "node_modules/markdown-table": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.2.tgz",
-      "integrity": "sha512-y8j3a5/DkJCmS5x4dMCQL+OR0+2EAq3DOtio1COSHsmW2BGXnNCK3v12hJt1LrUz5iZH5g0LmuYOjDdI+czghA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz",
+      "integrity": "sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -20010,9 +20010,9 @@
       }
     },
     "markdown-table": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.2.tgz",
-      "integrity": "sha512-y8j3a5/DkJCmS5x4dMCQL+OR0+2EAq3DOtio1COSHsmW2BGXnNCK3v12hJt1LrUz5iZH5g0LmuYOjDdI+czghA=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz",
+      "integrity": "sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw=="
     },
     "markdownlint": {
       "version": "0.26.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cosmiconfig": "^8.0.0",
     "deepmerge": "^4.2.2",
     "jest-diff": "^29.2.1",
-    "markdown-table": "^3.0.2",
+    "markdown-table": "^3.0.3",
     "type-fest": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
We no longer need to recreate the read-only array with `[...arr]` to get a normal array to pass to markdown-table.

This is possible thanks to the bug fix I submitted in https://github.com/wooorm/markdown-table/pull/30.

https://github.com/wooorm/markdown-table/releases/tag/3.0.3