### PR TITLE
Fix deprecated boolean package warning

### DIFF
--- a/lib/boolean.ts
+++ b/lib/boolean.ts
@@ -1,3 +1,25 @@
+export function boolean(value: unknown): boolean {
+  switch (typeof value) {
+    case 'string': {
+      return ['true', 't', 'yes', 'y', 'on', '1'].includes(
+        value.trim().toLowerCase(),
+      );
+    }
+
+    case 'number': {
+      return value.valueOf() === 1;
+    }
+
+    case 'boolean': {
+      return value.valueOf();
+    }
+
+    default: {
+      return false;
+    }
+  }
+}
+
 export function isBooleanable(value: unknown): boolean {
   switch (typeof value) {
     case 'string': {

--- a/lib/boolean.ts
+++ b/lib/boolean.ts
@@ -1,0 +1,32 @@
+export function isBooleanable(value: unknown): boolean {
+  switch (typeof value) {
+    case 'string': {
+      return [
+        'true',
+        't',
+        'yes',
+        'y',
+        'on',
+        '1',
+        'false',
+        'f',
+        'no',
+        'n',
+        'off',
+        '0',
+      ].includes(value.trim().toLowerCase());
+    }
+
+    case 'number': {
+      return [0, 1].includes(Number(value).valueOf());
+    }
+
+    case 'boolean': {
+      return true;
+    }
+
+    default: {
+      return false;
+    }
+  }
+}

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -11,7 +11,7 @@ import {
   OPTION_TYPE,
 } from './types.js';
 import { getCurrentPackageVersion } from './package-json.js';
-import { boolean, isBooleanable } from 'boolean';
+import { boolean, isBooleanable } from './boolean.js';
 import { CONFIG_FORMATS } from './config-format.js';
 
 /**

--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -40,7 +40,7 @@ import {
 } from './string.js';
 import { noCase } from 'change-case';
 import { getProperty } from 'dot-prop';
-import { boolean, isBooleanable } from 'boolean';
+import { boolean, isBooleanable } from './boolean.js';
 import Ajv from 'ajv';
 import { ConfigFormat } from './config-format.js';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@typescript-eslint/utils": "^8.0.0",
         "ajv": "^8.11.2",
-        "boolean": "^3.2.0",
         "change-case": "^5.0.0",
         "commander": "^12.1.0",
         "cosmiconfig": "^9.0.0",
@@ -2877,13 +2876,6 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
-    },
-    "node_modules/boolean": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
-      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT"
     },
     "node_modules/boxen": {
       "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   "dependencies": {
     "@typescript-eslint/utils": "^8.0.0",
     "ajv": "^8.11.2",
-    "boolean": "^3.2.0",
     "change-case": "^5.0.0",
     "commander": "^12.1.0",
     "cosmiconfig": "^9.0.0",

--- a/test/lib/boolean-test.ts
+++ b/test/lib/boolean-test.ts
@@ -1,6 +1,30 @@
-import { isBooleanable } from '../../lib/boolean.js';
+import { boolean, isBooleanable } from '../../lib/boolean.js';
 
 describe('boolean', function () {
+  describe('#boolean', function () {
+    it.each(['true', 't', 'yes', 'y', 'on', '1'])(
+      'returns true when string is %s',
+      function (value) {
+        expect(boolean(value)).toBe(true);
+      },
+    );
+
+    it('returns true when number is 1', function () {
+      expect(boolean(1)).toBe(true);
+    });
+
+    it('returns true when boolean is true', function () {
+      expect(boolean(true)).toBe(true);
+    });
+
+    it.each(['foo', 2, undefined])(
+      'returns false when value is %p',
+      function (value) {
+        expect(boolean(value)).toBe(false);
+      },
+    );
+  });
+
   describe('#isBooleanable', function () {
     it.each([
       'true',

--- a/test/lib/boolean-test.ts
+++ b/test/lib/boolean-test.ts
@@ -1,0 +1,37 @@
+import { isBooleanable } from '../../lib/boolean.js';
+
+describe('boolean', function () {
+  describe('#isBooleanable', function () {
+    it.each([
+      'true',
+      't',
+      'yes',
+      'y',
+      'on',
+      '1',
+      'false',
+      'f',
+      'no',
+      'n',
+      'off',
+      '0',
+    ])('returns true when string is %s', function (value) {
+      expect(isBooleanable(value)).toBe(true);
+    });
+
+    it.each([0, 1])('returns true when number is %i', function (value) {
+      expect(isBooleanable(value)).toBe(true);
+    });
+
+    it.each([true, false])('returns when boolean is %s', function (value) {
+      expect(isBooleanable(value)).toBe(true);
+    });
+
+    it.each(['foo', 2, undefined])(
+      'returns false when value is %p',
+      function (value) {
+        expect(isBooleanable(value)).toBe(false);
+      },
+    );
+  });
+});


### PR DESCRIPTION
Hi!
First of all, I want to say that I’ve been using eslint-doc-generator for a while and it has been very helpful! 😄

I noticed that when installing eslint-doc-generator, a warning about the deprecated boolean package appeared. To resolve this issue, I’ve created this PR. Most of the changes are based on the boolean package itself.

Please review the changes when you get a chance. Thank you for your time and consideration.