### PR TITLE
Support ESLint plugins with `"type": "module"` and `main` in package.json

### DIFF
--- a/lib/package-json.ts
+++ b/lib/package-json.ts
@@ -62,6 +62,10 @@ export async function loadPlugin(path: string): Promise<Plugin> {
       }
     }
 
+    if (pluginPackageJson.type === 'module' && !exports) {
+      pluginEntryPoint = pluginPackageJson.main;
+    }
+
     // If the ESM export doesn't exist, fall back to throwing the CJS error
     // (if the ESM export does exist, we'll validate it next)
     if (!pluginEntryPoint) {

--- a/test/lib/generate/package-json-test.ts
+++ b/test/lib/generate/package-json-test.ts
@@ -355,6 +355,44 @@ describe('generate (package.json)', function () {
     });
   });
 
+  describe("plugin entry point with type: 'module' and main field specified", function () {
+    beforeEach(function () {
+      mockFs({
+        'package.json': JSON.stringify({
+          name: 'eslint-plugin-test',
+          main: 'index.js',
+          type: 'module',
+        }),
+
+        'index.js': `export default {
+          rules: {
+            'no-foo': {
+              meta: { docs: { description: 'disallow foo.' }, },
+              create(context) {}
+            },
+          },
+        };`,
+
+        'README.md':
+          '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
+
+        'docs/rules/no-foo.md': '',
+
+        // Needed for some of the test infrastructure to work.
+        node_modules: mockFs.load(PATH_NODE_MODULES),
+      });
+    });
+
+    afterEach(function () {
+      mockFs.restore();
+      jest.resetModules();
+    });
+
+    it('finds the entry point', async function () {
+      await expect(generate('.')).resolves.toBeUndefined();
+    });
+  });
+
   describe('passing absolute path for plugin root', function () {
     beforeEach(function () {
       mockFs({


### PR DESCRIPTION


```json
{
  "main": "./dist/index.js",
  "type": "module",
  ...
}
```

Fixed an issue where the following error occurred with a package.json using `"type": "module"`:


```
require() of ES Module  ***/dist/index.js not supported.
Instead change the require of ***/dist/index.js to a dynamic import() which is available in all CommonJS modules.
```


#504  might be somewhat related to this.





