### PR TITLE
Ensure `deprecated`/`schema` properties are detected from function-style rules

### DIFF
--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -173,8 +173,10 @@ export async function generate(path: string, options?: GenerateOptions) {
           ? {
               // Deprecated function-style rule don't support most of the properties that object-style rules support, so we'll just use the bare minimum.
               meta: {
-                schema: [], // TODO: figure out how to access `schema` property that can be exported from function-style rules: https://github.com/bmish/eslint-doc-generator/issues/71
-                deprecated: false, // TODO: figure out how to access `deprecated` property that can be exported from function-style rules: https://github.com/bmish/eslint-doc-generator/issues/71
+                // @ts-expect-error -- type is missing for this property
+                schema: ruleModule.schema, // eslint-disable-line @typescript-eslint/no-unsafe-assignment -- type is missing for this property
+                // @ts-expect-error -- type is missing for this property
+                deprecated: ruleModule.deprecated, // eslint-disable-line @typescript-eslint/no-unsafe-assignment -- type is missing for this property
               },
               create: ruleModule,
             }

--- a/test/lib/generate/__snapshots__/rule-metadata-test.ts.snap
+++ b/test/lib/generate/__snapshots__/rule-metadata-test.ts.snap
@@ -22,6 +22,29 @@ exports[`generate (rule metadata) deprecated function-style rule generates the d
 "
 `;
 
+exports[`generate (rule metadata) deprecated function-style rule with deprecated/schema properties generates the documentation 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+❌ Deprecated.\\
+⚙️ Has configuration options.
+
+| Name                           | ❌  | ⚙️ |
+| :----------------------------- | :- | :- |
+| [no-foo](docs/rules/no-foo.md) | ❌  | ⚙️ |
+
+<!-- end auto-generated rules list -->
+"
+`;
+
+exports[`generate (rule metadata) deprecated function-style rule with deprecated/schema properties generates the documentation 2`] = `
+"# test/no-foo
+
+<!-- end auto-generated rule header -->
+## Options
+optionToDoSomething"
+`;
+
 exports[`generate (rule metadata) rule with no meta object generates the documentation 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->

--- a/test/lib/generate/rule-metadata-test.ts
+++ b/test/lib/generate/rule-metadata-test.ts
@@ -54,6 +54,60 @@ describe('generate (rule metadata)', function () {
     });
   });
 
+  describe('deprecated function-style rule with deprecated/schema properties', function () {
+    beforeEach(function () {
+      mockFs({
+        'package.json': JSON.stringify({
+          name: 'eslint-plugin-test',
+          exports: 'index.js',
+          type: 'module',
+        }),
+
+        'index.js': `
+          const noFoo = function create () {};
+          noFoo.deprecated = true;
+          noFoo.schema = [
+            {
+              type: 'object',
+              properties: {
+                optionToDoSomething: {
+                  type: 'boolean',
+                  default: false,
+                },
+              },
+              additionalProperties: false,
+            },
+          ];
+          export default {
+            rules: {
+              'no-foo': noFoo
+            },
+          };`,
+
+        'README.md': '## Rules\n',
+
+        'docs/rules/no-foo.md': '## Options\noptionToDoSomething',
+
+        // Needed for some of the test infrastructure to work.
+        node_modules: mockFs.load(PATH_NODE_MODULES),
+      });
+    });
+
+    afterEach(function () {
+      mockFs.restore();
+      jest.resetModules();
+    });
+
+    it('generates the documentation', async function () {
+      await generate('.', {
+        // Ensure the relevant properties are shown for the test.
+        ruleListColumns: ['name', 'deprecated', 'options'],
+      });
+      expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
+      expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
+    });
+  });
+
   describe('rule with no meta object', function () {
     beforeEach(function () {
       mockFs({


### PR DESCRIPTION
Function-style rules are deprecated, but we can still detect these properties from them as long as we support them.

I may follow-up to improve the type for the rule to more-accurately represent the properties it can have.

Fixes #71.
