### PR TITLE
Handle additional types of variable casing when creating sub-list headers with `--rule-list-split`

### DIFF
--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -26,7 +26,8 @@ import type {
 import { EMOJIS_TYPE, RULE_TYPE } from './rule-type.js';
 import { hasOptions } from './rule-options.js';
 import { getLinkToRule } from './rule-link.js';
-import { camelCaseStringToTitle, isCamelCase } from './string.js';
+import { capitalizeOnlyFirstLetter } from './string.js';
+import { noCase } from 'no-case';
 import { getProperty } from 'dot-prop';
 
 function getPropertyFromRule(
@@ -276,15 +277,12 @@ function generateRulesListMarkdownWithRuleListSplit(
 
     // Turn ruleListSplit into a title.
     // E.g. meta.docs.requiresTypeChecking to "Requires Type Checking".
-    // TODO: handle other types of variable casing.
     const ruleListSplitParts = ruleListSplit.split('.');
     const ruleListSplitFinalPart =
       ruleListSplitParts[ruleListSplitParts.length - 1];
-    const ruleListSplitTitle = isCamelCase(ruleListSplitFinalPart)
-      ? camelCaseStringToTitle(
-          ruleListSplitParts[ruleListSplitParts.length - 1]
-        )
-      : ruleListSplitFinalPart;
+    const ruleListSplitTitle = noCase(ruleListSplitFinalPart, {
+      transform: (str) => capitalizeOnlyFirstLetter(str),
+    });
 
     parts.push(
       `${'#'.repeat(headerLevel)} ${

--- a/lib/string.ts
+++ b/lib/string.ts
@@ -1,5 +1,3 @@
-import camelCase from 'camelcase';
-
 export function countOccurrencesInString(str: string, substring: string) {
   return str.split(substring).length - 1;
 }
@@ -15,13 +13,8 @@ export function removeTrailingPeriod(str: string) {
 }
 
 /**
- * Example: theWeatherIsNice => The Weather Is Nice
+ * Example: FOO => Foo, foo => Foo
  */
-export function camelCaseStringToTitle(str: string) {
-  const text = str.replace(/([A-Z])/gu, ' $1');
-  return text.charAt(0).toUpperCase() + text.slice(1);
-}
-
-export function isCamelCase(str: string) {
-  return camelCase(str) === str;
+export function capitalizeOnlyFirstLetter(str: string) {
+  return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "dot-prop": "^7.2.0",
         "jest-diff": "^29.2.1",
         "markdown-table": "^3.0.3",
+        "no-case": "^3.0.4",
         "type-fest": "^3.0.0"
       },
       "bin": {
@@ -8427,7 +8428,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
       "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.0.3"
       }
@@ -9615,7 +9615,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
       "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dev": true,
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
@@ -12848,8 +12847,7 @@
     "node_modules/tslib": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
-      "dev": true
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -19928,7 +19926,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
       "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dev": true,
       "requires": {
         "tslib": "^2.0.3"
       }
@@ -20743,7 +20740,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
       "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dev": true,
       "requires": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
@@ -23144,8 +23140,7 @@
     "tslib": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
-      "dev": true
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -47,13 +47,13 @@
   "dependencies": {
     "@typescript-eslint/utils": "^5.38.1",
     "ajv": "^8.11.2",
-    "camelcase": "^7.0.0",
     "commander": "^9.4.0",
     "cosmiconfig": "^8.0.0",
     "deepmerge": "^4.2.2",
     "dot-prop": "^7.2.0",
     "jest-diff": "^29.2.1",
     "markdown-table": "^3.0.3",
+    "no-case": "^3.0.4",
     "type-fest": "^3.0.0"
   },
   "devDependencies": {

--- a/test/lib/generate/__snapshots__/option-rule-list-split-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-rule-list-split-test.ts.snap
@@ -49,7 +49,7 @@ exports[`generate (--rule-list-split) by type splits the list 1`] = `
 "
 `;
 
-exports[`generate (--rule-list-split) ignores case splits the list 1`] = `
+exports[`generate (--rule-list-split) ignores case when sorting headers splits the list 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->
 
@@ -75,7 +75,45 @@ exports[`generate (--rule-list-split) ignores case splits the list 1`] = `
 "
 `;
 
-exports[`generate (--rule-list-split) with boolean splits the list 1`] = `
+exports[`generate (--rule-list-split) with boolean (CONSTANT_CASE) splits the list with the right header 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+| Name                           |
+| :----------------------------- |
+| [no-bar](docs/rules/no-bar.md) |
+| [no-baz](docs/rules/no-baz.md) |
+
+### Hello World
+
+| Name                           |
+| :----------------------------- |
+| [no-foo](docs/rules/no-foo.md) |
+
+<!-- end auto-generated rules list -->
+"
+`;
+
+exports[`generate (--rule-list-split) with boolean (PascalCase) splits the list with the right header 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+| Name                           |
+| :----------------------------- |
+| [no-bar](docs/rules/no-bar.md) |
+| [no-baz](docs/rules/no-baz.md) |
+
+### Hello World
+
+| Name                           |
+| :----------------------------- |
+| [no-foo](docs/rules/no-foo.md) |
+
+<!-- end auto-generated rules list -->
+"
+`;
+
+exports[`generate (--rule-list-split) with boolean (camelCase) splits the list with the right header 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->
 
@@ -91,6 +129,43 @@ exports[`generate (--rule-list-split) with boolean splits the list 1`] = `
 | Name                           | 💡 |
 | :----------------------------- | :- |
 | [no-foo](docs/rules/no-foo.md) | 💡 |
+
+<!-- end auto-generated rules list -->
+"
+`;
+
+exports[`generate (--rule-list-split) with boolean (snake_case) splits the list with the right header 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+| Name                           |
+| :----------------------------- |
+| [no-bar](docs/rules/no-bar.md) |
+| [no-baz](docs/rules/no-baz.md) |
+
+### Hello World
+
+| Name                           |
+| :----------------------------- |
+| [no-foo](docs/rules/no-foo.md) |
+
+<!-- end auto-generated rules list -->
+"
+`;
+
+exports[`generate (--rule-list-split) with boolean (unknown variable type) splits the list and does the best it can with the header 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+| Name                           |
+| :----------------------------- |
+| [no-foo](docs/rules/no-foo.md) |
+
+### Foo Bar Biz Baz3b Oz
+
+| Name                           |
+| :----------------------------- |
+| [no-bar](docs/rules/no-bar.md) |
 
 <!-- end auto-generated rules list -->
 "
@@ -162,22 +237,4 @@ exports[`generate (--rule-list-split) with only a title in the rules file uses t
 | [no-foo](docs/rules/no-foo.md) |
 
 <!-- end auto-generated rules list -->"
-`;
-
-exports[`generate (--rule-list-split) with unknown variable type splits the list but does not attempt to convert variable name to title 1`] = `
-"## Rules
-<!-- begin auto-generated rules list -->
-
-| Name                           |
-| :----------------------------- |
-| [no-foo](docs/rules/no-foo.md) |
-
-### foo_barBIZ-baz3bOz
-
-| Name                           |
-| :----------------------------- |
-| [no-bar](docs/rules/no-bar.md) |
-
-<!-- end auto-generated rules list -->
-"
 `;

--- a/test/lib/generate/option-rule-list-split-test.ts
+++ b/test/lib/generate/option-rule-list-split-test.ts
@@ -133,7 +133,7 @@ describe('generate (--rule-list-split)', function () {
     });
   });
 
-  describe('with boolean', function () {
+  describe('with boolean (camelCase)', function () {
     beforeEach(function () {
       mockFs({
         'package.json': JSON.stringify({
@@ -143,13 +143,13 @@ describe('generate (--rule-list-split)', function () {
         }),
 
         'index.js': `
-              export default {
-                rules: {
-                  'no-foo': { meta: { hasSuggestions: true }, create(context) {} },
-                  'no-bar': { meta: {  }, create(context) {} },
-                  'no-baz': { meta: { hasSuggestions: false }, create(context) {} },
-                },
-              };`,
+          export default {
+            rules: {
+              'no-foo': { meta: { hasSuggestions: true }, create(context) {} },
+              'no-bar': { meta: {  }, create(context) {} },
+              'no-baz': { meta: { hasSuggestions: false }, create(context) {} },
+            },
+          };`,
 
         'README.md': '## Rules\n',
 
@@ -167,9 +167,175 @@ describe('generate (--rule-list-split)', function () {
       jest.resetModules();
     });
 
-    it('splits the list', async function () {
+    it('splits the list with the right header', async function () {
       await generate('.', {
         ruleListSplit: 'meta.hasSuggestions',
+      });
+      expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
+    });
+  });
+
+  describe('with boolean (snake_case)', function () {
+    beforeEach(function () {
+      mockFs({
+        'package.json': JSON.stringify({
+          name: 'eslint-plugin-test',
+          exports: 'index.js',
+          type: 'module',
+        }),
+
+        'index.js': `
+          export default {
+            rules: {
+              'no-foo': { meta: { hello_world: true }, create(context) {} },
+              'no-bar': { meta: {  }, create(context) {} },
+              'no-baz': { meta: { hello_world: false }, create(context) {} },
+            },
+          };`,
+
+        'README.md': '## Rules\n',
+
+        'docs/rules/no-foo.md': '',
+        'docs/rules/no-bar.md': '',
+        'docs/rules/no-baz.md': '',
+
+        // Needed for some of the test infrastructure to work.
+        node_modules: mockFs.load(PATH_NODE_MODULES),
+      });
+    });
+
+    afterEach(function () {
+      mockFs.restore();
+      jest.resetModules();
+    });
+
+    it('splits the list with the right header', async function () {
+      await generate('.', {
+        ruleListSplit: 'meta.hello_world',
+      });
+      expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
+    });
+  });
+
+  describe('with boolean (PascalCase)', function () {
+    beforeEach(function () {
+      mockFs({
+        'package.json': JSON.stringify({
+          name: 'eslint-plugin-test',
+          exports: 'index.js',
+          type: 'module',
+        }),
+
+        'index.js': `
+          export default {
+            rules: {
+              'no-foo': { meta: { HelloWorld: true }, create(context) {} },
+              'no-bar': { meta: {  }, create(context) {} },
+              'no-baz': { meta: { HelloWorld: false }, create(context) {} },
+            },
+          };`,
+
+        'README.md': '## Rules\n',
+
+        'docs/rules/no-foo.md': '',
+        'docs/rules/no-bar.md': '',
+        'docs/rules/no-baz.md': '',
+
+        // Needed for some of the test infrastructure to work.
+        node_modules: mockFs.load(PATH_NODE_MODULES),
+      });
+    });
+
+    afterEach(function () {
+      mockFs.restore();
+      jest.resetModules();
+    });
+
+    it('splits the list with the right header', async function () {
+      await generate('.', {
+        ruleListSplit: 'meta.HelloWorld',
+      });
+      expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
+    });
+  });
+
+  describe('with boolean (CONSTANT_CASE)', function () {
+    beforeEach(function () {
+      mockFs({
+        'package.json': JSON.stringify({
+          name: 'eslint-plugin-test',
+          exports: 'index.js',
+          type: 'module',
+        }),
+
+        'index.js': `
+          export default {
+            rules: {
+              'no-foo': { meta: { HELLO_WORLD: true }, create(context) {} },
+              'no-bar': { meta: {  }, create(context) {} },
+              'no-baz': { meta: { HELLO_WORLD: false }, create(context) {} },
+            },
+          };`,
+
+        'README.md': '## Rules\n',
+
+        'docs/rules/no-foo.md': '',
+        'docs/rules/no-bar.md': '',
+        'docs/rules/no-baz.md': '',
+
+        // Needed for some of the test infrastructure to work.
+        node_modules: mockFs.load(PATH_NODE_MODULES),
+      });
+    });
+
+    afterEach(function () {
+      mockFs.restore();
+      jest.resetModules();
+    });
+
+    it('splits the list with the right header', async function () {
+      await generate('.', {
+        ruleListSplit: 'meta.HELLO_WORLD',
+      });
+      expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
+    });
+  });
+
+  describe('with boolean (unknown variable type)', function () {
+    beforeEach(function () {
+      mockFs({
+        'package.json': JSON.stringify({
+          name: 'eslint-plugin-test',
+          exports: 'index.js',
+          type: 'module',
+        }),
+
+        'index.js': `
+          export default {
+            rules: {
+              'no-foo': { 'foo_barBIZ-baz3bOz': false, meta: { }, create(context) {} },
+              'no-bar': { 'foo_barBIZ-baz3bOz': true, meta: { }, create(context) {} },
+            },
+          };`,
+
+        'README.md': '## Rules\n',
+
+        'docs/rules/no-foo.md': '',
+        'docs/rules/no-bar.md': '',
+
+        // Needed for some of the test infrastructure to work.
+        node_modules: mockFs.load(PATH_NODE_MODULES),
+      });
+    });
+
+    afterEach(function () {
+      mockFs.restore();
+      jest.resetModules();
+    });
+
+    it('splits the list and does the best it can with the header', async function () {
+      await generate('.', {
+        ruleListSplit: 'foo_barBIZ-baz3bOz',
       });
       expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
     });
@@ -257,7 +423,7 @@ describe('generate (--rule-list-split)', function () {
     });
   });
 
-  describe('ignores case', function () {
+  describe('ignores case when sorting headers', function () {
     beforeEach(function () {
       mockFs({
         'package.json': JSON.stringify({
@@ -294,46 +460,6 @@ describe('generate (--rule-list-split)', function () {
     it('splits the list', async function () {
       await generate('.', {
         ruleListSplit: 'meta.foo',
-      });
-      expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
-    });
-  });
-
-  describe('with unknown variable type', function () {
-    beforeEach(function () {
-      mockFs({
-        'package.json': JSON.stringify({
-          name: 'eslint-plugin-test',
-          exports: 'index.js',
-          type: 'module',
-        }),
-
-        'index.js': `
-              export default {
-                rules: {
-                  'no-foo': { 'foo_barBIZ-baz3bOz': false, meta: { }, create(context) {} },
-                  'no-bar': { 'foo_barBIZ-baz3bOz': true, meta: { }, create(context) {} },
-                },
-              };`,
-
-        'README.md': '## Rules\n',
-
-        'docs/rules/no-foo.md': '',
-        'docs/rules/no-bar.md': '',
-
-        // Needed for some of the test infrastructure to work.
-        node_modules: mockFs.load(PATH_NODE_MODULES),
-      });
-    });
-
-    afterEach(function () {
-      mockFs.restore();
-      jest.resetModules();
-    });
-
-    it('splits the list but does not attempt to convert variable name to title', async function () {
-      await generate('.', {
-        ruleListSplit: 'foo_barBIZ-baz3bOz',
       });
       expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
     });


### PR DESCRIPTION
Any of these properties could be passed to `--rule-list-split` for splitting the rules list:

* `meta.docs.helloWorld`
* `meta.docs.hello_world`
* `meta.docs.HELLO_WORLD`
* `meta.docs.HelloWorld`

And we will still generate the same sub-list header `Hello World` now.

Previously, we only supported camelCase.

For this, we switched from [camelcase](https://www.npmjs.com/package/camelcase) to [no-case](https://www.npmjs.com/package/no-case).