### PR TITLE
chore(deps): update eslint-plugin-jest to 27.9.0

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -38,6 +38,7 @@ if (process.version.startsWith('v14.')) {
   // https://github.com/facebook/jest/issues/11438#issuecomment-954155180
   jestConfig.maxConcurrency = 30;
   jestConfig.maxWorkers = 30;
+  jestConfig.testTimeout = 10_000; // 10 seconds timeout (twice the default)
 }
 
 module.exports = jestConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@typescript-eslint/eslint-plugin": "^5.38.1",
         "@typescript-eslint/parser": "^5.38.1",
         "eslint": "^8.57.1",
-        "eslint-plugin-jest": "^27.0.4",
+        "eslint-plugin-jest": "^27.9.0",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-square": "^24.0.0",
         "jest": "^29.1.1",
@@ -5467,10 +5467,11 @@
       "dev": true
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "27.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.2.1.tgz",
-      "integrity": "sha512-l067Uxx7ZT8cO9NJuf+eJHvt6bqJyz2Z29wykyEdz/OtmcELQl2MQGQLX8J94O1cSJWAwUSEvCjwjA7KEK3Hmg==",
+      "version": "27.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.9.0.tgz",
+      "integrity": "sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": "^5.10.0"
       },
@@ -5478,8 +5479,9 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       },
       "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.0.0",
-        "eslint": "^7.0.0 || ^8.0.0"
+        "@typescript-eslint/eslint-plugin": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "eslint": "^7.0.0 || ^8.0.0",
+        "jest": "*"
       },
       "peerDependenciesMeta": {
         "@typescript-eslint/eslint-plugin": {
@@ -18163,9 +18165,9 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "27.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.2.1.tgz",
-      "integrity": "sha512-l067Uxx7ZT8cO9NJuf+eJHvt6bqJyz2Z29wykyEdz/OtmcELQl2MQGQLX8J94O1cSJWAwUSEvCjwjA7KEK3Hmg==",
+      "version": "27.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.9.0.tgz",
+      "integrity": "sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==",
       "dev": true,
       "requires": {
         "@typescript-eslint/utils": "^5.10.0"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@typescript-eslint/eslint-plugin": "^5.38.1",
     "@typescript-eslint/parser": "^5.38.1",
     "eslint": "^8.57.1",
-    "eslint-plugin-jest": "^27.0.4",
+    "eslint-plugin-jest": "^27.9.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-square": "^24.0.0",
     "jest": "^29.1.1",


### PR DESCRIPTION
- supports resolution of https://github.com/bmish/eslint-doc-generator/issues/529

## Issue

[eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest) is configured in [package.json](https://github.com/bmish/eslint-doc-generator/blob/39ec71433c0e6a24924f9833f81658cd80188ecf/package.json#L71) with version `^27.0.4` and locked to [eslint-plugin-jest@27.2.1](https://github.com/jest-community/eslint-plugin-jest/releases/tag/v27.2.1), released Jan 2023, in [package-lock.json](https://github.com/bmish/eslint-doc-generator/blob/main/package-lock.json).

A minimum version of [eslint-plugin-jest@27.9.0](https://github.com/jest-community/eslint-plugin-jest/releases/tag/v27.9.0) is required to support flat config files.

## Change

Update [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest) to [eslint-plugin-jest@27.9.0](https://github.com/jest-community/eslint-plugin-jest/releases/tag/v27.9.0) (latest `27.x` version)

Note: [eslint-plugin-jest@28.0.0](https://github.com/jest-community/eslint-plugin-jest/releases/tag/v28.0.0) or above cannot yet be used, since it drops support for `@typescript-eslint/eslint-plugin` `v5`.

## Verification

On Ubuntu `24.04.1` LTS, Node.js `18.20.4`

```shell
git clean -xfd
npm ci
npm run lint
npm test
```

Ignore warnings from `npm ci`:

```text
npm warn deprecated @npmcli/move-file@1.1.2: This functionality has been moved to @npmcli/fs
npm warn deprecated @humanwhocodes/config-array@0.13.0: Use @eslint/config-array instead
npm warn deprecated @humanwhocodes/object-schema@2.0.3: Use @eslint/object-schema instead
npm warn deprecated eslint@8.57.1: This version is no longer supported. Please see https://eslint.org/version-support for other options.
```

Confirm no errors and no uncommitted changes.