### PR TITLE
Update editor suggestions link

### DIFF
--- a/docs/examples/eslint-plugin-test/README.md
+++ b/docs/examples/eslint-plugin-test/README.md
@@ -25,7 +25,7 @@ This plugin is for x purpose.
 🎨 Set in the `stylistic` configuration.\
 ⌨️ Set in the `typescript` configuration.\
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
-💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).\
+💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/extend/custom-rules#providing-suggestions).\
 ⚙️ Has configuration options.\
 💭 Requires [type information](https://typescript-eslint.io/linting/typed-linting).\
 🗂️ The type of rule.\

--- a/docs/examples/eslint-plugin-test/docs/rules/prefer-bar.md
+++ b/docs/examples/eslint-plugin-test/docs/rules/prefer-bar.md
@@ -2,7 +2,7 @@
 
 💼⚠️ This rule is enabled in the ✅ `recommended` config. This rule _warns_ in the 🎨 `stylistic` config.
 
-💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
+💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/latest/extend/custom-rules#providing-suggestions).
 
 💭 This rule requires [type information](https://typescript-eslint.io/linting/typed-linting).
 

--- a/lib/rule-doc-notices.ts
+++ b/lib/rule-doc-notices.ts
@@ -84,7 +84,7 @@ function configsToNoticeSentence(
 
 // A few individual notices declared here just so they can be reused in multiple notices.
 const NOTICE_FIXABLE = `${EMOJI_FIXABLE} This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).`;
-const NOTICE_HAS_SUGGESTIONS = `${EMOJI_HAS_SUGGESTIONS} This rule is manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).`;
+const NOTICE_HAS_SUGGESTIONS = `${EMOJI_HAS_SUGGESTIONS} This rule is manually fixable by [editor suggestions](https://eslint.org/docs/latest/extend/custom-rules#providing-suggestions).`;
 
 /**
  * An object containing the text for each notice type (as a string or function to generate the string).
@@ -242,7 +242,7 @@ const RULE_NOTICES: {
   [NOTICE_TYPE.FIXABLE]: NOTICE_FIXABLE,
   [NOTICE_TYPE.FIXABLE_AND_HAS_SUGGESTIONS]: ({ fixable, hasSuggestions }) => {
     if (fixable && hasSuggestions) {
-      return `${EMOJI_FIXABLE}${EMOJI_HAS_SUGGESTIONS} This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) and manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).`;
+      return `${EMOJI_FIXABLE}${EMOJI_HAS_SUGGESTIONS} This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) and manually fixable by [editor suggestions](https://eslint.org/docs/latest/extend/custom-rules#providing-suggestions).`;
     } else if (fixable) {
       return NOTICE_FIXABLE;
     } else if (hasSuggestions) {

--- a/lib/rule-list-legend.ts
+++ b/lib/rule-list-legend.ts
@@ -31,7 +31,7 @@ export const SEVERITY_TYPE_TO_WORD: {
 
 // A few individual legends declared here just so they can be reused in multiple legends.
 const LEGEND_FIXABLE = `${EMOJI_FIXABLE} Automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).`;
-const LEGEND_HAS_SUGGESTIONS = `${EMOJI_HAS_SUGGESTIONS} Manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).`;
+const LEGEND_HAS_SUGGESTIONS = `${EMOJI_HAS_SUGGESTIONS} Manually fixable by [editor suggestions](https://eslint.org/docs/latest/extend/custom-rules#providing-suggestions).`;
 
 /**
  * An object containing the legends for each column (as a string or function to generate the string).

--- a/test/lib/generate/__snapshots__/general-test.ts.snap
+++ b/test/lib/generate/__snapshots__/general-test.ts.snap
@@ -11,7 +11,7 @@ Description.
 ✅ Set in the \`recommended\` configuration.\\
 🎨 Set in the \`style\` configuration.\\
 🔧 Automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\\
-💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
+💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/extend/custom-rules#providing-suggestions).
 
 | Name                           | Description            | 💼    | 🔧 | 💡 |
 | :----------------------------- | :--------------------- | :---- | :- | :- |
@@ -28,7 +28,7 @@ exports[`generate (general) basic updates the documentation 2`] = `
 
 💼 This rule is enabled in the following configs: 🌐 \`all\`, ✅ \`recommended\`.
 
-🔧💡 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) and manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
+🔧💡 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) and manually fixable by [editor suggestions](https://eslint.org/docs/latest/extend/custom-rules#providing-suggestions).
 
 <!-- end auto-generated rule header -->
 ## Rule details

--- a/test/lib/generate/__snapshots__/option-rule-doc-notices-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-rule-doc-notices-test.ts.snap
@@ -5,7 +5,7 @@ exports[`generate (--rule-doc-notices) basic shows the right rule doc notices 1`
 <!-- begin auto-generated rules list -->
 
 🔧 Automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\\
-💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).\\
+💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/extend/custom-rules#providing-suggestions).\\
 ❌ Deprecated.
 
 | Name                           | Description             | 🔧 | 💡 | ❌  |
@@ -19,7 +19,7 @@ exports[`generate (--rule-doc-notices) basic shows the right rule doc notices 1`
 exports[`generate (--rule-doc-notices) basic shows the right rule doc notices 2`] = `
 "# Description for no-foo (\`test/no-foo\`)
 
-💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
+💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/latest/extend/custom-rules#providing-suggestions).
 
 🔧 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/test/lib/generate/__snapshots__/option-rule-list-columns-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-rule-list-columns-test.ts.snap
@@ -4,7 +4,7 @@ exports[`generate (--rule-list-columns) basic shows the right columns and legend
 "## Rules
 <!-- begin auto-generated rules list -->
 
-💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).\\
+💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/extend/custom-rules#providing-suggestions).\\
 🔧 Automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
 | 💡 | 🔧 | Name                           |
@@ -20,7 +20,7 @@ exports[`generate (--rule-list-columns) basic shows the right columns and legend
 
 ❌ This rule is deprecated.
 
-🔧💡 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) and manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
+🔧💡 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) and manually fixable by [editor suggestions](https://eslint.org/docs/latest/extend/custom-rules#providing-suggestions).
 
 <!-- end auto-generated rule header -->
 "
@@ -31,7 +31,7 @@ exports[`generate (--rule-list-columns) consolidated fixableAndHasSuggestions co
 <!-- begin auto-generated rules list -->
 
 🔧 Automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\\
-💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
+💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/extend/custom-rules#providing-suggestions).
 
 | Name                           | 🔧💡 |
 | :----------------------------- | :--- |

--- a/test/lib/generate/__snapshots__/option-rule-list-split-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-rule-list-split-test.ts.snap
@@ -197,7 +197,7 @@ exports[`generate (--rule-list-split) with boolean (camelCase) splits the list w
 "## Rules
 <!-- begin auto-generated rules list -->
 
-💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
+💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/extend/custom-rules#providing-suggestions).
 
 | Name                           | 💡 |
 | :----------------------------- | :- |


### PR DESCRIPTION
The editor suggestions link was leading to a "Page not found" page.
Updated the link to point to the correct destination.