### PR TITLE
Support a user-defined function for `--rule-list-split` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ There's also a `postprocess` option that's only available via a [config file](#c
 | `--rule-doc-section-options` | Whether to require an "Options" or "Config" rule doc section and mention of any named options for rules with options. Default: `true`. |
 | `--rule-doc-title-format` | The format to use for rule doc titles. Defaults to `desc-parens-prefix-name`. See choices in below [table](#--rule-doc-title-format). |
 | `--rule-list-columns` | Ordered, comma-separated list of columns to display in rule list. Empty columns will be hidden. See choices in below [table](#column-and-notice-types). Default: `name,description,configsError,configsWarn,configsOff,fixable,hasSuggestions,requiresTypeChecking,deprecated`. |
-| `--rule-list-split` | Rule property(s) to split the rules list by. A separate list and header will be created for each value. Example: `meta.type`. |
+| `--rule-list-split` | Rule property(s) to split the rules list by. A separate list and header will be created for each value. Example: `meta.type`. A function can also be provided for this option via a [config file](#configuration-file). |
 | `--url-configs` | Link to documentation about the ESLint configurations exported by the plugin. |
 | `--url-rule-doc` | Link to documentation for each rule. Useful when it differs from the rule doc path on disk (e.g. custom documentation site in use). Use `{name}` placeholder for the rule name. |
 
@@ -187,7 +187,10 @@ There are a few ways to create a config file (as an alternative to passing the o
 
 Config files support all the [CLI options](#configuration-options) but in camelCase.
 
-Using a JavaScript-based config file also allows you to provide a `postprocess` function to be called with the generated content and file path for each processed file. This is useful for applying custom transformations such as formatting with tools like prettier (see [prettier example](#prettier)).
+Some options are exclusive to a JavaScript-based config file:
+
+- `postprocess` - A function-only option useful for applying custom transformations such as formatting with tools like prettier. See [prettier example](#prettier).
+- [`ruleListSplit`](#configuration-options) with a function - This is useful for customizing the grouping of rules into lists.
 
 Example `.eslint-doc-generatorrc.js`:
 
@@ -195,6 +198,32 @@ Example `.eslint-doc-generatorrc.js`:
 /** @type {import('eslint-doc-generator').GenerateOptions} */
 const config = {
   ignoreConfig: ['all'],
+};
+
+module.exports = config;
+```
+
+Example `.eslint-doc-generatorrc.js` with `ruleListSplit` function:
+
+```js
+/** @type {import('eslint-doc-generator').GenerateOptions} */
+const config = {
+  ruleListSplit(rules) {
+    return [
+      {
+        // No header for this list.
+        rules: rules.filter(([name, rule]) => !rule.meta.someProp),
+      },
+      {
+        title: 'Foo',
+        rules: rules.filter(([name, rule]) => rule.meta.someProp === 'foo'),
+      },
+      {
+        title: 'Bar',
+        rules: rules.filter(([name, rule]) => rule.meta.someProp === 'bar'),
+      },
+    ];
+  },
 };
 
 module.exports = config;

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -156,10 +156,13 @@ export async function generate(path: string, options?: GenerateOptions) {
     options?.ruleDocTitleFormat ??
     OPTION_DEFAULTS[OPTION_TYPE.RULE_DOC_TITLE_FORMAT];
   const ruleListColumns = parseRuleListColumnsOption(options?.ruleListColumns);
-  const ruleListSplit = stringOrArrayToArrayWithFallback(
-    options?.ruleListSplit,
-    OPTION_DEFAULTS[OPTION_TYPE.RULE_LIST_SPLIT]
-  );
+  const ruleListSplit =
+    typeof options?.ruleListSplit === 'function'
+      ? options.ruleListSplit
+      : stringOrArrayToArrayWithFallback(
+          options?.ruleListSplit,
+          OPTION_DEFAULTS[OPTION_TYPE.RULE_LIST_SPLIT]
+        );
   const urlConfigs =
     options?.urlConfigs ?? OPTION_DEFAULTS[OPTION_TYPE.URL_CONFIGS];
   const urlRuleDoc =

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -36,9 +36,12 @@ export const SEVERITY_TYPE_TO_SET: {
 export type ConfigsToRules = Record<string, Rules>;
 
 /**
- * Convenient way to pass around a list of rules (as tuples).
+ * List of rules in the form of tuples (rule name and the actual rule).
  */
-export type RuleNamesAndRules = readonly [name: string, rule: RuleModule][];
+export type RuleNamesAndRules = readonly (readonly [
+  name: string,
+  rule: RuleModule
+])[];
 
 /**
  * The emoji for each config that has one after option parsing and defaults have been applied.
@@ -101,6 +104,17 @@ export enum OPTION_TYPE {
   URL_RULE_DOC = 'urlRuleDoc',
 }
 
+/**
+ * Function for splitting the rule list into multiple sections.
+ * Can be provided via a JavaScript-based config file using the `ruleListSplit` option.
+ * @param rules - all rules from the plugin
+ * @returns an array of sections, each with a title (optional) and list of rules
+ */
+export type RuleListSplitFunction = (rules: RuleNamesAndRules) => readonly {
+  title?: string;
+  rules: RuleNamesAndRules;
+}[];
+
 // JSDocs for options should be kept in sync with README.md and the CLI runner in cli.ts.
 /** The type for the config file (e.g. `.eslint-doc-generatorrc.js`) and internal `generate()` function. */
 export type GenerateOptions = {
@@ -129,7 +143,7 @@ export type GenerateOptions = {
   /**
    * Function to be called with the generated content and file path for each processed file.
    * Useful for applying custom transformations such as formatting with tools like prettier.
-   * Only available via a JavaScript config file.
+   * Only available via a JavaScript-based config file.
    */
   readonly postprocess?: (
     content: string,
@@ -158,11 +172,12 @@ export type GenerateOptions = {
    */
   readonly ruleListColumns?: readonly `${COLUMN_TYPE}`[];
   /**
-   * Rule property to split the rules list by.
+   * Rule property(s) or function to split the rules list by.
    * A separate list and header will be created for each value.
    * Example: `meta.type`.
    */
-  readonly ruleListSplit?: string | readonly string[];
+  readonly ruleListSplit?: string | readonly string[] | RuleListSplitFunction;
+
   /** Link to documentation about the ESLint configurations exported by the plugin. */
   readonly urlConfigs?: string;
   /**

--- a/test/lib/cli-test.ts
+++ b/test/lib/cli-test.ts
@@ -377,7 +377,94 @@ describe('cli', function () {
           ],
           stub
         )
-      ).rejects.toThrow('postprocess must be a function');
+      ).rejects.toThrow('postprocess must be a function.');
+    });
+
+    it('ruleListSplit is the wrong primitive type', async function () {
+      mockFs({
+        'package.json': JSON.stringify({
+          name: 'eslint-plugin-test',
+          main: 'index.js',
+          type: 'module',
+          version: '1.0.0',
+        }),
+
+        '.eslint-doc-generatorrc.json': JSON.stringify({
+          // Doesn't match schema.
+          ruleListSplit: 123,
+        }),
+      });
+
+      const stub = sinon.stub().resolves();
+      await expect(
+        run(
+          [
+            'node', // Path to node.
+            'eslint-doc-generator.js', // Path to this binary.
+          ],
+          stub
+        )
+      ).rejects.toThrow(
+        'config file/ruleListSplit must be string, config file/ruleListSplit must be array, config file/ruleListSplit must match a schema in anyOf'
+      );
+    });
+
+    it('ruleListSplit is the wrong array type', async function () {
+      mockFs({
+        'package.json': JSON.stringify({
+          name: 'eslint-plugin-test',
+          main: 'index.js',
+          type: 'module',
+          version: '1.0.0',
+        }),
+
+        '.eslint-doc-generatorrc.json': JSON.stringify({
+          // Doesn't match schema.
+          ruleListSplit: [123],
+        }),
+      });
+
+      const stub = sinon.stub().resolves();
+      await expect(
+        run(
+          [
+            'node', // Path to node.
+            'eslint-doc-generator.js', // Path to this binary.
+          ],
+          stub
+        )
+      ).rejects.toThrow(
+        'config file/ruleListSplit must be string, config file/ruleListSplit/0 must be string, config file/ruleListSplit must match a schema in anyOf'
+      );
+    });
+
+    it('ruleListSplit is an empty array', async function () {
+      mockFs({
+        'package.json': JSON.stringify({
+          name: 'eslint-plugin-test',
+          main: 'index.js',
+          type: 'module',
+          version: '1.0.0',
+        }),
+
+        '.eslint-doc-generatorrc.json': JSON.stringify({
+          // Doesn't match schema.
+          ruleListSplit: [],
+        }),
+      });
+
+      const stub = sinon.stub().resolves();
+      await expect(
+        run(
+          [
+            'node', // Path to node.
+            'eslint-doc-generator.js', // Path to this binary.
+          ],
+          stub
+        )
+      ).rejects.toThrow(
+        'config file/ruleListSplit must be string, config file/ruleListSplit must NOT have fewer than 1 items, config file/ruleListSplit must match a schema in anyOf'
+      );
     });
   });
 });

--- a/test/lib/generate/__snapshots__/option-rule-list-split-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-rule-list-split-test.ts.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`generate (--rule-list-split) as a function generates the documentation 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+❌ Deprecated.
+
+| Name                           | ❌  |
+| :----------------------------- | :- |
+| [no-biz](docs/rules/no-biz.md) |    |
+
+### Not Deprecated
+
+| Name                           | ❌  |
+| :----------------------------- | :- |
+| [no-bar](docs/rules/no-bar.md) |    |
+| [no-baz](docs/rules/no-baz.md) |    |
+| [no-biz](docs/rules/no-biz.md) |    |
+
+### Deprecated
+
+| Name                           | ❌  |
+| :----------------------------- | :- |
+| [no-foo](docs/rules/no-foo.md) | ❌  |
+
+### Name = "no-baz"
+
+| Name                           | ❌  |
+| :----------------------------- | :- |
+| [no-baz](docs/rules/no-baz.md) |    |
+
+<!-- end auto-generated rules list -->
+"
+`;
+
 exports[`generate (--rule-list-split) by nested property meta.docs.category splits the list 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->


### PR DESCRIPTION
Fixes #294.

The implementation of this is pretty simple because we now allow the user to provide the same function we use internally to split lists. The more complex part is dealing with the various kinds of values that are now allowed for this option.

TODO:

- [x] Add more documentation
- [x] Add more comments to new types
- [x] Too many disable comments in validation code
- [x] Throw if function returns no sections or no rules in a section
- [x] Throw if a list contains the same rule twice
- [x] Use ajv to validate return value of user-defined function

Open question:
- Should the function return value include the list of tuples `[ruleName, rule]` which is the same format it is passed, or should it just include the list of rule name strings? I have chosen to stick with the tuples because this allows very simple filtering without having to map the filtering results to the rule name.

Potential follow-up
- Improve README organization
- Fix TODO comment regarding workaround to avoid losing function during merge of options in cli.ts 
- #366
