### PR TITLE
fix: detect rule prefix from ConfigsToRules and apply to rule doc title

### DIFF
--- a/lib/plugin-configs.ts
+++ b/lib/plugin-configs.ts
@@ -45,17 +45,18 @@ export function getConfigsThatSetARule(
 export function getConfigsForRule(
   ruleName: string,
   configsToRules: ConfigsToRules,
-  pluginPrefix: string,
+  pluginPrefix: string | undefined,
   severityType?: SEVERITY_TYPE,
 ) {
   const severity = severityType
     ? SEVERITY_TYPE_TO_SET[severityType]
     : undefined;
   const configNames: Array<keyof typeof configsToRules> = [];
+  const prefix = pluginPrefix ? `${pluginPrefix}/` : '';
 
   for (const configName in configsToRules) {
     const rules = configsToRules[configName];
-    const value = rules[`${pluginPrefix}/${ruleName}`];
+    const value = rules[`${prefix}${ruleName}`];
     const isSet =
       ((typeof value === 'string' || typeof value === 'number') &&
         (!severity || severity.has(value))) ||

--- a/lib/rule-link.ts
+++ b/lib/rule-link.ts
@@ -31,7 +31,7 @@ function pathToUrl(path: string): string {
 export function getUrlToRule(
   ruleName: string,
   ruleSource: RULE_SOURCE,
-  pluginPrefix: string,
+  pluginPrefix: string | undefined,
   pathPlugin: string,
   pathRuleDoc: string | PathRuleDocFunction,
   pathCurrentPage: string,
@@ -51,10 +51,12 @@ export function getUrlToRule(
     }
   }
 
+  const prefix = pluginPrefix ? `${pluginPrefix}/` : '';
+
   // Ignore plugin prefix if it's included in rule name.
   // While we could display the prefix if we wanted, it definitely cannot be part of the link.
-  const ruleNameWithoutPluginPrefix = ruleName.startsWith(`${pluginPrefix}/`)
-    ? ruleName.slice(pluginPrefix.length + 1)
+  const ruleNameWithoutPluginPrefix = ruleName.startsWith(prefix)
+    ? ruleName.slice(prefix.length + 1)
     : ruleName;
 
   // If the URL is a function, evaluate it.
@@ -85,7 +87,7 @@ export function getUrlToRule(
 export function getLinkToRule(
   ruleName: string,
   plugin: Plugin,
-  pluginPrefix: string,
+  pluginPrefix: string | undefined,
   pathPlugin: string,
   pathRuleDoc: string | PathRuleDocFunction,
   pathCurrentPage: string,
@@ -93,8 +95,9 @@ export function getLinkToRule(
   includePrefix: boolean,
   urlRuleDoc?: string | UrlRuleDocFunction,
 ) {
-  const ruleNameWithoutPluginPrefix = ruleName.startsWith(`${pluginPrefix}/`)
-    ? ruleName.slice(pluginPrefix.length + 1)
+  const prefix = pluginPrefix ? `${pluginPrefix}/` : '';
+  const ruleNameWithoutPluginPrefix = ruleName.startsWith(prefix)
+    ? ruleName.slice(prefix.length + 1)
     : ruleName;
 
   // Determine what plugin this rule comes from.
@@ -108,10 +111,10 @@ export function getLinkToRule(
     ruleSource = RULE_SOURCE.eslintCore;
   }
 
-  const ruleNameWithPluginPrefix = ruleName.startsWith(`${pluginPrefix}/`)
+  const ruleNameWithPluginPrefix = ruleName.startsWith(prefix)
     ? ruleName
     : ruleSource === RULE_SOURCE.self
-      ? `${pluginPrefix}/${ruleName}`
+      ? `${prefix}${ruleName}`
       : undefined;
 
   const urlToRule = getUrlToRule(

--- a/test/fixtures/cjs/docs/rules/no-foo.md
+++ b/test/fixtures/cjs/docs/rules/no-foo.md
@@ -1,3 +1,3 @@
-# Disallow foo (`test/no-foo`)
+# Disallow foo (`no-foo`)
 
 <!-- end auto-generated rule header -->

--- a/test/lib/generate/__snapshots__/cjs-test.ts.snap
+++ b/test/lib/generate/__snapshots__/cjs-test.ts.snap
@@ -14,7 +14,7 @@ exports[`generate (cjs) basic generates the documentation 1`] = `
 `;
 
 exports[`generate (cjs) basic generates the documentation 2`] = `
-"# Disallow foo (\`test/no-foo\`)
+"# Disallow foo (\`no-foo\`)
 
 <!-- end auto-generated rule header -->
 "

--- a/test/lib/generate/__snapshots__/comment-markers-test.ts.snap
+++ b/test/lib/generate/__snapshots__/comment-markers-test.ts.snap
@@ -38,7 +38,7 @@ exports[`generate (comment markers) no existing comment markers - minimal doc co
 `;
 
 exports[`generate (comment markers) no existing comment markers - minimal doc content generates the documentation 2`] = `
-"# Description of no-foo (\`test/no-foo\`)
+"# Description of no-foo (\`no-foo\`)
 
 🔧 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
@@ -79,7 +79,7 @@ Existing rules section content."
 `;
 
 exports[`generate (comment markers) no existing comment markers - with no blank lines in existing content generates the documentation 2`] = `
-"# Description of no-foo (\`test/no-foo\`)
+"# Description of no-foo (\`no-foo\`)
 
 🔧 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
@@ -103,7 +103,7 @@ Existing rules section content."
 `;
 
 exports[`generate (comment markers) no existing comment markers - with one blank line around existing content generates the documentation 2`] = `
-"# Description of no-foo (\`test/no-foo\`)
+"# Description of no-foo (\`no-foo\`)
 
 🔧 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
@@ -173,7 +173,7 @@ No blank line before this."
 `;
 
 exports[`generate (comment markers) with no blank lines around comment markers generates the documentation 2`] = `
-"# Description of no-foo (\`test/no-foo\`)
+"# Description of no-foo (\`no-foo\`)
 
 🔧 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
@@ -200,7 +200,7 @@ One blank line before this."
 `;
 
 exports[`generate (comment markers) with one blank line around comment markers generates the documentation 2`] = `
-"# Description of no-foo (\`test/no-foo\`)
+"# Description of no-foo (\`no-foo\`)
 
 🔧 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/test/lib/generate/__snapshots__/editor-config-test.ts.snap
+++ b/test/lib/generate/__snapshots__/editor-config-test.ts.snap
@@ -26,14 +26,14 @@ exports[`string (getEndOfLine) generates using the correct end of line when .edi
 `;
 
 exports[`string (getEndOfLine) generates using the correct end of line when .editorconfig exists generates using crlf end of line from .editorconfig 3`] = `
-"# test/B
+"# B
 
 <!-- end auto-generated rule header -->
 "
 `;
 
 exports[`string (getEndOfLine) generates using the correct end of line when .editorconfig exists generates using crlf end of line from .editorconfig 4`] = `
-"# test/c
+"# c
 
 <!-- end auto-generated rule header -->
 "
@@ -65,14 +65,14 @@ exports[`string (getEndOfLine) generates using the correct end of line when .edi
 `;
 
 exports[`string (getEndOfLine) generates using the correct end of line when .editorconfig exists generates using lf end of line from .editorconfig 3`] = `
-"# test/B
+"# B
 
 <!-- end auto-generated rule header -->
 "
 `;
 
 exports[`string (getEndOfLine) generates using the correct end of line when .editorconfig exists generates using lf end of line from .editorconfig 4`] = `
-"# test/c
+"# c
 
 <!-- end auto-generated rule header -->
 "
@@ -104,14 +104,14 @@ exports[`string (getEndOfLine) generates using the correct end of line when .edi
 `;
 
 exports[`string (getEndOfLine) generates using the correct end of line when .editorconfig exists generates using the end of line from .editorconfig while respecting the .md specific end of line setting 3`] = `
-"# test/B
+"# B
 
 <!-- end auto-generated rule header -->
 "
 `;
 
 exports[`string (getEndOfLine) generates using the correct end of line when .editorconfig exists generates using the end of line from .editorconfig while respecting the .md specific end of line setting 4`] = `
-"# test/c
+"# c
 
 <!-- end auto-generated rule header -->
 "

--- a/test/lib/generate/__snapshots__/file-paths-test.ts.snap
+++ b/test/lib/generate/__snapshots__/file-paths-test.ts.snap
@@ -11,7 +11,7 @@ exports[`generate (file paths) custom path to rule docs and rules list generates
 `;
 
 exports[`generate (file paths) custom path to rule docs and rules list generates the documentation 2`] = `
-"# test/no-foo
+"# no-foo
 
 <!-- end auto-generated rule header -->
 "
@@ -28,7 +28,7 @@ exports[`generate (file paths) custom path to rule docs and rules list generates
 `;
 
 exports[`generate (file paths) custom path to rule docs and rules list generates the documentation using a function for pathRuleDoc 2`] = `
-"# test/no-foo
+"# no-foo
 
 <!-- end auto-generated rule header -->
 "
@@ -55,14 +55,14 @@ exports[`generate (file paths) lowercase README file generates the documentation
 `;
 
 exports[`generate (file paths) missing rule doc when initRuleDocs is true creates the rule doc 1`] = `
-"# test/no-foo
+"# no-foo
 
 <!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generate (file paths) missing rule doc when initRuleDocs is true creates the rule doc 2`] = `
-"# test/no-bar
+"# no-bar
 
 <!-- end auto-generated rule header -->
 
@@ -79,7 +79,7 @@ exports[`generate (file paths) missing rule doc when initRuleDocs is true create
 `;
 
 exports[`generate (file paths) missing rule doc, initRuleDocs is true, and with ruleDocSectionInclude creates the rule doc including the mandatory section 1`] = `
-"# test/no-foo
+"# no-foo
 
 <!-- end auto-generated rule header -->
 
@@ -88,7 +88,7 @@ exports[`generate (file paths) missing rule doc, initRuleDocs is true, and with 
 `;
 
 exports[`generate (file paths) missing rule doc, initRuleDocs is true, and with ruleDocSectionInclude creates the rule doc including the mandatory section 2`] = `
-"# test/no-bar
+"# no-bar
 
 <!-- end auto-generated rule header -->
 

--- a/test/lib/generate/__snapshots__/general-test.ts.snap
+++ b/test/lib/generate/__snapshots__/general-test.ts.snap
@@ -51,7 +51,7 @@ details"
 `;
 
 exports[`generate (general) basic updates the documentation 4`] = `
-"# Description of no-boz (\`test/no-baz\`)
+"# Description of no-boz (\`no-baz\`)
 
 <!-- end auto-generated rule header -->
 ## Rule details

--- a/test/lib/generate/__snapshots__/option-check-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-check-test.ts.snap
@@ -5,7 +5,7 @@ exports[`generate (--check) basic prints the issues, exits with failure, and doe
   "[32m- Expected[39m
 [31m+ Received[39m
 
-[32m- # Description for no-foo (\`test/no-foo\`)[39m
+[32m- # Description for no-foo (\`no-foo\`)[39m
 [32m-[39m
 [32m- <!-- end auto-generated rule header -->[39m
 [32m-[39m

--- a/test/lib/generate/__snapshots__/option-postprocess-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-postprocess-test.ts.snap
@@ -15,7 +15,7 @@ Located at README.md"
 `;
 
 exports[`generate (postprocess option) basic calls the postprocessor 2`] = `
-"# test/no-foo
+"# no-foo
 
 <!-- end auto-generated rule header -->
 

--- a/test/lib/generate/__snapshots__/option-rule-doc-notices-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-rule-doc-notices-test.ts.snap
@@ -17,7 +17,7 @@ exports[`generate (--rule-doc-notices) basic shows the right rule doc notices 1`
 `;
 
 exports[`generate (--rule-doc-notices) basic shows the right rule doc notices 2`] = `
-"# Description for no-foo (\`test/no-foo\`)
+"# Description for no-foo (\`no-foo\`)
 
 💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
 

--- a/test/lib/generate/__snapshots__/option-rule-doc-title-format-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-rule-doc-title-format-test.ts.snap
@@ -8,7 +8,7 @@ exports[`generate (--rule-doc-title-format) desc uses the right rule doc title f
 `;
 
 exports[`generate (--rule-doc-title-format) desc uses the right rule doc title format 2`] = `
-"# test/no-bar
+"# no-bar
 
 <!-- end auto-generated rule header -->
 "
@@ -29,14 +29,14 @@ exports[`generate (--rule-doc-title-format) desc-parens-name uses the right rule
 `;
 
 exports[`generate (--rule-doc-title-format) desc-parens-prefix-name uses the right rule doc title format, with fallback when missing description 1`] = `
-"# Description for no-foo (\`test/no-foo\`)
+"# Description for no-foo (\`no-foo\`)
 
 <!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generate (--rule-doc-title-format) desc-parens-prefix-name uses the right rule doc title format, with fallback when missing description 2`] = `
-"# test/no-bar
+"# no-bar
 
 <!-- end auto-generated rule header -->
 "
@@ -50,7 +50,7 @@ exports[`generate (--rule-doc-title-format) name uses the right rule doc title f
 `;
 
 exports[`generate (--rule-doc-title-format) prefix-name uses the right rule doc title format 1`] = `
-"# test/no-foo
+"# no-foo
 
 <!-- end auto-generated rule header -->
 "

--- a/test/lib/generate/__snapshots__/option-rule-list-columns-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-rule-list-columns-test.ts.snap
@@ -16,7 +16,7 @@ exports[`generate (--rule-list-columns) basic shows the right columns and legend
 `;
 
 exports[`generate (--rule-list-columns) basic shows the right columns and legend 2`] = `
-"# Description for no-foo (\`test/no-foo\`)
+"# Description for no-foo (\`no-foo\`)
 
 ❌ This rule is deprecated.
 
@@ -68,7 +68,7 @@ exports[`generate (--rule-list-columns) shows column and notice for requiresType
 `;
 
 exports[`generate (--rule-list-columns) shows column and notice for requiresTypeChecking updates the documentation 3`] = `
-"# Description of no-bar (\`test/no-bar\`)
+"# Description of no-bar (\`no-bar\`)
 
 💭 This rule requires [type information](https://typescript-eslint.io/linting/typed-linting).
 

--- a/test/lib/generate/__snapshots__/option-url-rule-doc-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-url-rule-doc-test.ts.snap
@@ -16,7 +16,7 @@ exports[`generate (--url-rule-doc) basic uses the right URLs 1`] = `
 `;
 
 exports[`generate (--url-rule-doc) basic uses the right URLs 2`] = `
-"# Description for no-foo (\`test/no-foo\`)
+"# Description for no-foo (\`no-foo\`)
 
 ❌ This rule is deprecated. It was replaced by [\`test/no-bar\`](https://example.com/rule-docs/no-bar/).
 
@@ -25,7 +25,7 @@ exports[`generate (--url-rule-doc) basic uses the right URLs 2`] = `
 `;
 
 exports[`generate (--url-rule-doc) basic uses the right URLs 3`] = `
-"# Description for no-bar (\`test/no-bar\`)
+"# Description for no-bar (\`no-bar\`)
 
 <!-- end auto-generated rule header -->
 "
@@ -62,7 +62,7 @@ exports[`generate (--url-rule-doc) function returns undefined should fallback to
 `;
 
 exports[`generate (--url-rule-doc) function returns undefined should fallback to the normal URL 3`] = `
-"# Description for no-foo (\`test/no-foo\`)
+"# Description for no-foo (\`no-foo\`)
 
 ❌ This rule is deprecated. It was replaced by [\`test/no-bar\`](no-bar.md).
 
@@ -71,7 +71,7 @@ exports[`generate (--url-rule-doc) function returns undefined should fallback to
 `;
 
 exports[`generate (--url-rule-doc) function returns undefined should fallback to the normal URL 4`] = `
-"# Description for no-bar (\`test/no-bar\`)
+"# Description for no-bar (\`no-bar\`)
 
 <!-- end auto-generated rule header -->
 "
@@ -108,7 +108,7 @@ exports[`generate (--url-rule-doc) function uses the custom URL 2`] = `
 `;
 
 exports[`generate (--url-rule-doc) function uses the custom URL 3`] = `
-"# Description for no-foo (\`test/no-foo\`)
+"# Description for no-foo (\`no-foo\`)
 
 ❌ This rule is deprecated. It was replaced by [\`test/no-bar\`](https://example.com/rule-docs/name:no-bar/path:docs/rules/no-foo.md).
 
@@ -117,7 +117,7 @@ exports[`generate (--url-rule-doc) function uses the custom URL 3`] = `
 `;
 
 exports[`generate (--url-rule-doc) function uses the custom URL 4`] = `
-"# Description for no-bar (\`test/no-bar\`)
+"# Description for no-bar (\`no-bar\`)
 
 <!-- end auto-generated rule header -->
 "

--- a/test/lib/generate/__snapshots__/package-json-test.ts.snap
+++ b/test/lib/generate/__snapshots__/package-json-test.ts.snap
@@ -15,7 +15,7 @@ exports[`generate (package.json) No configs found omits the config column 1`] = 
 `;
 
 exports[`generate (package.json) No configs found omits the config column 2`] = `
-"# Disallow foo (\`test/no-foo\`)
+"# Disallow foo (\`no-foo\`)
 
 <!-- end auto-generated rule header -->
 "
@@ -46,7 +46,7 @@ exports[`generate (package.json) Scoped plugin with custom plugin name determine
 `;
 
 exports[`generate (package.json) Scoped plugin with custom plugin name determines the correct plugin prefix 2`] = `
-"# Disallow foo (\`@my-scope/foo/no-foo\`)
+"# Disallow foo (\`no-foo\`)
 
 💼 This rule is enabled in the ✅ \`recommended\` config.
 

--- a/test/lib/generate/__snapshots__/rule-deprecation-test.ts.snap
+++ b/test/lib/generate/__snapshots__/rule-deprecation-test.ts.snap
@@ -13,7 +13,7 @@ exports[`generate (deprecated rules) replaced by ESLint core rule uses correct r
 `;
 
 exports[`generate (deprecated rules) replaced by ESLint core rule uses correct replacement rule link 2`] = `
-"# Description (\`test/no-foo\`)
+"# Description (\`no-foo\`)
 
 ❌ This rule is deprecated. It was replaced by [\`no-unused-vars\`](https://eslint.org/docs/latest/rules/no-unused-vars).
 
@@ -34,7 +34,7 @@ exports[`generate (deprecated rules) replaced by third-party plugin rule uses co
 `;
 
 exports[`generate (deprecated rules) replaced by third-party plugin rule uses correct replacement rule link 2`] = `
-"# Description (\`test/no-foo\`)
+"# Description (\`no-foo\`)
 
 ❌ This rule is deprecated. It was replaced by \`other-plugin/no-unused-vars\`.
 
@@ -55,7 +55,7 @@ exports[`generate (deprecated rules) replaced by third-party plugin rule with sa
 `;
 
 exports[`generate (deprecated rules) replaced by third-party plugin rule with same rule name as one of our rules uses correct replacement rule link 2`] = `
-"# Description (\`test/no-foo\`)
+"# Description (\`no-foo\`)
 
 ❌ This rule is deprecated. It was replaced by \`other-plugin/no-foo\`.
 
@@ -79,7 +79,7 @@ exports[`generate (deprecated rules) several deprecated rules updates the docume
 `;
 
 exports[`generate (deprecated rules) several deprecated rules updates the documentation 2`] = `
-"# Description (\`test/no-foo\`)
+"# Description (\`no-foo\`)
 
 ❌ This rule is deprecated. It was replaced by [\`test/no-bar\`](no-bar.md).
 
@@ -88,7 +88,7 @@ exports[`generate (deprecated rules) several deprecated rules updates the docume
 `;
 
 exports[`generate (deprecated rules) several deprecated rules updates the documentation 3`] = `
-"# Description (\`test/no-bar\`)
+"# Description (\`no-bar\`)
 
 ❌ This rule is deprecated.
 
@@ -97,7 +97,7 @@ exports[`generate (deprecated rules) several deprecated rules updates the docume
 `;
 
 exports[`generate (deprecated rules) several deprecated rules updates the documentation 4`] = `
-"# Description (\`test/no-baz\`)
+"# Description (\`no-baz\`)
 
 ❌ This rule is deprecated.
 
@@ -106,7 +106,7 @@ exports[`generate (deprecated rules) several deprecated rules updates the docume
 `;
 
 exports[`generate (deprecated rules) several deprecated rules updates the documentation 5`] = `
-"# Description (\`test/no-biz\`)
+"# Description (\`no-biz\`)
 
 <!-- end auto-generated rule header -->
 "
@@ -126,16 +126,16 @@ exports[`generate (deprecated rules) using prefix ahead of replacement rule name
 `;
 
 exports[`generate (deprecated rules) using prefix ahead of replacement rule name uses correct replacement rule link 2`] = `
-"# Description (\`test/no-foo\`)
+"# Description (\`no-foo\`)
 
-❌ This rule is deprecated. It was replaced by [\`test/no-bar\`](no-bar.md).
+❌ This rule is deprecated. It was replaced by \`test/no-bar\`.
 
 <!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generate (deprecated rules) using prefix ahead of replacement rule name uses correct replacement rule link 3`] = `
-"# Description (\`test/no-bar\`)
+"# Description (\`no-bar\`)
 
 <!-- end auto-generated rule header -->
 "
@@ -155,7 +155,7 @@ exports[`generate (deprecated rules) with --path-rule-doc has the correct links,
 `;
 
 exports[`generate (deprecated rules) with --path-rule-doc has the correct links, especially replacement rule link 2`] = `
-"# Description (\`test/category/no-foo\`)
+"# Description (\`category/no-foo\`)
 
 ❌ This rule is deprecated. It was replaced by [\`test/category/no-bar\`](../no-bar/README.md).
 
@@ -164,9 +164,9 @@ exports[`generate (deprecated rules) with --path-rule-doc has the correct links,
 `;
 
 exports[`generate (deprecated rules) with --path-rule-doc has the correct links, especially replacement rule link 3`] = `
-"# Description (\`test/category/no-bar\`)
+"# Description (\`category/no-bar\`)
 
-❌ This rule is deprecated. It was replaced by [\`test/category/no-foo\`](../no-foo/README.md).
+❌ This rule is deprecated. It was replaced by \`test/category/no-foo\`.
 
 <!-- end auto-generated rule header -->
 "
@@ -186,7 +186,7 @@ exports[`generate (deprecated rules) with nested rule names has the correct link
 `;
 
 exports[`generate (deprecated rules) with nested rule names has the correct links, especially replacement rule link 2`] = `
-"# Description (\`test/category/no-foo\`)
+"# Description (\`category/no-foo\`)
 
 ❌ This rule is deprecated. It was replaced by [\`test/category/no-bar\`](no-bar.md).
 
@@ -195,9 +195,9 @@ exports[`generate (deprecated rules) with nested rule names has the correct link
 `;
 
 exports[`generate (deprecated rules) with nested rule names has the correct links, especially replacement rule link 3`] = `
-"# Description (\`test/category/no-bar\`)
+"# Description (\`category/no-bar\`)
 
-❌ This rule is deprecated. It was replaced by [\`test/category/no-foo\`](no-foo.md).
+❌ This rule is deprecated. It was replaced by \`test/category/no-foo\`.
 
 <!-- end auto-generated rule header -->
 "

--- a/test/lib/generate/__snapshots__/rule-description-test.ts.snap
+++ b/test/lib/generate/__snapshots__/rule-description-test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`generate (rule descriptions) Rule description needs to be formatted capitalizes the first letter and removes the trailing period from the description 1`] = `
-"# Disallow foo (\`test/no-foo\`)
+"# Disallow foo (\`no-foo\`)
 
 <!-- end auto-generated rule header -->
 "
@@ -20,7 +20,7 @@ exports[`generate (rule descriptions) no rules with description generates the do
 `;
 
 exports[`generate (rule descriptions) no rules with description generates the documentation 2`] = `
-"# test/no-foo
+"# no-foo
 
 <!-- end auto-generated rule header -->
 "
@@ -40,14 +40,14 @@ exports[`generate (rule descriptions) one rule missing description generates the
 `;
 
 exports[`generate (rule descriptions) one rule missing description generates the documentation 2`] = `
-"# Description for no-foo (\`test/no-foo\`)
+"# Description for no-foo (\`no-foo\`)
 
 <!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generate (rule descriptions) one rule missing description generates the documentation 3`] = `
-"# test/no-bar
+"# no-bar
 
 <!-- end auto-generated rule header -->
 "
@@ -66,7 +66,7 @@ exports[`generate (rule descriptions) rule with long-enough description to requi
 `;
 
 exports[`generate (rule descriptions) rule with long-enough description to require name column wrapping avoidance adds spaces to the name column 2`] = `
-"# Over 60 chars over 60 chars over 60 chars over 60 chars over 60 chars over 60 chars (\`test/no-foo\`)
+"# Over 60 chars over 60 chars over 60 chars over 60 chars over 60 chars over 60 chars (\`no-foo\`)
 
 <!-- end auto-generated rule header -->
 "
@@ -85,7 +85,7 @@ exports[`generate (rule descriptions) rule with long-enough description to requi
 `;
 
 exports[`generate (rule descriptions) rule with long-enough description to require name column wrapping avoidance but rule name too short does not add spaces to name column 2`] = `
-"# Over 60 chars over 60 chars over 60 chars over 60 chars over 60 chars over 60 chars (\`test/foo\`)
+"# Over 60 chars over 60 chars over 60 chars over 60 chars over 60 chars over 60 chars (\`foo\`)
 
 <!-- end auto-generated rule header -->
 "

--- a/test/lib/generate/__snapshots__/rule-metadata-test.ts.snap
+++ b/test/lib/generate/__snapshots__/rule-metadata-test.ts.snap
@@ -38,7 +38,7 @@ exports[`generate (rule metadata) deprecated function-style rule with deprecated
 `;
 
 exports[`generate (rule metadata) deprecated function-style rule with deprecated/schema properties generates the documentation 2`] = `
-"# test/no-foo
+"# no-foo
 
 <!-- end auto-generated rule header -->
 ## Options

--- a/test/lib/generate/__snapshots__/rule-options-list-test.ts.snap
+++ b/test/lib/generate/__snapshots__/rule-options-list-test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`generate (rule options list) basic generates the documentation 1`] = `
-"# test/no-foo
+"# no-foo
 
 <!-- end auto-generated rule header -->
 ## Options
@@ -25,7 +25,7 @@ exports[`generate (rule options list) basic generates the documentation 1`] = `
 `;
 
 exports[`generate (rule options list) displays default column even when only falsy value, hiding deprecated/required cols with only falsy value generates the documentation 1`] = `
-"# test/no-foo
+"# no-foo
 
 <!-- end auto-generated rule header -->
 ## Options
@@ -39,7 +39,7 @@ exports[`generate (rule options list) displays default column even when only fal
 `;
 
 exports[`generate (rule options list) with no marker comments generates the documentation 1`] = `
-"# test/no-foo
+"# no-foo
 
 <!-- end auto-generated rule header -->
 ## Options
@@ -47,7 +47,7 @@ foo"
 `;
 
 exports[`generate (rule options list) with no options generates the documentation 1`] = `
-"# test/no-foo
+"# no-foo
 
 <!-- end auto-generated rule header -->
 
@@ -59,7 +59,7 @@ exports[`generate (rule options list) with no options generates the documentatio
 `;
 
 exports[`generate (rule options list) with string that needs to be escaped in table generates the documentation 1`] = `
-"# test/no-foo
+"# no-foo
 
 <!-- end auto-generated rule header -->
 ## Options

--- a/test/lib/generate/__snapshots__/rule-options-test.ts.snap
+++ b/test/lib/generate/__snapshots__/rule-options-test.ts.snap
@@ -18,7 +18,7 @@ exports[`generate (rule options) rule with options, options column/notice enable
 `;
 
 exports[`generate (rule options) rule with options, options column/notice enabled displays the column and notice 2`] = `
-"# test/no-foo
+"# no-foo
 
 ⚙️ This rule is configurable.
 
@@ -28,7 +28,7 @@ exports[`generate (rule options) rule with options, options column/notice enable
 `;
 
 exports[`generate (rule options) rule with options, options column/notice enabled displays the column and notice 3`] = `
-"# test/no-bar
+"# no-bar
 
 ⚙️ This rule is configurable.
 
@@ -38,14 +38,14 @@ exports[`generate (rule options) rule with options, options column/notice enable
 `;
 
 exports[`generate (rule options) rule with options, options column/notice enabled displays the column and notice 4`] = `
-"# test/no-biz
+"# no-biz
 
 <!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generate (rule options) rule with options, options column/notice enabled displays the column and notice 5`] = `
-"# test/no-baz
+"# no-baz
 
 <!-- end auto-generated rule header -->
 "

--- a/test/lib/generate/__snapshots__/rule-type-test.ts.snap
+++ b/test/lib/generate/__snapshots__/rule-type-test.ts.snap
@@ -22,35 +22,35 @@ exports[`generate (rule type) rule with type, type column enabled displays the t
 `;
 
 exports[`generate (rule type) rule with type, type column enabled displays the type 2`] = `
-"# test/no-foo
+"# no-foo
 
 <!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generate (rule type) rule with type, type column enabled displays the type 3`] = `
-"# test/no-bar
+"# no-bar
 
 <!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generate (rule type) rule with type, type column enabled displays the type 4`] = `
-"# test/no-biz
+"# no-biz
 
 <!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generate (rule type) rule with type, type column enabled displays the type 5`] = `
-"# test/no-boz
+"# no-boz
 
 <!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generate (rule type) rule with type, type column enabled displays the type 6`] = `
-"# test/no-buz
+"# no-buz
 
 <!-- end auto-generated rule header -->
 "
@@ -69,7 +69,7 @@ exports[`generate (rule type) rule with type, type column enabled, but only an u
 `;
 
 exports[`generate (rule type) rule with type, type column enabled, but only an unknown type hides the type column and notice 2`] = `
-"# test/no-foo
+"# no-foo
 
 <!-- end auto-generated rule header -->
 "
@@ -88,7 +88,7 @@ exports[`generate (rule type) rule with type, type column not enabled hides the 
 `;
 
 exports[`generate (rule type) rule with type, type column not enabled hides the type column 2`] = `
-"# test/no-foo
+"# no-foo
 
 <!-- end auto-generated rule header -->
 "

--- a/test/lib/generate/__snapshots__/sorting-test.ts.snap
+++ b/test/lib/generate/__snapshots__/sorting-test.ts.snap
@@ -26,14 +26,14 @@ exports[`generate (sorting) sorting rules and configs case-insensitive sorts cor
 `;
 
 exports[`generate (sorting) sorting rules and configs case-insensitive sorts correctly 3`] = `
-"# test/B
+"# B
 
 <!-- end auto-generated rule header -->
 "
 `;
 
 exports[`generate (sorting) sorting rules and configs case-insensitive sorts correctly 4`] = `
-"# test/c
+"# c
 
 <!-- end auto-generated rule header -->
 "


### PR DESCRIPTION
This PR introduces a utility function `detectPrefixFromConfigsToRules` to infer the rule prefix by analyzing the rule IDs in `ConfigsToRules`, instead of relying on `package.json.name` or a hardcoded plugin prefix.

### Motivation

Currently, there's no single agreed-upon source for determining a plugin's rule prefix. It's unclear whether the most reliable approach is:
- Reading from `configs[configName].plugins`
- Inspecting `configs[configName].rules`
- Or potentially something else entirely

So, as a first step, I've made a minimal change that applies this prefix detection only to the **rule documentation title**.

### Future Scope

Depending on how the discussion evolves, I’m open to applying this logic more broadly across the codebase (e.g. for rule links, config listings, etc.).

If this approach is misaligned with expectations or future direction, I’m also totally fine with closing this PR.

### Notes

- The prefix is inferred by matching suffixes of rule names in `plugin.rules` with rule IDs in `ConfigsToRules`.
- This change is scoped and safe, intended to address the issue described in #610.

Looking forward to your feedback!
