### PR TITLE
Sanitize newlines and pipes from markdown table cells

### DIFF
--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -32,7 +32,7 @@ import type {
 import { EMOJIS_TYPE } from './rule-type.js';
 import { hasOptions } from './rule-options.js';
 import { getLinkToRule } from './rule-link.js';
-import { capitalizeOnlyFirstLetter } from './string.js';
+import { capitalizeOnlyFirstLetter, sanitizeMarkdownTable } from './string.js';
 import { noCase } from 'no-case';
 import { getProperty } from 'dot-prop';
 import { boolean, isBooleanable } from 'boolean';
@@ -178,7 +178,9 @@ function buildRuleRow(
     [COLUMN_TYPE.REQUIRES_TYPE_CHECKING]: rule.meta?.docs?.requiresTypeChecking
       ? EMOJI_REQUIRES_TYPE_CHECKING
       : '',
-    [COLUMN_TYPE.TYPE]: rule.meta?.type ? EMOJIS_TYPE[rule.meta?.type] : '',
+    [COLUMN_TYPE.TYPE]: rule.meta?.type
+      ? EMOJIS_TYPE[rule.meta?.type] || ''
+      : '',
   };
 
   // List columns using the ordering and presence of columns specified in columnsEnabled.
@@ -222,7 +224,7 @@ function generateRulesListMarkdown(
   });
 
   return markdownTable(
-    [
+    sanitizeMarkdownTable([
       listHeaderRow,
       ...ruleNamesAndRules.map(([name, rule]) =>
         buildRuleRow(
@@ -240,7 +242,7 @@ function generateRulesListMarkdown(
           urlRuleDoc
         )
       ),
-    ],
+    ]),
     { align: 'l' } // Left-align headers.
   );
 }

--- a/lib/rule-options-list.ts
+++ b/lib/rule-options-list.ts
@@ -5,7 +5,7 @@ import {
 import { markdownTable } from 'markdown-table';
 import type { RuleModule } from './types.js';
 import { RuleOption, getAllNamedOptions } from './rule-options.js';
-import { capitalizeOnlyFirstLetter } from './string.js';
+import { capitalizeOnlyFirstLetter, sanitizeMarkdownTable } from './string.js';
 
 export enum COLUMN_TYPE {
   // Alphabetical order.
@@ -116,11 +116,11 @@ function generateRuleOptionsListMarkdown(rule: RuleModule): string {
       // Recreate object using correct ordering and presence of columns.
       return Object.keys(COLUMN_TYPE_DEFAULT_PRESENCE_AND_ORDERING)
         .filter((type) => columnsToDisplay[type as COLUMN_TYPE])
-        .map((type) => ruleOptionColumnValues[type as COLUMN_TYPE]);
+        .map((type) => ruleOptionColumnValues[type as COLUMN_TYPE] || '');
     });
 
   return markdownTable(
-    [listHeaderRow, ...rows],
+    sanitizeMarkdownTable([listHeaderRow, ...rows]),
     { align: 'l' } // Left-align headers.
   );
 }

--- a/lib/string.ts
+++ b/lib/string.ts
@@ -18,3 +18,13 @@ export function addTrailingPeriod(str: string) {
 export function capitalizeOnlyFirstLetter(str: string) {
   return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 }
+
+function sanitizeMarkdownTableCell(text: string): string {
+  return text.replace(/\|/gu, '\\|').replace(/\n/gu, '<br/>');
+}
+
+export function sanitizeMarkdownTable(
+  text: readonly (readonly string[])[]
+): readonly (readonly string[])[] {
+  return text.map((row) => row.map((col) => sanitizeMarkdownTableCell(col)));
+}

--- a/test/lib/generate/__snapshots__/configs-list-test.ts.snap
+++ b/test/lib/generate/__snapshots__/configs-list-test.ts.snap
@@ -19,6 +19,25 @@ exports[`generate (configs list) basic generates the documentation 1`] = `
 <!-- end auto-generated configs list -->"
 `;
 
+exports[`generate (configs list) when a config description needs to be escaped in table generates the documentation 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+| Name                           | Description         |
+| :----------------------------- | :------------------ |
+| [no-foo](docs/rules/no-foo.md) | Description no-foo. |
+
+<!-- end auto-generated rules list -->
+## Configs
+<!-- begin auto-generated configs list -->
+
+|    | Name          | Description |
+| :- | :------------ | :---------- |
+| ✅  | \`recommended\` | Foo\\|Bar    |
+
+<!-- end auto-generated configs list -->"
+`;
+
 exports[`generate (configs list) when a config exports a description generates the documentation 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->

--- a/test/lib/generate/__snapshots__/rule-description-test.ts.snap
+++ b/test/lib/generate/__snapshots__/rule-description-test.ts.snap
@@ -90,3 +90,15 @@ exports[`generate (rule descriptions) rule with long-enough description to requi
 <!-- end auto-generated rule header -->
 "
 `;
+
+exports[`generate (rule descriptions) with rule description that needs to be escaped in table generates the documentation 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+| Name                           | Description |
+| :----------------------------- | :---------- |
+| [no-foo](docs/rules/no-foo.md) | Foo\\|Bar    |
+
+<!-- end auto-generated rules list -->
+"
+`;

--- a/test/lib/generate/__snapshots__/rule-options-list-test.ts.snap
+++ b/test/lib/generate/__snapshots__/rule-options-list-test.ts.snap
@@ -36,3 +36,17 @@ exports[`generate (rule options list) with no options generates the documentatio
 
 <!-- end auto-generated rule options list -->"
 `;
+
+exports[`generate (rule options list) with string that needs to be escaped in table generates the documentation 1`] = `
+"# test/no-foo
+
+<!-- end auto-generated rule header -->
+## Options
+<!-- begin auto-generated rule options list -->
+
+| Name  | Description                     | Type           |
+| :---- | :------------------------------ | :------------- |
+| \`foo\` | test<br/>                  desc | String\\|number |
+
+<!-- end auto-generated rule options list -->"
+`;

--- a/test/lib/generate/configs-list-test.ts
+++ b/test/lib/generate/configs-list-test.ts
@@ -238,6 +238,51 @@ describe('generate (configs list)', function () {
     });
   });
 
+  describe('when a config description needs to be escaped in table', function () {
+    beforeEach(function () {
+      mockFs({
+        'package.json': JSON.stringify({
+          name: 'eslint-plugin-test',
+          exports: 'index.js',
+          type: 'module',
+        }),
+
+        'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: { docs: { description: 'Description no-foo.' }, },
+                create(context) {}
+              },
+            },
+            configs: {
+              recommended: { description: 'Foo|Bar' },
+            }
+          };`,
+
+        'README.md': `## Rules
+## Configs
+<!-- begin auto-generated configs list -->
+<!-- end auto-generated configs list -->`,
+
+        'docs/rules/no-foo.md': '',
+
+        // Needed for some of the test infrastructure to work.
+        node_modules: mockFs.load(PATH_NODE_MODULES),
+      });
+    });
+
+    afterEach(function () {
+      mockFs.restore();
+      jest.resetModules();
+    });
+
+    it('generates the documentation', async function () {
+      await generate('.');
+      expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
+    });
+  });
+
   describe('when there are no configs', function () {
     beforeEach(function () {
       mockFs({

--- a/test/lib/generate/rule-description-test.ts
+++ b/test/lib/generate/rule-description-test.ts
@@ -208,4 +208,43 @@ describe('generate (rule descriptions)', function () {
       expect(readFileSync('docs/rules/no-bar.md', 'utf8')).toMatchSnapshot();
     });
   });
+
+  describe('with rule description that needs to be escaped in table', function () {
+    beforeEach(function () {
+      mockFs({
+        'package.json': JSON.stringify({
+          name: 'eslint-plugin-test',
+          exports: 'index.js',
+          type: 'module',
+        }),
+
+        'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: { docs: { description: 'Foo|Bar'} },
+                create(context) {},
+              },
+            },
+          };`,
+
+        'README.md': '## Rules\n',
+
+        'docs/rules/no-foo.md': '',
+
+        // Needed for some of the test infrastructure to work.
+        node_modules: mockFs.load(PATH_NODE_MODULES),
+      });
+    });
+
+    afterEach(function () {
+      mockFs.restore();
+      jest.resetModules();
+    });
+
+    it('generates the documentation', async function () {
+      await generate('.');
+      expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
+    });
+  });
 });

--- a/test/lib/generate/rule-options-list-test.ts
+++ b/test/lib/generate/rule-options-list-test.ts
@@ -163,4 +163,48 @@ describe('generate (rule options list)', function () {
       expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
     });
   });
+
+  describe('with string that needs to be escaped in table', function () {
+    beforeEach(function () {
+      mockFs({
+        'package.json': JSON.stringify({
+          name: 'eslint-plugin-test',
+          exports: 'index.js',
+          type: 'module',
+        }),
+
+        'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: {
+                  schema: [{ type: "object", properties: { foo: { description: \`test
+                  desc\`, type: 'string|number' } } }]
+                },
+                create(context) {}
+              },
+            },
+          };`,
+
+        'README.md': '## Rules\n',
+
+        'docs/rules/no-foo.md': `## Options
+<!-- begin auto-generated rule options list -->
+<!-- end auto-generated rule options list -->`,
+
+        // Needed for some of the test infrastructure to work.
+        node_modules: mockFs.load(PATH_NODE_MODULES),
+      });
+    });
+
+    afterEach(function () {
+      mockFs.restore();
+      jest.resetModules();
+    });
+
+    it('generates the documentation', async function () {
+      await generate('.');
+      expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
+    });
+  });
 });


### PR DESCRIPTION
Having a `|` or `\n` in rule/config properties that we use could break rendering of markdown tables, so escape them.

We could consider switching to a third-party library for this if available, although note that we want to allow most other markdown to be used.

Related:
* https://github.com/wooorm/markdown-table/pull/31