### PR TITLE
Clarify error message when rule option is missing from rule doc

### DIFF
--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -68,3 +68,64 @@ export function findFinalHeaderLevel(str: string) {
   const finalHeader = lines.reverse().find((line) => line.match('^(#+) .+$'));
   return finalHeader ? finalHeader.indexOf(' ') : undefined;
 }
+
+/**
+ * Ensure a doc contains (or doesn't contain) some particular content.
+ * Upon failure, output the failure and set a failure exit code.
+ * @param docName - name of doc for error message
+ * @param contentName - name of content for error message
+ * @param contents - the doc's contents
+ * @param content - the content we are checking for
+ * @param expected - whether the content should be present or not present
+ */
+export function expectContentOrFail(
+  docName: string,
+  contentName: string,
+  contents: string,
+  content: string,
+  expected: boolean
+) {
+  // Check for the content and also the versions of the content with escaped quotes
+  // in case escaping is needed where the content is referenced.
+  const hasContent =
+    contents.includes(content) ||
+    contents.includes(content.replace(/"/gu, '\\"')) ||
+    contents.includes(content.replace(/'/gu, "\\'"));
+  if (hasContent !== expected) {
+    console.error(
+      `${docName} should ${
+        /* istanbul ignore next -- TODO: test !expected or remove parameter */
+        expected ? '' : 'not '
+      }have included ${contentName}: ${content}`
+    );
+    process.exitCode = 1;
+  }
+}
+
+export function expectSectionHeaderOrFail(
+  contentName: string,
+  contents: string,
+  possibleHeaders: readonly string[],
+  expected: boolean
+) {
+  const found = possibleHeaders.some((header) =>
+    findSectionHeader(contents, header)
+  );
+  if (found !== expected) {
+    if (possibleHeaders.length > 1) {
+      console.error(
+        `${contentName} should ${expected ? '' : 'not '}have included ${
+          expected ? 'one' : 'any'
+        } of these headers: ${possibleHeaders.join(', ')}`
+      );
+    } else {
+      console.error(
+        `${contentName} should ${
+          expected ? '' : 'not '
+        }have included the header: ${possibleHeaders.join(', ')}`
+      );
+    }
+
+    process.exitCode = 1;
+  }
+}

--- a/test/lib/generate/rule-options-test.ts
+++ b/test/lib/generate/rule-options-test.ts
@@ -314,7 +314,7 @@ describe('generate (rule options)', function () {
       await generate('.');
       expect(consoleErrorStub.callCount).toBe(1);
       expect(consoleErrorStub.firstCall.args).toStrictEqual([
-        '`no-foo` rule doc should have included: optionToDoSomething',
+        '`no-foo` rule doc should have included rule option: optionToDoSomething',
       ]);
       consoleErrorStub.restore();
     });


### PR DESCRIPTION
Inspired by the confusion from here: https://github.com/eslint-community/eslint-plugin-n/pull/76#issuecomment-1376694658

Before:

```
`no-extraneous-import` rule doc should have included: include
```

After:

```
`no-extraneous-import` rule doc should have included rule option: include
```

Also extracts a few markdown functions into our generic markdown helper file.