### PR TITLE
Show rule option list "Default" column even with only a falsy value

### DIFF
--- a/lib/rule-options-list.ts
+++ b/lib/rule-options-list.ts
@@ -79,7 +79,9 @@ function ruleOptionsToColumnsToDisplay(ruleOptions: readonly RuleOption[]): {
     [key in COLUMN_TYPE]: boolean;
   } = {
     // Alphabetical order.
-    [COLUMN_TYPE.DEFAULT]: ruleOptions.some((ruleOption) => ruleOption.default),
+    [COLUMN_TYPE.DEFAULT]: ruleOptions.some(
+      (ruleOption) => ruleOption.default !== undefined
+    ),
     [COLUMN_TYPE.DEPRECATED]: ruleOptions.some(
       (ruleOption) => ruleOption.deprecated
     ),

--- a/test/lib/generate/__snapshots__/rule-options-list-test.ts.snap
+++ b/test/lib/generate/__snapshots__/rule-options-list-test.ts.snap
@@ -17,6 +17,20 @@ exports[`generate (rule options list) basic generates the documentation 1`] = `
 <!-- end auto-generated rule options list -->"
 `;
 
+exports[`generate (rule options list) displays default column even when only falsy value, hiding deprecated/required cols with only falsy value generates the documentation 1`] = `
+"# test/no-foo
+
+<!-- end auto-generated rule header -->
+## Options
+<!-- begin auto-generated rule options list -->
+
+| Name  | Default |
+| :---- | :------ |
+| \`foo\` | \`false\` |
+
+<!-- end auto-generated rule options list -->"
+`;
+
 exports[`generate (rule options list) with no marker comments generates the documentation 1`] = `
 "# test/no-foo
 

--- a/test/lib/generate/rule-options-list-test.ts
+++ b/test/lib/generate/rule-options-list-test.ts
@@ -79,6 +79,58 @@ describe('generate (rule options list)', function () {
     });
   });
 
+  describe('displays default column even when only falsy value, hiding deprecated/required cols with only falsy value', function () {
+    beforeEach(function () {
+      mockFs({
+        'package.json': JSON.stringify({
+          name: 'eslint-plugin-test',
+          exports: 'index.js',
+          type: 'module',
+        }),
+
+        'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: {
+                  schema: [{
+                    type: "object",
+                    properties: {
+                        foo: {
+                            default: false,
+                            required: false,
+                            deprecated: false,
+                        },
+                    },
+                 }],
+                },
+                create(context) {}
+              },
+            },
+          };`,
+
+        'README.md': '## Rules\n',
+
+        'docs/rules/no-foo.md': `## Options
+<!-- begin auto-generated rule options list -->
+<!-- end auto-generated rule options list -->`,
+
+        // Needed for some of the test infrastructure to work.
+        node_modules: mockFs.load(PATH_NODE_MODULES),
+      });
+    });
+
+    afterEach(function () {
+      mockFs.restore();
+      jest.resetModules();
+    });
+
+    it('generates the documentation', async function () {
+      await generate('.');
+      expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
+    });
+  });
+
   describe('with no options', function () {
     beforeEach(function () {
       mockFs({


### PR DESCRIPTION
Knowing that `false` is the default for a rule option is valuable so we should still display the "Default" column when that information is available. Example:

| Name  | Default |
| :---- | :------ |
| `foo` | `false` |