### PR TITLE
Use external library to retrieve arbitrary properties from rule

### DIFF
--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -27,6 +27,7 @@ import { EMOJIS_TYPE, RULE_TYPE } from './rule-type.js';
 import { hasOptions } from './rule-options.js';
 import { getLinkToRule } from './rule-link.js';
 import { camelCaseStringToTitle, isCamelCase } from './string.js';
+import { getProperty } from 'dot-prop';
 
 function getPropertyFromRule(
   plugin: Plugin,
@@ -41,18 +42,7 @@ function getPropertyFromRule(
   }
 
   const rule = plugin.rules[ruleName];
-
-  // Loop through all the nested property parts.
-  const parts = property.split('.');
-  // @ts-expect-error - Could be non-standard property on a function-style or object-style rule.
-  let result = rule[parts[0]];
-  for (const part of parts.slice(1)) {
-    if (typeof result !== 'object') {
-      return undefined; // eslint-disable-line unicorn/no-useless-undefined -- Rule doesn't have this property.
-    }
-    result = result[part];
-  }
-  return result;
+  return getProperty(rule, property) as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- This could be any type, not just undefined (https://github.com/sindresorhus/dot-prop/issues/95).
 }
 
 function getConfigurationColumnValueForRule(

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "commander": "^9.4.0",
         "cosmiconfig": "^8.0.0",
         "deepmerge": "^4.2.2",
+        "dot-prop": "^7.2.0",
         "jest-diff": "^29.2.1",
         "markdown-table": "^3.0.3",
         "type-fest": "^3.0.0"
@@ -4025,6 +4026,21 @@
         "url": "https://github.com/yeoman/configstore?sponsor=1"
       }
     },
+    "node_modules/configstore/node_modules/dot-prop": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+      "dev": true,
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/configstore/node_modules/write-file-atomic": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
@@ -4406,15 +4422,25 @@
       }
     },
     "node_modules/dot-prop": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
-      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
-      "dev": true,
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-7.2.0.tgz",
+      "integrity": "sha512-Ol/IPXUARn9CSbkrdV4VJo7uCy1I3VuSiWCaFSg+8BdUOzF9n3jefIpcgAydvUZbTdEBZs2vEiTiS9m61ssiDA==",
       "dependencies": {
-        "is-obj": "^2.0.0"
+        "type-fest": "^2.11.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dot-prop/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -16629,6 +16655,15 @@
         "xdg-basedir": "^5.0.1"
       },
       "dependencies": {
+        "dot-prop": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+          "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+          "dev": true,
+          "requires": {
+            "is-obj": "^2.0.0"
+          }
+        },
         "write-file-atomic": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
@@ -16906,12 +16941,18 @@
       }
     },
     "dot-prop": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
-      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
-      "dev": true,
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-7.2.0.tgz",
+      "integrity": "sha512-Ol/IPXUARn9CSbkrdV4VJo7uCy1I3VuSiWCaFSg+8BdUOzF9n3jefIpcgAydvUZbTdEBZs2vEiTiS9m61ssiDA==",
       "requires": {
-        "is-obj": "^2.0.0"
+        "type-fest": "^2.11.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "eastasianwidth": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "commander": "^9.4.0",
     "cosmiconfig": "^8.0.0",
     "deepmerge": "^4.2.2",
+    "dot-prop": "^7.2.0",
     "jest-diff": "^29.2.1",
     "markdown-table": "^3.0.3",
     "type-fest": "^3.0.0"


### PR DESCRIPTION
This is mostly an internal refactoring and shouldn't result in behavior changes.

We need to get a property (e.g. `meta.docs.category`) from a rule. Previously, we had our own looping logic for this.

Now, we use [dot-prop](https://www.npmjs.com/package/dot-prop). There were a number of external libraries to choose from for this but this seemed like one of the most popular.