### PR TITLE
Switch to `change-case`

### DIFF
--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -35,7 +35,7 @@ import { EMOJIS_TYPE } from './rule-type.js';
 import { hasOptions } from './rule-options.js';
 import { getLinkToRule } from './rule-link.js';
 import { capitalizeOnlyFirstLetter, sanitizeMarkdownTable } from './string.js';
-import { noCase } from 'no-case';
+import { noCase } from 'change-case';
 import { getProperty } from 'dot-prop';
 import { boolean, isBooleanable } from 'boolean';
 import Ajv from 'ajv';
@@ -370,9 +370,10 @@ function getRulesAndHeadersForSplit(
       if (!ruleListSplitFinalPart) {
         throw new Error(`Invalid ruleListSplit value "${ruleListSplitItem}".`);
       }
-      const ruleListSplitTitle = noCase(ruleListSplitFinalPart, {
-        transform: (str) => capitalizeOnlyFirstLetter(str),
-      });
+      const ruleListSplitTitle = noCase(ruleListSplitFinalPart)
+        .split(' ')
+        .map((word) => capitalizeOnlyFirstLetter(word))
+        .join(' ');
 
       // Add a list for the rules with property set to this value.
       rulesAndHeadersForThisSplit.push({

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "json-schema": "^0.4.0",
         "json-schema-traverse": "^1.0.0",
         "markdown-table": "^3.0.3",
-        "no-case": "^3.0.4",
+        "no-case": "^4.0.0",
         "type-fest": "^4.0.0"
       },
       "bin": {
@@ -60,7 +60,7 @@
         "node": "^18.18.0 || ^20.9.0 || >=22.0.0"
       },
       "peerDependencies": {
-        "eslint": ">= 7"
+        "eslint": ">= 8.57.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -7941,15 +7941,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -9162,14 +9153,10 @@
       }
     },
     "node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "license": "MIT",
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-4.0.0.tgz",
+      "integrity": "sha512-WmS3EUGw+vXHlTgiUPi3NzbZNwH6+uGX0QLGgqG+aFSJ5rkX/Ee0nuwHBJfZTfQwwR8lGO819NEIwQ7CGhkdEQ==",
+      "deprecated": "Use `change-case`"
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -12623,6 +12610,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@typescript-eslint/utils": "^8.0.0",
         "ajv": "^8.11.2",
         "boolean": "^3.2.0",
+        "change-case": "^5.0.0",
         "commander": "^12.1.0",
         "cosmiconfig": "^9.0.0",
         "deepmerge": "^4.2.2",
@@ -20,7 +21,6 @@
         "json-schema": "^0.4.0",
         "json-schema-traverse": "^1.0.0",
         "markdown-table": "^3.0.3",
-        "no-case": "^4.0.0",
         "type-fest": "^4.0.0"
       },
       "bin": {
@@ -3484,6 +3484,12 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "license": "MIT"
     },
     "node_modules/char-regex": {
       "version": "1.0.2",
@@ -9285,12 +9291,6 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
-    },
-    "node_modules/no-case": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-4.0.0.tgz",
-      "integrity": "sha512-WmS3EUGw+vXHlTgiUPi3NzbZNwH6+uGX0QLGgqG+aFSJ5rkX/Ee0nuwHBJfZTfQwwR8lGO819NEIwQ7CGhkdEQ==",
-      "deprecated": "Use `change-case`"
     },
     "node_modules/node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "json-schema": "^0.4.0",
     "json-schema-traverse": "^1.0.0",
     "markdown-table": "^3.0.3",
-    "no-case": "^3.0.4",
+    "no-case": "^4.0.0",
     "type-fest": "^4.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@typescript-eslint/utils": "^8.0.0",
     "ajv": "^8.11.2",
     "boolean": "^3.2.0",
+    "change-case": "^5.0.0",
     "commander": "^12.1.0",
     "cosmiconfig": "^9.0.0",
     "deepmerge": "^4.2.2",
@@ -56,7 +57,6 @@
     "json-schema": "^0.4.0",
     "json-schema-traverse": "^1.0.0",
     "markdown-table": "^3.0.3",
-    "no-case": "^4.0.0",
     "type-fest": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`no-case` is deprecated in favor of `change-case`.

https://github.com/blakeembrey/change-case/releases/tag/change-case%405.0.0

https://github.com/blakeembrey/change-case/tree/main/packages/change-case#built-in-methods

Originally added in:
* https://github.com/bmish/eslint-doc-generator/pull/314