### PR TITLE
Use concise relative paths for rule links

### DIFF
--- a/lib/string.ts
+++ b/lib/string.ts
@@ -1,7 +1,3 @@
-export function countOccurrencesInString(str: string, substring: string) {
-  return str.split(substring).length - 1;
-}
-
 export function toSentenceCase(str: string) {
   return str.replace(/^\w/u, function (txt) {
     return txt.charAt(0).toUpperCase() + txt.slice(1).toLowerCase();

--- a/test/lib/generate/__snapshots__/file-paths-test.ts.snap
+++ b/test/lib/generate/__snapshots__/file-paths-test.ts.snap
@@ -3,9 +3,9 @@
 exports[`generate (file paths) custom path to rule docs and rules list generates the documentation 1`] = `
 "<!-- begin auto-generated rules list -->
 
-| Name                                |
-| :---------------------------------- |
-| [no-foo](../rules/no-foo/no-foo.md) |
+| Name                       |
+| :------------------------- |
+| [no-foo](no-foo/no-foo.md) |
 
 <!-- end auto-generated rules list -->"
 `;
@@ -67,9 +67,9 @@ exports[`generate (file paths) multiple rules lists generates the documentation 
 exports[`generate (file paths) multiple rules lists generates the documentation 3`] = `
 "<!-- begin auto-generated rules list -->
 
-| Name                                 |
-| :----------------------------------- |
-| [no-foo](../../docs/rules/no-foo.md) |
+| Name                |
+| :------------------ |
+| [no-foo](no-foo.md) |
 
 <!-- end auto-generated rules list -->"
 `;

--- a/test/lib/generate/__snapshots__/option-url-rule-doc-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-url-rule-doc-test.ts.snap
@@ -64,7 +64,7 @@ exports[`generate (--url-rule-doc) function returns undefined should fallback to
 exports[`generate (--url-rule-doc) function returns undefined should fallback to the normal URL 3`] = `
 "# Description for no-foo (\`test/no-foo\`)
 
-❌ This rule is deprecated. It was replaced by [\`test/no-bar\`](../../docs/rules/no-bar.md).
+❌ This rule is deprecated. It was replaced by [\`test/no-bar\`](no-bar.md).
 
 <!-- end auto-generated rule header -->
 "

--- a/test/lib/generate/__snapshots__/rule-deprecation-test.ts.snap
+++ b/test/lib/generate/__snapshots__/rule-deprecation-test.ts.snap
@@ -81,7 +81,7 @@ exports[`generate (deprecated rules) several deprecated rules updates the docume
 exports[`generate (deprecated rules) several deprecated rules updates the documentation 2`] = `
 "# Description (\`test/no-foo\`)
 
-❌ This rule is deprecated. It was replaced by [\`test/no-bar\`](../../docs/rules/no-bar.md).
+❌ This rule is deprecated. It was replaced by [\`test/no-bar\`](no-bar.md).
 
 <!-- end auto-generated rule header -->
 "
@@ -128,7 +128,7 @@ exports[`generate (deprecated rules) using prefix ahead of replacement rule name
 exports[`generate (deprecated rules) using prefix ahead of replacement rule name uses correct replacement rule link 2`] = `
 "# Description (\`test/no-foo\`)
 
-❌ This rule is deprecated. It was replaced by [\`test/no-bar\`](../../docs/rules/no-bar.md).
+❌ This rule is deprecated. It was replaced by [\`test/no-bar\`](no-bar.md).
 
 <!-- end auto-generated rule header -->
 "
@@ -157,7 +157,7 @@ exports[`generate (deprecated rules) with --path-rule-doc has the correct links,
 exports[`generate (deprecated rules) with --path-rule-doc has the correct links, especially replacement rule link 2`] = `
 "# Description (\`test/category/no-foo\`)
 
-❌ This rule is deprecated. It was replaced by [\`test/category/no-bar\`](../../../docs/category/no-bar/README.md).
+❌ This rule is deprecated. It was replaced by [\`test/category/no-bar\`](../no-bar/README.md).
 
 <!-- end auto-generated rule header -->
 "
@@ -166,7 +166,7 @@ exports[`generate (deprecated rules) with --path-rule-doc has the correct links,
 exports[`generate (deprecated rules) with --path-rule-doc has the correct links, especially replacement rule link 3`] = `
 "# Description (\`test/category/no-bar\`)
 
-❌ This rule is deprecated. It was replaced by [\`test/category/no-foo\`](../../../docs/category/no-foo/README.md).
+❌ This rule is deprecated. It was replaced by [\`test/category/no-foo\`](../no-foo/README.md).
 
 <!-- end auto-generated rule header -->
 "
@@ -188,7 +188,7 @@ exports[`generate (deprecated rules) with nested rule names has the correct link
 exports[`generate (deprecated rules) with nested rule names has the correct links, especially replacement rule link 2`] = `
 "# Description (\`test/category/no-foo\`)
 
-❌ This rule is deprecated. It was replaced by [\`test/category/no-bar\`](../../../docs/rules/category/no-bar.md).
+❌ This rule is deprecated. It was replaced by [\`test/category/no-bar\`](no-bar.md).
 
 <!-- end auto-generated rule header -->
 "
@@ -197,7 +197,7 @@ exports[`generate (deprecated rules) with nested rule names has the correct link
 exports[`generate (deprecated rules) with nested rule names has the correct links, especially replacement rule link 3`] = `
 "# Description (\`test/category/no-bar\`)
 
-❌ This rule is deprecated. It was replaced by [\`test/category/no-foo\`](../../../docs/rules/category/no-foo.md).
+❌ This rule is deprecated. It was replaced by [\`test/category/no-foo\`](no-foo.md).
 
 <!-- end auto-generated rule header -->
 "


### PR DESCRIPTION
Specifically, this avoids including redundant dot segments like `../../docs/rules` when that's equivalent to `./`.

To do this, we use Node's `relative` function and two absolute URLs, the first being a path without the filename.

Fixes #284.

TODO:

- [x] Cleanup algorithm