### PR TITLE
Support multiple potential property locations for config description

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Delete any old rules list from your `README.md`. A new one will be automatically
 <!-- end auto-generated rules list -->
 ```
 
-Optionally, add these marker comments to your `README.md` in a `## Configs` section or similar location (uses the `description` property exported by each config if available):
+Optionally, add these marker comments to your `README.md` in a `## Configs` section or similar location (uses the `meta.docs.description` property exported by each config if available):
 
 ```md
 <!-- begin auto-generated configs list -->

--- a/test/lib/generate/__snapshots__/configs-list-test.ts.snap
+++ b/test/lib/generate/__snapshots__/configs-list-test.ts.snap
@@ -38,7 +38,7 @@ exports[`generate (configs list) when a config description needs to be escaped i
 <!-- end auto-generated configs list -->"
 `;
 
-exports[`generate (configs list) when a config exports a description generates the documentation 1`] = `
+exports[`generate (configs list) when a config exports a description property=description generates the documentation 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->
 
@@ -47,8 +47,48 @@ exports[`generate (configs list) when a config exports a description generates t
 | [no-foo](docs/rules/no-foo.md) | Description of no-foo. |
 
 <!-- end auto-generated rules list -->
-## Configs
-<!-- begin auto-generated configs list -->
+  ## Configs
+  <!-- begin auto-generated configs list -->
+
+|    | Name          | Description                              |
+| :- | :------------ | :--------------------------------------- |
+|    | \`foo\`         |                                          |
+| ✅  | \`recommended\` | This config has the recommended rules... |
+
+<!-- end auto-generated configs list -->"
+`;
+
+exports[`generate (configs list) when a config exports a description property=meta.description generates the documentation 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+| Name                           | Description            |
+| :----------------------------- | :--------------------- |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. |
+
+<!-- end auto-generated rules list -->
+  ## Configs
+  <!-- begin auto-generated configs list -->
+
+|    | Name          | Description                              |
+| :- | :------------ | :--------------------------------------- |
+|    | \`foo\`         |                                          |
+| ✅  | \`recommended\` | This config has the recommended rules... |
+
+<!-- end auto-generated configs list -->"
+`;
+
+exports[`generate (configs list) when a config exports a description property=meta.docs.description generates the documentation 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+| Name                           | Description            |
+| :----------------------------- | :--------------------- |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. |
+
+<!-- end auto-generated rules list -->
+  ## Configs
+  <!-- begin auto-generated configs list -->
 
 |    | Name          | Description                              |
 | :- | :------------ | :--------------------------------------- |

--- a/test/lib/generate/configs-list-test.ts
+++ b/test/lib/generate/configs-list-test.ts
@@ -193,48 +193,142 @@ describe('generate (configs list)', function () {
   });
 
   describe('when a config exports a description', function () {
-    beforeEach(function () {
-      mockFs({
-        'package.json': JSON.stringify({
-          name: 'eslint-plugin-test',
-          exports: 'index.js',
-          type: 'module',
-        }),
+    describe('property=description', function () {
+      beforeEach(function () {
+        mockFs({
+          'package.json': JSON.stringify({
+            name: 'eslint-plugin-test',
+            exports: 'index.js',
+            type: 'module',
+          }),
 
-        'index.js': `
-          export default {
-            rules: {
-              'no-foo': {
-                meta: { docs: { description: 'Description of no-foo.' }, },
-                create(context) {}
+          'index.js': `
+            export default {
+              rules: {
+                'no-foo': {
+                  meta: { docs: { description: 'Description of no-foo.' }, },
+                  create(context) {}
+                },
               },
-            },
-            configs: {
-              foo: {},
-              recommended: { description: 'This config has the recommended rules...' },
-            }
-          };`,
+              configs: {
+                foo: {},
+                recommended: { description: 'This config has the recommended rules...' },
+              }
+            };`,
 
-        'README.md': `## Rules
-## Configs
-<!-- begin auto-generated configs list -->
-<!-- end auto-generated configs list -->`,
+          'README.md': `## Rules
+  ## Configs
+  <!-- begin auto-generated configs list -->
+  <!-- end auto-generated configs list -->`,
 
-        'docs/rules/no-foo.md': '',
+          'docs/rules/no-foo.md': '',
 
-        // Needed for some of the test infrastructure to work.
-        node_modules: mockFs.load(PATH_NODE_MODULES),
+          // Needed for some of the test infrastructure to work.
+          node_modules: mockFs.load(PATH_NODE_MODULES),
+        });
+      });
+
+      afterEach(function () {
+        mockFs.restore();
+        jest.resetModules();
+      });
+
+      it('generates the documentation', async function () {
+        await generate('.');
+        expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
       });
     });
 
-    afterEach(function () {
-      mockFs.restore();
-      jest.resetModules();
+    describe('property=meta.description', function () {
+      beforeEach(function () {
+        mockFs({
+          'package.json': JSON.stringify({
+            name: 'eslint-plugin-test',
+            exports: 'index.js',
+            type: 'module',
+          }),
+
+          'index.js': `
+            export default {
+              rules: {
+                'no-foo': {
+                  meta: { docs: { description: 'Description of no-foo.' }, },
+                  create(context) {}
+                },
+              },
+              configs: {
+                foo: {},
+                recommended: { meta: { description: 'This config has the recommended rules...' } },
+              }
+            };`,
+
+          'README.md': `## Rules
+  ## Configs
+  <!-- begin auto-generated configs list -->
+  <!-- end auto-generated configs list -->`,
+
+          'docs/rules/no-foo.md': '',
+
+          // Needed for some of the test infrastructure to work.
+          node_modules: mockFs.load(PATH_NODE_MODULES),
+        });
+      });
+
+      afterEach(function () {
+        mockFs.restore();
+        jest.resetModules();
+      });
+
+      it('generates the documentation', async function () {
+        await generate('.');
+        expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
+      });
     });
 
-    it('generates the documentation', async function () {
-      await generate('.');
-      expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
+    describe('property=meta.docs.description', function () {
+      beforeEach(function () {
+        mockFs({
+          'package.json': JSON.stringify({
+            name: 'eslint-plugin-test',
+            exports: 'index.js',
+            type: 'module',
+          }),
+
+          'index.js': `
+            export default {
+              rules: {
+                'no-foo': {
+                  meta: { docs: { description: 'Description of no-foo.' }, },
+                  create(context) {}
+                },
+              },
+              configs: {
+                foo: {},
+                recommended: { meta: { docs: { description: 'This config has the recommended rules...' } } },
+              }
+            };`,
+
+          'README.md': `## Rules
+  ## Configs
+  <!-- begin auto-generated configs list -->
+  <!-- end auto-generated configs list -->`,
+
+          'docs/rules/no-foo.md': '',
+
+          // Needed for some of the test infrastructure to work.
+          node_modules: mockFs.load(PATH_NODE_MODULES),
+        });
+      });
+
+      afterEach(function () {
+        mockFs.restore();
+        jest.resetModules();
+      });
+
+      it('generates the documentation', async function () {
+        await generate('.');
+        expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
+      });
     });
   });
 


### PR DESCRIPTION
The official recommendation for where to store config description is still pending the outcome of:
* https://github.com/eslint/eslint/issues/17842

For now, we can support multiple potential locations.

Related:
* #506