### PR TITLE
Improve type for `configEmoji` option

### DIFF
--- a/lib/option-parsers.ts
+++ b/lib/option-parsers.ts
@@ -15,7 +15,10 @@ import type { Plugin, ConfigEmojis } from './types.js';
  */
 export function parseConfigEmojiOptions(
   plugin: Plugin,
-  configEmoji?: readonly (readonly string[])[]
+  configEmoji?: readonly (
+    | [configName: string, emoji: string]
+    | [configName: string]
+  )[]
 ): ConfigEmojis {
   const configsSeen = new Set<string>();
   const configsWithDefaultEmojiRemoved: string[] = [];

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -48,7 +48,7 @@ export interface RuleDetails {
 }
 
 /**
- * Some configs may have an emoji defined.
+ * The emoji for each config that has one after option parsing and defaults have been applied.
  */
 export type ConfigEmojis = readonly { config: string; emoji: string }[];
 
@@ -119,7 +119,10 @@ export type GenerateOptions = {
    * Default emojis are provided for common configs.
    * To remove a default emoji and rely on a badge instead, provide the config name without an emoji.
    */
-  readonly configEmoji?: readonly (readonly string[])[];
+  readonly configEmoji?: readonly (
+    | [configName: string, emoji: string]
+    | [configName: string]
+  )[];
   /** Configs to ignore from being displayed. Often used for an `all` config. */
   readonly ignoreConfig?: readonly string[];
   /** Whether to ignore deprecated rules from being checked, displayed, or updated. Default: `false`. */

--- a/test/lib/generate/option-config-emoji-test.ts
+++ b/test/lib/generate/option-config-emoji-test.ts
@@ -102,9 +102,17 @@ describe('generate (--config-emoji)', function () {
 
     it('throws an error', async function () {
       await expect(
+        // @ts-expect-error -- testing invalid input (too many items)
         generate('.', { configEmoji: [['foo', 'bar', 'baz']] })
       ).rejects.toThrow(
         'Invalid configEmoji option: foo,bar,baz. Expected format: config,emoji'
+      );
+
+      await expect(
+        // @ts-expect-error -- testing invalid input (too few items)
+        generate('.', { configEmoji: [[]] })
+      ).rejects.toThrow(
+        'Invalid configEmoji option: . Expected format: config,emoji'
       );
     });
   });


### PR DESCRIPTION
Use a tuple with named elements instead of just a string array. This provides more information about the expected type, and allows the type-checker (when present) to catch issues sooner instead of depending on runtime checks. This is not a breaking change because we already enforced the same checks at runtime.

As a reminder, the way this option is used is for specifying an emoji for each config like this:

```js
{
  configEmoji: [
    ['recommended', '🔥'],
    ['stylistic', '🎨'],
  ],
}
```