### PR TITLE
Better display of rule option default for array option

### DIFF
--- a/lib/rule-options-list.ts
+++ b/lib/rule-options-list.ts
@@ -45,6 +45,17 @@ const COLUMN_TYPE_DEFAULT_PRESENCE_AND_ORDERING: {
   [COLUMN_TYPE.DEPRECATED]: true,
 };
 
+/**
+ * Output could look like:
+ * - `[]`
+ * - [`hello world`, `1`, `2`, `true`]
+ */
+function arrayToString(arr: readonly unknown[]): string {
+  return `${arr.length === 0 ? '`' : ''}[${arr.length > 0 ? '`' : ''}${arr.join(
+    '`, `'
+  )}${arr.length > 0 ? '`' : ''}]${arr.length === 0 ? '`' : ''}`;
+}
+
 function ruleOptionToColumnValues(ruleOption: RuleOption): {
   [key in COLUMN_TYPE]: string | undefined;
 } {
@@ -55,6 +66,8 @@ function ruleOptionToColumnValues(ruleOption: RuleOption): {
     [COLUMN_TYPE.DEFAULT]:
       ruleOption.default === undefined
         ? undefined
+        : Array.isArray(ruleOption.default)
+        ? arrayToString(ruleOption.default)
         : `\`${String(ruleOption.default)}\``,
     [COLUMN_TYPE.DEPRECATED]: ruleOption.deprecated ? 'Yes' : undefined,
     [COLUMN_TYPE.DESCRIPTION]: ruleOption.description,

--- a/test/lib/generate/__snapshots__/rule-options-list-test.ts.snap
+++ b/test/lib/generate/__snapshots__/rule-options-list-test.ts.snap
@@ -7,17 +7,19 @@ exports[`generate (rule options list) basic generates the documentation 1`] = `
 ## Options
 <!-- begin auto-generated rule options list -->
 
-| Name                       | Description                   | Type                | Choices           | Default  | Required | Deprecated |
-| :------------------------- | :---------------------------- | :------------------ | :---------------- | :------- | :------- | :--------- |
-| \`arr1\`                     |                               | Array               |                   |          |          |            |
-| \`arrWithArrType\`           |                               | String, Boolean     |                   |          |          |            |
-| \`arrWithArrTypeSingleItem\` |                               | String              |                   |          |          |            |
-| \`arrWithItemsArrayType\`    |                               | (String, Boolean)[] |                   |          |          |            |
-| \`arrWithItemsType\`         |                               | String[]            |                   |          |          |            |
-| \`bar\`                      | Choose how to use the rule.   | String              | \`always\`, \`never\` | \`always\` | Yes      |            |
-| \`baz\`                      |                               |                     |                   | \`true\`   | Yes      |            |
-| \`biz\`                      |                               |                     |                   |          |          |            |
-| \`foo\`                      | Enable some kind of behavior. | Boolean             |                   | \`false\`  |          | Yes        |
+| Name                       | Description                   | Type                | Choices           | Default                                | Required | Deprecated |
+| :------------------------- | :---------------------------- | :------------------ | :---------------- | :------------------------------------- | :------- | :--------- |
+| \`arr1\`                     |                               | Array               |                   |                                        |          |            |
+| \`arrWithArrType\`           |                               | String, Boolean     |                   |                                        |          |            |
+| \`arrWithArrTypeSingleItem\` |                               | String              |                   |                                        |          |            |
+| \`arrWithDefault\`           |                               | Array               |                   | [\`hello world\`, \`1\`, \`2\`, \`3\`, \`true\`] |          |            |
+| \`arrWithDefaultEmpty\`      |                               | Array               |                   | \`[]\`                                   |          |            |
+| \`arrWithItemsArrayType\`    |                               | (String, Boolean)[] |                   |                                        |          |            |
+| \`arrWithItemsType\`         |                               | String[]            |                   |                                        |          |            |
+| \`bar\`                      | Choose how to use the rule.   | String              | \`always\`, \`never\` | \`always\`                               | Yes      |            |
+| \`baz\`                      |                               |                     |                   | \`true\`                                 | Yes      |            |
+| \`biz\`                      |                               |                     |                   |                                        |          |            |
+| \`foo\`                      | Enable some kind of behavior. | Boolean             |                   | \`false\`                                |          | Yes        |
 
 <!-- end auto-generated rule options list -->"
 `;

--- a/test/lib/generate/rule-options-list-test.ts
+++ b/test/lib/generate/rule-options-list-test.ts
@@ -66,6 +66,14 @@ describe('generate (rule options list)', function () {
                             type: ["string", "boolean"]
                           }
                         },
+                        arrWithDefaultEmpty: {
+                          type: "array",
+                          default: [],
+                        },
+                        arrWithDefault: {
+                          type: "array",
+                          default: ['hello world', 1, 2, 3, true],
+                        },
                     },
                     required: ["bar"],
                     additionalProperties: false


### PR DESCRIPTION
Before:

| Name       | Description                    | Type  | Default             |
| :--------- | :----------------------------- | :---- | :------------------ |
| `methods`  | An additional list of methods. | Array | ``                  |
| `methods2` | An additional list of methods. | Array | `hello world,1,2,3` |

After:

| Name       | Description                                                 | Type  | Default                        |
| :--------- | :---------------------------------------------------------- | :---- | :----------------------------- |
| `methods`  | An additional list of methods. | Array | `[]`                            |
| `methods2` | An additional list of methods. | Array | [`hello world`, `1`, `2`, `3`] |

Open to tweaking this further if there is a more standard or aesthetic format to use.

Part of: #491