### PR TITLE
chore(deps): update @release-it-plugins/lerna-changelog to 7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
       },
       "devDependencies": {
         "@jest/globals": "^29.1.2",
-        "@release-it-plugins/lerna-changelog": "^5.0.0",
+        "@release-it-plugins/lerna-changelog": "^7.0.0",
         "@types/jest": "^29.1.0",
         "@types/mock-fs": "^4.13.1",
         "@types/node": "^20.1.4",
@@ -1508,24 +1508,24 @@
       }
     },
     "node_modules/@release-it-plugins/lerna-changelog": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@release-it-plugins/lerna-changelog/-/lerna-changelog-5.0.0.tgz",
-      "integrity": "sha512-nMhAUptKSfIsiY0c//HuBcd2VT7D/IoxAQNwRgPx+jf3FM7HA5KD4KSl3oLoz4uA4GjvypWQP4ODX8UbWjmUZA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@release-it-plugins/lerna-changelog/-/lerna-changelog-7.0.0.tgz",
+      "integrity": "sha512-IGHKdcUCyQ5ibtfkF2AQNMrMtyWF1aigic/ZWHPbD77B2zCcymzsyzVskhrGnHVeZGoOOG3vqGuE6U2INz8k6w==",
       "dev": true,
       "dependencies": {
         "execa": "^5.1.1",
         "lerna-changelog": "^2.2.0",
-        "lodash.template": "^4.5.0",
+        "lodash": "^4.17.21",
         "mdast-util-from-markdown": "^1.2.0",
         "tmp": "^0.2.1",
         "validate-peer-dependencies": "^2.0.0",
         "which": "^2.0.2"
       },
       "engines": {
-        "node": "^14.13.1 || >= 16"
+        "node": ">= 16"
       },
       "peerDependencies": {
-        "release-it": "^14.0.0 || ^15.1.3"
+        "release-it": "^14.0.0 || ^15.1.3 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@release-it-plugins/lerna-changelog/node_modules/resolve-package-path": {
@@ -7601,12 +7601,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "node_modules/lodash._reinterpolate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==",
-      "dev": true
-    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -7623,25 +7617,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    },
-    "node_modules/lodash.template": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
-      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-      "dev": true,
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.templatesettings": "^4.0.0"
-      }
-    },
-    "node_modules/lodash.templatesettings": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
-      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
-      "dev": true,
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0"
-      }
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -13595,14 +13570,14 @@
       }
     },
     "@release-it-plugins/lerna-changelog": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@release-it-plugins/lerna-changelog/-/lerna-changelog-5.0.0.tgz",
-      "integrity": "sha512-nMhAUptKSfIsiY0c//HuBcd2VT7D/IoxAQNwRgPx+jf3FM7HA5KD4KSl3oLoz4uA4GjvypWQP4ODX8UbWjmUZA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@release-it-plugins/lerna-changelog/-/lerna-changelog-7.0.0.tgz",
+      "integrity": "sha512-IGHKdcUCyQ5ibtfkF2AQNMrMtyWF1aigic/ZWHPbD77B2zCcymzsyzVskhrGnHVeZGoOOG3vqGuE6U2INz8k6w==",
       "dev": true,
       "requires": {
         "execa": "^5.1.1",
         "lerna-changelog": "^2.2.0",
-        "lodash.template": "^4.5.0",
+        "lodash": "^4.17.21",
         "mdast-util-from-markdown": "^1.2.0",
         "tmp": "^0.2.1",
         "validate-peer-dependencies": "^2.0.0",
@@ -17989,12 +17964,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "lodash._reinterpolate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==",
-      "dev": true
-    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -18011,25 +17980,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    },
-    "lodash.template": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
-      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-      "dev": true,
-      "requires": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.templatesettings": "^4.0.0"
-      }
-    },
-    "lodash.templatesettings": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
-      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
-      "dev": true,
-      "requires": {
-        "lodash._reinterpolate": "^3.0.0"
-      }
     },
     "log-symbols": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.1.2",
-    "@release-it-plugins/lerna-changelog": "^5.0.0",
+    "@release-it-plugins/lerna-changelog": "^7.0.0",
     "@types/jest": "^29.1.0",
     "@types/mock-fs": "^4.13.1",
     "@types/node": "^20.1.4",


### PR DESCRIPTION
## Issue

- The currently configured [@release-it-plugins/lerna-changelog@^5.0.0](https://github.com/release-it-plugins/lerna-changelog/releases/tag/v5.0.0) is blocking PR https://github.com/bmish/eslint-doc-generator/pull/551 from succeeding.

- To bump `release-it` from `15.6.0` to [release-it@17.10.0](https://github.com/release-it/release-it/releases/tag/17.10.0) needs a minimum of [release-it-plugins/lerna-changelog@6.1.0](https://github.com/release-it-plugins/lerna-changelog/releases/tag/v6.1.0) before it will install.

## Change

Update [@release-it-plugins/lerna-changelog](https://www.npmjs.com/package/@release-it-plugins/lerna-changelog) to [@release-it-plugins/lerna-changelog@7.0.0](https://github.com/release-it-plugins/lerna-changelog/releases/tag/v7.0.0) (current `latest`).

## Verify

Ubuntu `24.04.1` LTS, Node.js `v18.20.4`

```shell
npm ci
```

and confirm no dependency errors / warnings apart from known deprecations:

```text
$ npm ci
npm warn deprecated @npmcli/move-file@1.1.2: This functionality has been moved to @npmcli/fs
npm warn deprecated @humanwhocodes/config-array@0.13.0: Use @eslint/config-array instead
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated @humanwhocodes/object-schema@2.0.3: Use @eslint/object-schema instead
npm warn deprecated eslint@8.57.1: This version is no longer supported. Please see https://eslint.org/version-support for other options.
```
