### PR TITLE
Add hint about using `--init-rule-docs` when rule doc missing

### DIFF
--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -157,7 +157,10 @@ export async function generate(path: string, options?: GenerateOptions) {
     if (!existsSync(pathToDoc)) {
       if (!initRuleDocs) {
         throw new Error(
-          `Could not find rule doc: ${relative(getPluginRoot(path), pathToDoc)}`
+          `Could not find rule doc (run with --init-rule-docs to create): ${relative(
+            getPluginRoot(path),
+            pathToDoc
+          )}`
         );
       }
 

--- a/test/lib/generate/file-paths-test.ts
+++ b/test/lib/generate/file-paths-test.ts
@@ -50,7 +50,11 @@ describe('generate (file paths)', function () {
       it('throws an error', async function () {
         // Use join to handle both Windows and Unix paths.
         await expect(generate('.')).rejects.toThrow(
-          `Could not find rule doc: ${join('docs', 'rules', 'no-bar.md')}`
+          `Could not find rule doc (run with --init-rule-docs to create): ${join(
+            'docs',
+            'rules',
+            'no-bar.md'
+          )}`
         );
       });
     });


### PR DESCRIPTION
This improves the discoverability of this option.