### PR TITLE
Support splitting by multiple properties in `--rule-list-split` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ There's also a `postprocess` option that's only available via a [config file](#c
 | `--rule-doc-section-options` | Whether to require an "Options" or "Config" rule doc section and mention of any named options for rules with options. Default: `true`. |
 | `--rule-doc-title-format` | The format to use for rule doc titles. Defaults to `desc-parens-prefix-name`. See choices in below [table](#--rule-doc-title-format). |
 | `--rule-list-columns` | Ordered, comma-separated list of columns to display in rule list. Empty columns will be hidden. See choices in below [table](#column-and-notice-types). Default: `name,description,configsError,configsWarn,configsOff,fixable,hasSuggestions,requiresTypeChecking,deprecated`. |
-| `--rule-list-split` | Rule property to split the rules list by. A separate list and header will be created for each value. Example: `meta.type`. |
+| `--rule-list-split` | Rule property(s) to split the rules list by. A separate list and header will be created for each value. Example: `meta.type`. |
 | `--url-configs` | Link to documentation about the ESLint configurations exported by the plugin. |
 | `--url-rule-doc` | Link to documentation for each rule. Useful when it differs from the rule doc path on disk (e.g. custom documentation site in use). Use `{name}` placeholder for the rule name. |
 

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -105,7 +105,7 @@ async function loadConfigFileOptions(): Promise<GenerateOptions> {
       ruleDocSectionOptions: { type: 'boolean' },
       ruleDocTitleFormat: { type: 'string' },
       ruleListColumns: schemaStringArray,
-      ruleListSplit: { type: 'string' },
+      ruleListSplit: { anyOf: [{ type: 'string' }, schemaStringArray] },
       urlConfigs: { type: 'string' },
       urlRuleDoc: { type: 'string' },
     };
@@ -139,6 +139,10 @@ async function loadConfigFileOptions(): Promise<GenerateOptions> {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     if (typeof config.pathRuleList === 'string') {
       config.pathRuleList = [config.pathRuleList]; // eslint-disable-line @typescript-eslint/no-unsafe-member-access
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    if (typeof config.ruleListSplit === 'string') {
+      config.ruleListSplit = [config.ruleListSplit]; // eslint-disable-line @typescript-eslint/no-unsafe-member-access
     }
 
     return explorerResults.config as GenerateOptions;
@@ -260,7 +264,9 @@ export async function run(
     )
     .option(
       '--rule-list-split <property>',
-      '(optional) Rule property to split the rules list by. A separate list and header will be created for each value. Example: `meta.type`.'
+      '(optional) Rule property(s) to split the rules list by. A separate list and header will be created for each value. Example: `meta.type`.',
+      collectCSV,
+      []
     )
     .option(
       '--url-configs <url>',

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -156,8 +156,10 @@ export async function generate(path: string, options?: GenerateOptions) {
     options?.ruleDocTitleFormat ??
     OPTION_DEFAULTS[OPTION_TYPE.RULE_DOC_TITLE_FORMAT];
   const ruleListColumns = parseRuleListColumnsOption(options?.ruleListColumns);
-  const ruleListSplit =
-    options?.ruleListSplit ?? OPTION_DEFAULTS[OPTION_TYPE.RULE_LIST_SPLIT];
+  const ruleListSplit = stringOrArrayToArrayWithFallback(
+    options?.ruleListSplit,
+    OPTION_DEFAULTS[OPTION_TYPE.RULE_LIST_SPLIT]
+  );
   const urlConfigs =
     options?.urlConfigs ?? OPTION_DEFAULTS[OPTION_TYPE.URL_CONFIGS];
   const urlRuleDoc =

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -63,7 +63,7 @@ export const OPTION_DEFAULTS = {
   )
     .filter(([_col, enabled]) => enabled)
     .map(([col]) => col),
-  [OPTION_TYPE.RULE_LIST_SPLIT]: undefined,
+  [OPTION_TYPE.RULE_LIST_SPLIT]: [],
   [OPTION_TYPE.URL_CONFIGS]: undefined,
   [OPTION_TYPE.URL_RULE_DOC]: undefined,
 } satisfies Record<OPTION_TYPE, unknown>; // Satisfies is used to ensure all options are included, but without losing type information.

--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -220,10 +220,7 @@ function generateRulesListMarkdown(
 }
 
 type RulesAndHeaders = { header?: string; rules: RuleNamesAndRules }[];
-type RulesAndHeadersReadOnly = readonly {
-  header?: string;
-  rules: RuleNamesAndRules;
-}[];
+type RulesAndHeadersReadOnly = Readonly<RulesAndHeaders>;
 
 function generateRuleListMarkdownForRulesAndHeaders(
   rulesAndHeaders: RulesAndHeadersReadOnly,
@@ -269,66 +266,95 @@ function generateRuleListMarkdownForRulesAndHeaders(
 function getRulesAndHeadersForSplit(
   ruleNamesAndRules: RuleNamesAndRules,
   plugin: Plugin,
-  ruleListSplit: string
+  ruleListSplit: readonly string[]
 ): RulesAndHeadersReadOnly {
   const rulesAndHeaders: RulesAndHeaders = [];
 
-  const values = new Set(
-    ruleNamesAndRules.map(([name]) =>
-      getPropertyFromRule(plugin, name, ruleListSplit)
-    )
-  );
-  const valuesAll = [...values.values()];
+  // Initially, all rules are unused.
+  let unusedRules: RuleNamesAndRules = ruleNamesAndRules;
 
-  if (values.size === 1 && isConsideredFalse(valuesAll[0])) {
-    throw new Error(
-      `No rules found with --rule-list-split property "${ruleListSplit}".`
-    );
-  }
+  // Loop through each split property.
+  for (const ruleListSplitItem of ruleListSplit) {
+    // Store the rules and headers for this split property.
+    const rulesAndHeadersForThisSplit: RulesAndHeaders = [];
 
-  // Show any rules that don't have a value for this rule-list-split property first, or for which the boolean property is off.
-  if (valuesAll.some((val) => isConsideredFalse(val))) {
-    const rulesForThisValue = ruleNamesAndRules.filter(([name]) =>
-      isConsideredFalse(getPropertyFromRule(plugin, name, ruleListSplit))
-    );
+    // Check what possible values this split property can have.
+    const valuesForThisPropertyFromUnusedRules = [
+      ...new Set(
+        unusedRules.map(([name]) =>
+          getPropertyFromRule(plugin, name, ruleListSplitItem)
+        )
+      ).values(),
+    ];
+    const valuesForThisPropertyFromAllRules = [
+      ...new Set(
+        ruleNamesAndRules.map(([name]) =>
+          getPropertyFromRule(plugin, name, ruleListSplitItem)
+        )
+      ).values(),
+    ];
 
-    rulesAndHeaders.push({
-      rules: rulesForThisValue,
-    });
-  }
-
-  // For each possible non-disabled value, show a header and list of corresponding rules.
-  const valuesNotFalseAndNotTrue = valuesAll.filter(
-    (val) => !isConsideredFalse(val) && !isBooleanableTrue(val)
-  );
-  const valuesTrue = valuesAll.filter((val) => isBooleanableTrue(val));
-  const valuesNew = [
-    ...valuesNotFalseAndNotTrue,
-    ...(valuesTrue.length > 0 ? [true] : []), // If there are multiple true values, combine them all into one.
-  ];
-  for (const value of valuesNew.sort((a, b) =>
-    String(a).toLowerCase().localeCompare(String(b).toLowerCase())
-  )) {
-    const rulesForThisValue = ruleNamesAndRules.filter(([name]) => {
-      const property = getPropertyFromRule(plugin, name, ruleListSplit);
-      return (
-        property === value || (value === true && isBooleanableTrue(property))
+    // Throw an exception if there are no possible rules with this split property.
+    if (
+      valuesForThisPropertyFromAllRules.length === 1 &&
+      isConsideredFalse(valuesForThisPropertyFromAllRules[0])
+    ) {
+      throw new Error(
+        `No rules found with --rule-list-split property "${ruleListSplitItem}".`
       );
-    });
+    }
 
-    // Turn ruleListSplit into a title.
-    // E.g. meta.docs.requiresTypeChecking to "Requires Type Checking".
-    const ruleListSplitParts = ruleListSplit.split('.');
-    const ruleListSplitFinalPart =
-      ruleListSplitParts[ruleListSplitParts.length - 1];
-    const ruleListSplitTitle = noCase(ruleListSplitFinalPart, {
-      transform: (str) => capitalizeOnlyFirstLetter(str),
-    });
+    // For each possible non-disabled value, show a header and list of corresponding rules.
+    const valuesNotFalseAndNotTrue =
+      valuesForThisPropertyFromUnusedRules.filter(
+        (val) => !isConsideredFalse(val) && !isBooleanableTrue(val)
+      );
+    const valuesTrue = valuesForThisPropertyFromUnusedRules.filter((val) =>
+      isBooleanableTrue(val)
+    );
+    const valuesNew = [
+      ...valuesNotFalseAndNotTrue,
+      ...(valuesTrue.length > 0 ? [true] : []), // If there are multiple true values, combine them all into one.
+    ];
+    for (const value of valuesNew.sort((a, b) =>
+      String(a).toLowerCase().localeCompare(String(b).toLowerCase())
+    )) {
+      // Rules with the property set to this value.
+      const rulesForThisValue = unusedRules.filter(([name]) => {
+        const property = getPropertyFromRule(plugin, name, ruleListSplitItem);
+        return (
+          property === value || (value === true && isBooleanableTrue(property))
+        );
+      });
 
-    rulesAndHeaders.push({
-      header: String(isBooleanableTrue(value) ? ruleListSplitTitle : value),
-      rules: rulesForThisValue,
-    });
+      // Turn ruleListSplit into a title.
+      // E.g. meta.docs.requiresTypeChecking to "Requires Type Checking".
+      const ruleListSplitParts = ruleListSplitItem.split('.');
+      const ruleListSplitFinalPart =
+        ruleListSplitParts[ruleListSplitParts.length - 1];
+      const ruleListSplitTitle = noCase(ruleListSplitFinalPart, {
+        transform: (str) => capitalizeOnlyFirstLetter(str),
+      });
+
+      // Add a list for the rules with property set to this value.
+      rulesAndHeadersForThisSplit.push({
+        header: String(isBooleanableTrue(value) ? ruleListSplitTitle : value),
+        rules: rulesForThisValue,
+      });
+
+      // Remove these rules from the unused rules.
+      unusedRules = unusedRules.filter(
+        (rule) => !rulesForThisValue.includes(rule)
+      );
+    }
+
+    // Add the rules and headers for this split property to the beginning of the list of all rules and headers.
+    rulesAndHeaders.unshift(...rulesAndHeadersForThisSplit);
+  }
+
+  // All remaining unused rules go at the beginning.
+  if (unusedRules.length > 0) {
+    rulesAndHeaders.unshift({ rules: unusedRules });
   }
 
   return rulesAndHeaders;
@@ -346,7 +372,7 @@ export function updateRulesList(
   configEmojis: ConfigEmojis,
   ignoreConfig: readonly string[],
   ruleListColumns: readonly COLUMN_TYPE[],
-  ruleListSplit?: string,
+  ruleListSplit: readonly string[],
   urlConfigs?: string,
   urlRuleDoc?: string
 ): string {
@@ -414,7 +440,7 @@ export function updateRulesList(
 
   // Determine the pairs of rules and headers based on any split property.
   const rulesAndHeaders: RulesAndHeaders = [];
-  if (ruleListSplit) {
+  if (ruleListSplit.length > 0) {
     rulesAndHeaders.push(
       ...getRulesAndHeadersForSplit(ruleNamesAndRules, plugin, ruleListSplit)
     );

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -162,7 +162,7 @@ export type GenerateOptions = {
    * A separate list and header will be created for each value.
    * Example: `meta.type`.
    */
-  readonly ruleListSplit?: string;
+  readonly ruleListSplit?: string | readonly string[];
   /** Link to documentation about the ESLint configurations exported by the plugin. */
   readonly urlConfigs?: string;
   /**

--- a/test/lib/__snapshots__/cli-test.ts.snap
+++ b/test/lib/__snapshots__/cli-test.ts.snap
@@ -51,7 +51,10 @@ exports[`cli all CLI options and all config files options merges correctly, with
       "hasSuggestions",
       "type",
     ],
-    "ruleListSplit": "meta.docs.foo-from-cli",
+    "ruleListSplit": [
+      "meta.docs.foo-from-config-file",
+      "meta.docs.foo-from-cli",
+    ],
     "urlConfigs": "https://example.com/configs-url-from-cli",
     "urlRuleDoc": "https://example.com/rule-doc-url-from-cli",
   },
@@ -95,7 +98,9 @@ exports[`cli all CLI options, no config file options is called correctly 1`] = `
     "ruleListColumns": [
       "type",
     ],
-    "ruleListSplit": "meta.docs.foo-from-cli",
+    "ruleListSplit": [
+      "meta.docs.foo-from-cli",
+    ],
     "urlConfigs": "https://example.com/configs-url-from-cli",
     "urlRuleDoc": "https://example.com/rule-doc-url-from-cli",
   },
@@ -140,7 +145,9 @@ exports[`cli all config files options, no CLI options is called correctly 1`] = 
       "fixable",
       "hasSuggestions",
     ],
-    "ruleListSplit": "meta.docs.foo-from-config-file",
+    "ruleListSplit": [
+      "meta.docs.foo-from-config-file",
+    ],
     "urlConfigs": "https://example.com/configs-url-from-config-file",
     "urlRuleDoc": "https://example.com/rule-doc-url-from-config-file",
   },
@@ -159,6 +166,7 @@ exports[`cli boolean option - false (explicit) is called correctly 1`] = `
     "ruleDocSectionExclude": [],
     "ruleDocSectionInclude": [],
     "ruleListColumns": [],
+    "ruleListSplit": [],
   },
 ]
 `;
@@ -175,6 +183,7 @@ exports[`cli boolean option - true (explicit) is called correctly 1`] = `
     "ruleDocSectionExclude": [],
     "ruleDocSectionInclude": [],
     "ruleListColumns": [],
+    "ruleListSplit": [],
   },
 ]
 `;
@@ -191,6 +200,7 @@ exports[`cli boolean option - true (implicit) is called correctly 1`] = `
     "ruleDocSectionExclude": [],
     "ruleDocSectionInclude": [],
     "ruleListColumns": [],
+    "ruleListSplit": [],
   },
 ]
 `;
@@ -206,6 +216,7 @@ exports[`cli no options is called correctly 1`] = `
     "ruleDocSectionExclude": [],
     "ruleDocSectionInclude": [],
     "ruleListColumns": [],
+    "ruleListSplit": [],
   },
 ]
 `;
@@ -226,6 +237,7 @@ exports[`cli pathRuleList as array in config file and CLI merges correctly 1`] =
     "ruleDocSectionExclude": [],
     "ruleDocSectionInclude": [],
     "ruleListColumns": [],
+    "ruleListSplit": [],
   },
 ]
 `;

--- a/test/lib/generate/__snapshots__/option-rule-list-split-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-rule-list-split-test.ts.snap
@@ -75,6 +75,52 @@ exports[`generate (--rule-list-split) ignores case when sorting headers splits t
 "
 `;
 
+exports[`generate (--rule-list-split) multiple properties and no rules left for second property (already shown for first property) does not show the property with no rules left and does not throw 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+❌ Deprecated.
+
+### Deprecated
+
+| Name                           | ❌  |
+| :----------------------------- | :- |
+| [no-bar](docs/rules/no-bar.md) | ❌  |
+| [no-foo](docs/rules/no-foo.md) | ❌  |
+
+<!-- end auto-generated rules list -->
+"
+`;
+
+exports[`generate (--rule-list-split) multiple properties splits the list by multiple properties 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+❌ Deprecated.
+
+### Hello
+
+| Name                           | ❌  |
+| :----------------------------- | :- |
+| [no-foo](docs/rules/no-foo.md) |    |
+
+### World
+
+| Name                           | ❌  |
+| :----------------------------- | :- |
+| [no-biz](docs/rules/no-biz.md) |    |
+
+### Deprecated
+
+| Name                           | ❌  |
+| :----------------------------- | :- |
+| [no-bar](docs/rules/no-bar.md) | ❌  |
+| [no-baz](docs/rules/no-baz.md) | ❌  |
+
+<!-- end auto-generated rules list -->
+"
+`;
+
 exports[`generate (--rule-list-split) with boolean (CONSTANT_CASE) splits the list with the right header 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->


### PR DESCRIPTION
Fixes #291.


- [x] This is not yet splitting the lists correctly. The same rule should not be included in multiple lists.
- [x] Ensure the CSV string behavior is correct.
- [x] Ensure this will be compatible with #294. We might want to just use an underlying function even if the user isn't using one.