### PR TITLE
Fix ESM support in Node 22+ when the package includes the `main` property

### DIFF
--- a/lib/package-json.ts
+++ b/lib/package-json.ts
@@ -35,8 +35,19 @@ async function loadPackageJson(path: string): Promise<PackageJson> {
 export async function loadPlugin(path: string): Promise<Plugin> {
   const pluginRoot = getPluginRoot(path);
   try {
-    // Try require first which should work for CJS plugins.
-    return require(pluginRoot) as Plugin; // eslint-disable-line import/no-dynamic-require
+    /**
+     * Try require first which should work for CJS plugins.
+     * From Node 22 requiring on ESM module returns the module object
+     * @see https://github.com/bmish/eslint-doc-generator/issues/615
+     */
+    type cjsOrEsmPlugin = Plugin | { __esModule: boolean; default: Plugin };
+    // eslint-disable-next-line import/no-dynamic-require
+    const _plugin = require(pluginRoot) as cjsOrEsmPlugin;
+
+    if ('__esModule' in _plugin && _plugin.__esModule && _plugin.default) {
+      return _plugin.default;
+    }
+    return _plugin as Plugin;
   } catch (error) {
     // Otherwise, for ESM plugins, we'll have to try to resolve the exact plugin entry point and import it.
     const pluginPackageJson = await loadPackageJson(path);

--- a/lib/package-json.ts
+++ b/lib/package-json.ts
@@ -44,6 +44,7 @@ export async function loadPlugin(path: string): Promise<Plugin> {
     // eslint-disable-next-line import/no-dynamic-require
     const _plugin = require(pluginRoot) as cjsOrEsmPlugin;
 
+    /* istanbul ignore next */
     if ('__esModule' in _plugin && _plugin.__esModule && _plugin.default) {
       return _plugin.default;
     }

--- a/test/lib/generate/cjs-test.ts
+++ b/test/lib/generate/cjs-test.ts
@@ -62,11 +62,7 @@ describe('generate (cjs)', function () {
 
   describe('package.json `main` field points to non-existent file', function () {
     it('throws an error', async function () {
-      const FIXTURE_PATH = join(
-        'test',
-        'fixtures',
-        'cjs-main-file-does-not-exist',
-      );
+      const FIXTURE_PATH = join(FIXTURE_ROOT, 'cjs-main-file-does-not-exist');
       await expect(generate(FIXTURE_PATH)).rejects.toThrow(
         /Cannot find module/u,
       );


### PR DESCRIPTION
Try to close #615

This PR adds a check in the `loadPlugin` `require` inside `package-json.ts` to verify if the returned value is an `ESModule`, in an attempt to resolve #615.

> [!WARNING]  
> I was unable to create a fixture inside `test/fixtures` to add a test to avoid regression.  
> I created a new fixture named `esm` with a `package.json` of type `module`, including `main` and `exports` entries. 
> However, when running `jest`, the `require` call consistently threw an error, making my code unreachable.

---

In `test/lib/generate/cjs-test.ts`, 
within the `'package.json main field points to a non-existent file'` test, 
I updated the `FIXTURE_PATH` generation to align with the pattern used in other tests.