### PR TITLE
Initialize rule doc options section when using `--init-rule-docs`

### DIFF
--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -15,7 +15,11 @@ import {
   parseRuleListColumnsOption,
   parseConfigEmojiOptions,
 } from './option-parsers.js';
-import { END_RULE_HEADER_MARKER } from './comment-markers.js';
+import {
+  BEGIN_RULE_OPTIONS_LIST_MARKER,
+  END_RULE_HEADER_MARKER,
+  END_RULE_OPTIONS_LIST_MARKER,
+} from './comment-markers.js';
 import {
   replaceOrCreateHeader,
   expectContentOrFail,
@@ -148,6 +152,7 @@ export async function generate(path: string, options?: GenerateOptions) {
     const schema = rule.meta?.schema;
     const description = rule.meta?.docs?.description;
     const pathToDoc = replaceRulePlaceholder(join(path, pathRuleDoc), name);
+    const ruleHasOptions = hasOptions(schema);
 
     if (!existsSync(pathToDoc)) {
       if (!initRuleDocs) {
@@ -157,7 +162,12 @@ export async function generate(path: string, options?: GenerateOptions) {
       }
 
       mkdirSync(dirname(pathToDoc), { recursive: true });
-      writeFileSync(pathToDoc, '');
+      writeFileSync(
+        pathToDoc,
+        ruleHasOptions
+          ? `\n## Options\n\n${BEGIN_RULE_OPTIONS_LIST_MARKER}\n${END_RULE_OPTIONS_LIST_MARKER}\n`
+          : ''
+      );
       initializedRuleDoc = true;
     }
 
@@ -235,7 +245,7 @@ export async function generate(path: string, options?: GenerateOptions) {
         `\`${name}\` rule doc`,
         contentsNew,
         ['Options', 'Config'],
-        hasOptions(schema)
+        ruleHasOptions
       );
       for (const { name: namedOption } of getAllNamedOptions(schema)) {
         expectContentOrFail(

--- a/test/lib/generate/__snapshots__/file-paths-test.ts.snap
+++ b/test/lib/generate/__snapshots__/file-paths-test.ts.snap
@@ -44,6 +44,23 @@ exports[`generate (file paths) missing rule doc when initRuleDocs is true create
 "
 `;
 
+exports[`generate (file paths) missing rule doc when initRuleDocs is true creates the rule doc 2`] = `
+"# test/no-bar
+
+<!-- end auto-generated rule header -->
+
+## Options
+
+<!-- begin auto-generated rule options list -->
+
+| Name      |
+| :-------- |
+| \`option1\` |
+
+<!-- end auto-generated rule options list -->
+"
+`;
+
 exports[`generate (file paths) multiple rules lists generates the documentation 1`] = `
 "<!-- begin auto-generated rules list -->
 

--- a/test/lib/generate/file-paths-test.ts
+++ b/test/lib/generate/file-paths-test.ts
@@ -26,6 +26,10 @@ describe('generate (file paths)', function () {
                 meta: { },
                 create(context) {}
               },
+              'no-bar': {
+                meta: { schema: [{ type: 'object', properties: { option1: {} } }] },
+                create(context) {}
+              },
             },
           };`,
 
@@ -46,7 +50,7 @@ describe('generate (file paths)', function () {
       it('throws an error', async function () {
         // Use join to handle both Windows and Unix paths.
         await expect(generate('.')).rejects.toThrow(
-          `Could not find rule doc: ${join('docs', 'rules', 'no-foo.md')}`
+          `Could not find rule doc: ${join('docs', 'rules', 'no-bar.md')}`
         );
       });
     });
@@ -55,6 +59,7 @@ describe('generate (file paths)', function () {
       it('creates the rule doc', async function () {
         await generate('.', { initRuleDocs: true });
         expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
+        expect(readFileSync('docs/rules/no-bar.md', 'utf8')).toMatchSnapshot(); // Should add options section.
       });
     });
   });


### PR DESCRIPTION
When using `--init-rule-docs` to create rule docs, we should initialize the `## Options` section if the rule has options.

Follow-up to this new feature:
* https://github.com/bmish/eslint-doc-generator/pull/481