### PR TITLE
Use async file access

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -186,7 +186,7 @@ export async function run(
 
   // Documentation for options should be kept in sync with README.md and the JSDocs for the `GenerateOptions` type.
   await program
-    .version(getCurrentPackageVersion())
+    .version(await getCurrentPackageVersion())
     .addArgument(
       new Argument('[path]', 'path to ESLint plugin root').default('.')
     )


### PR DESCRIPTION
This seems to fix an issue where jest test snapshots of the output files have text cutoff at the end starting in Node 20. Could be an issue related to mock-fs. 

It should be better practice to use the async methods anyway.