### PR TITLE
Drop support below ESLint v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "typescript-eslint": "^8.0.0"
   },
   "peerDependencies": {
-    "eslint": ">= 7"
+    "eslint": ">= 8.57.1"
   },
   "engines": {
     "node": "^18.18.0 || ^20.9.0 || >=22.0.0"


### PR DESCRIPTION
Technically, ESLint v8 is end-of-life: https://eslint.org/blog/2024/09/eslint-v8-eol-version-support/

However, a lot of users will be stuck on ESLint v8 for a while, as noted by the npm download numbers https://www.npmjs.com/package/eslint?activeTab=versions, given the larger changes needed to migrate to flat config, so it doesn't hurt for us to continue to support the final version of ESLint v8.

Theoretically, dropping support for old versions of ESLint could make development easier for us. However, we haven't identified tangible examples of this yet. So we can be flexible on this as needed.