### PR TITLE
Require Node 18, 20, 22+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu, windows ]
-        node-version: [18.x]
+        node-version: [18.x, 20.x, 22.x, 23.x]
 
     steps:
     - uses: actions/checkout@v4

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -32,13 +32,4 @@ const jestConfig = {
   },
 };
 
-if (process.version.startsWith('v14.')) {
-  // TODO: remove this workaround after dropping support for Node 14.
-  // Use number greater than number of test suites to avoid: "You are trying to `import` a file after the Jest environment has been torn down."
-  // https://github.com/facebook/jest/issues/11438#issuecomment-954155180
-  jestConfig.maxConcurrency = 30;
-  jestConfig.maxWorkers = 30;
-  jestConfig.testTimeout = 10_000; // 10 seconds timeout (twice the default)
-}
-
 module.exports = jestConfig;

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "eslint": ">= 7"
   },
   "engines": {
-    "node": "^14.18.0 || ^16.0.0 || >=18.0.0"
+    "node": "^18.18.0 || ^20.9.0 || >=22.0.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
https://github.com/nodejs/Release#release-schedule

Follow-up to:
* https://github.com/bmish/eslint-doc-generator/pull/536

Match ESLint engines but also drop Node 21: https://github.com/eslint/eslint/blob/4b3132c3f55db6b51665c4c42bb762d00e266262/package.json#L217

There are two more `TODO` comments related to dropping Node 14 support that can be handled later.

Fixes #554.
Fixes #546.
Fixes #543.