### PR TITLE
Use string union types instead of enums for better TypeScript compatibility with config file type

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -143,7 +143,7 @@ export type GenerateOptions = {
    * Choices: `configs`, `deprecated`, `fixable` (off by default), `fixableAndHasSuggestions`, `hasSuggestions` (off by default), `options` (off by default), `requiresTypeChecking`, `type` (off by default).
    * Default: `['deprecated', 'configs', 'fixableAndHasSuggestions', 'requiresTypeChecking']`.
    */
-  readonly ruleDocNotices?: readonly NOTICE_TYPE[];
+  readonly ruleDocNotices?: readonly `${NOTICE_TYPE}`[];
   /** Disallowed sections in each rule doc. Exit with failure if present. */
   readonly ruleDocSectionExclude?: readonly string[];
   /** Required sections in each rule doc. Exit with failure if missing. */
@@ -158,7 +158,7 @@ export type GenerateOptions = {
    * Choices: `configsError`, `configsOff`, `configsWarn`, `deprecated`, `description`, `fixable`, `fixableAndHasSuggestions` (off by default), `hasSuggestions`, `name`, `options` (off by default), `requiresTypeChecking`, `type` (off by default).
    * Default: `['name', 'description', 'configsError', 'configsWarn', 'configsOff', 'fixable', 'hasSuggestions', 'requiresTypeChecking', 'deprecated']`.
    */
-  readonly ruleListColumns?: readonly COLUMN_TYPE[];
+  readonly ruleListColumns?: readonly `${COLUMN_TYPE}`[];
   /**
    * Rule property to split the rules list by.
    * A separate list and header will be created for each value.

--- a/test/lib/generate/option-rule-doc-notices-test.ts
+++ b/test/lib/generate/option-rule-doc-notices-test.ts
@@ -174,9 +174,7 @@ describe('generate (--rule-doc-notices)', function () {
     it('has no issues', async function () {
       await expect(
         generate('.', {
-          // @ts-expect-error -- testing string value instead of enum
           ruleDocNotices: ['type'],
-          // @ts-expect-error -- testing string value instead of enum
           ruleListColumns: ['name'],
         })
       ).resolves.toBeUndefined();


### PR DESCRIPTION
This allows the user to use either the enums (available in ESM / when using this type internally) or just the plain string values (especially in CJS config files) without encountering TypeScript errors.

Fixes #321.

Website that suggests this solution: https://bobbyhadz.com/blog/typescript-convert-enum-to-union

