### PR TITLE
Hide stack trace when throwing exception

### DIFF
--- a/bin/eslint-doc-generator.ts
+++ b/bin/eslint-doc-generator.ts
@@ -4,11 +4,10 @@
 import { run } from '../lib/cli.js';
 import { generate } from '../lib/generator.js';
 
-try {
-  run(process.argv, (path, options) => generate(path, options));
-} catch (error) {
+// eslint-disable-next-line unicorn/prefer-top-level-await -- TODO: use top-level await once updating TypeScript target to ES2022 (when dropping Node 14 support).
+run(process.argv, (path, options) => generate(path, options)).catch((error) => {
   if (error instanceof Error) {
     console.error(error.message);
   }
   process.exitCode = 1;
-}
+});


### PR DESCRIPTION
Caught this bug with https://typescript-eslint.io/rules/no-floating-promises/

The try-catch wasn't working before.

We don't need to show the entire stack trace to end-users, just the error message from the exception.