### PR TITLE
chore: use `.prettierrc.json` instead of `eslint` `prettier` rule to configure format options

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,1 +1,4 @@
-{}
+{
+  "$schema": "https://json.schemastore.org/prettierrc",
+  "singleQuote": true
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,12 +25,7 @@ export default tseslint.config(
     rules: {
       'n/no-missing-import': 'off', // bug with recognizing node: prefix https://github.com/mysticatea/eslint-plugin-node/issues/275
 
-      'prettier/prettier': [
-        'error',
-        {
-          singleQuote: true,
-        },
-      ],
+      'prettier/prettier': 'error', // see `.prettierrc.json` for format config
 
       // unicorn rules:
       'unicorn/expiring-todo-comments': 'off',


### PR DESCRIPTION
During #648 I have some clash between Prettier and ESLint:
I'm using an editor with support for both tools, however they have a different behaviour when dealing with quotes:
- `eslint` was using single quotes due to the inline configuration of `eslint.config.js`
   https://github.com/bmish/eslint-doc-generator/blob/f73317020aa916ca7fa29eeed2edb33fcc7858dd/eslint.config.js#L28-L33
- `prettier` was using the double quotes, which is prettier default due to the empty config in `.prettierrc.json`
  https://github.com/bmish/eslint-doc-generator/blob/f73317020aa916ca7fa29eeed2edb33fcc7858dd/.prettierrc.json#L1

To resolve this inconsistency, I added the `singleQuote` option to `.prettierrc.json` and removed it from `eslint.config.js`. 
There should be no further issues since the ESLint plugin now reads options directly from Prettier's configuration: 
https://github.com/prettier/eslint-plugin-prettier?tab=readme-ov-file#options