### PR TITLE
More robust handling of boolean-equivalent strings for parsing boolean CLI options or boolean properties in `--rule-list-split`

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -11,6 +11,7 @@ import {
   OPTION_TYPE,
 } from './types.js';
 import { getCurrentPackageVersion } from './package-json.js';
+import { boolean, isBooleanable } from 'boolean';
 
 /**
  * Used for collecting repeated CLI options into an array.
@@ -46,7 +47,7 @@ function collectCSVNested(
 }
 
 function parseBoolean(value: string | undefined): boolean {
-  return ['true', undefined].includes(value);
+  return value === undefined || (isBooleanable(value) && boolean(value));
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@typescript-eslint/utils": "^5.38.1",
         "ajv": "^8.11.2",
-        "camelcase": "^7.0.0",
+        "boolean": "^3.2.0",
         "commander": "^9.4.0",
         "cosmiconfig": "^8.0.0",
         "deepmerge": "^4.2.2",
@@ -2657,6 +2657,11 @@
       "integrity": "sha512-kXQ19Xhoghiyw66CUiGypnuRpWlbHAzY/+NyvqTEdTfhfQGH1/dbEMYiXju7fYKIFePpzp/y9dsu5Cu/PkmawQ==",
       "dev": true
     },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="
+    },
     "node_modules/boxen": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.0.0.tgz",
@@ -3579,6 +3584,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.0.tgz",
       "integrity": "sha512-JToIvOmz6nhGsUhAYScbo2d6Py5wojjNfoxoc2mEVLUdJ70gJK2gnd+ABY1Tc3sVMyK7QDPtN0T/XdlCQWITyQ==",
+      "dev": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -15569,6 +15575,11 @@
       "integrity": "sha512-kXQ19Xhoghiyw66CUiGypnuRpWlbHAzY/+NyvqTEdTfhfQGH1/dbEMYiXju7fYKIFePpzp/y9dsu5Cu/PkmawQ==",
       "dev": true
     },
+    "boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="
+    },
     "boxen": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.0.0.tgz",
@@ -16324,7 +16335,8 @@
     "camelcase": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.0.tgz",
-      "integrity": "sha512-JToIvOmz6nhGsUhAYScbo2d6Py5wojjNfoxoc2mEVLUdJ70gJK2gnd+ABY1Tc3sVMyK7QDPtN0T/XdlCQWITyQ=="
+      "integrity": "sha512-JToIvOmz6nhGsUhAYScbo2d6Py5wojjNfoxoc2mEVLUdJ70gJK2gnd+ABY1Tc3sVMyK7QDPtN0T/XdlCQWITyQ==",
+      "dev": true
     },
     "camelcase-keys": {
       "version": "6.2.2",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@typescript-eslint/utils": "^5.38.1",
     "ajv": "^8.11.2",
+    "boolean": "^3.2.0",
     "commander": "^9.4.0",
     "cosmiconfig": "^8.0.0",
     "deepmerge": "^4.2.2",

--- a/test/lib/generate/__snapshots__/option-rule-list-split-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-rule-list-split-test.ts.snap
@@ -171,6 +171,34 @@ exports[`generate (--rule-list-split) with boolean (unknown variable type) split
 "
 `;
 
+exports[`generate (--rule-list-split) with boolean (various boolean equivalent values) splits the list 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+| Name                                         |
+| :------------------------------------------- |
+| [no](docs/rules/no.md)                       |
+| [noEmptyString](docs/rules/noEmptyString.md) |
+| [noFalse](docs/rules/noFalse.md)             |
+| [noFalseString](docs/rules/noFalseString.md) |
+| [noNo](docs/rules/noNo.md)                   |
+| [noNull](docs/rules/noNull.md)               |
+| [noOff](docs/rules/noOff.md)                 |
+| [noUndefined](docs/rules/noUndefined.md)     |
+
+### Foo
+
+| Name                                       |
+| :----------------------------------------- |
+| [noOn](docs/rules/noOn.md)                 |
+| [noTrue](docs/rules/noTrue.md)             |
+| [noTrueString](docs/rules/noTrueString.md) |
+| [noYes](docs/rules/noYes.md)               |
+
+<!-- end auto-generated rules list -->
+"
+`;
+
 exports[`generate (--rule-list-split) with no existing headers in file uses the proper sub-list header level 1`] = `
 "<!-- begin auto-generated rules list -->
 

--- a/test/lib/generate/option-rule-list-split-test.ts
+++ b/test/lib/generate/option-rule-list-split-test.ts
@@ -341,6 +341,72 @@ describe('generate (--rule-list-split)', function () {
     });
   });
 
+  describe('with boolean (various boolean equivalent values)', function () {
+    beforeEach(function () {
+      mockFs({
+        'package.json': JSON.stringify({
+          name: 'eslint-plugin-test',
+          exports: 'index.js',
+          type: 'module',
+        }),
+
+        'index.js': `
+          export default {
+            rules: {
+              // true
+              'noOn': { meta: { foo: 'on' }, create(context) {} },
+              'noYes': { meta: { foo: 'yes' }, create(context) {} },
+              'noTrueString': { meta: { foo: 'true' }, create(context) {} },
+              'noTrue': { meta: { foo: true }, create(context) {} },
+
+              // false
+              'no': { meta: {  }, create(context) {} },
+              'noUndefined': { meta: { foo: undefined }, create(context) {} },
+              'noOff': { meta: { foo: 'off' }, create(context) {} },
+              'noNo': { meta: { foo: 'no' }, create(context) {} },
+              'noFalseString': { meta: { foo: 'false' }, create(context) {} },
+              'noFalse': { meta: { foo: false }, create(context) {} },
+              'noNull': { meta: { foo: null }, create(context) {} },
+              'noEmptyString': { meta: { foo: '' }, create(context) {} },
+            },
+          };`,
+
+        'README.md': '## Rules\n',
+
+        // true
+        'docs/rules/noOn.md': '',
+        'docs/rules/noYes.md': '',
+        'docs/rules/noTrueString.md': '',
+        'docs/rules/noTrue.md': '',
+
+        // false
+        'docs/rules/no.md': '',
+        'docs/rules/noUndefined.md': '',
+        'docs/rules/noOff.md': '',
+        'docs/rules/noNo.md': '',
+        'docs/rules/noFalseString.md': '',
+        'docs/rules/noFalse.md': '',
+        'docs/rules/noNull.md': '',
+        'docs/rules/noEmptyString.md': '',
+
+        // Needed for some of the test infrastructure to work.
+        node_modules: mockFs.load(PATH_NODE_MODULES),
+      });
+    });
+
+    afterEach(function () {
+      mockFs.restore();
+      jest.resetModules();
+    });
+
+    it('splits the list', async function () {
+      await generate('.', {
+        ruleListSplit: 'meta.foo',
+      });
+      expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
+    });
+  });
+
   describe('with no existing headers in file', function () {
     beforeEach(function () {
       mockFs({


### PR DESCRIPTION
Use the [boolean](https://www.npmjs.com/package/boolean) library to handle more types of boolean-equivalent strings like `'true'`, `'on`', `'no'`, etc. Useful when we're determining how to split the rules list with `--rule-list-split` or parsing boolean CLI options like `--check yes`. 