### PR TITLE
Enable flat configs

### DIFF
--- a/lib/plugin-config-resolution.ts
+++ b/lib/plugin-config-resolution.ts
@@ -1,6 +1,13 @@
 import { existsSync } from 'node:fs';
 import { importAbs } from './import.js';
 import type { Plugin, Config, Rules, ConfigsToRules } from './types.js';
+import { TSESLint } from '@typescript-eslint/utils';
+
+import {
+  ClassicConfig,
+  FlatConfig,
+  // eslint-disable-next-line import/extensions -- false positive
+} from '@typescript-eslint/utils/dist/ts-eslint';
 
 /**
  * ESLint configs can extend other configs, so for convenience, let's resolve all the rules in each config upfront.
@@ -10,25 +17,48 @@ export async function resolveConfigsToRules(
 ): Promise<ConfigsToRules> {
   const configs: Record<string, Rules> = {};
   for (const [configName, config] of Object.entries(plugin.configs || {})) {
-    configs[configName] = await resolveConfigRules(config);
+    configs[configName] = await resolvePotentiallyFlatConfigs(config);
   }
   return configs;
 }
 
 /**
+ * Check whether the passed config is an array and iterate over it
+ */
+async function resolvePotentiallyFlatConfigs(
+  potentiallyFlatConfigs: TSESLint.Linter.ConfigType,
+): Promise<Rules> {
+  const rules: Rules = {};
+  if (Array.isArray(potentiallyFlatConfigs)) {
+    for (const config of potentiallyFlatConfigs) {
+      Object.assign(rules, await resolvePotentiallyFlatConfigs(config));
+    }
+  } else {
+    Object.assign(rules, await resolveConfigRules(potentiallyFlatConfigs));
+  }
+  return rules;
+}
+
+/**
  * Recursively gather all the rules from a config that may extend other configs.
  */
-async function resolveConfigRules(config: Config): Promise<Rules> {
+async function resolveConfigRules(
+  config: ClassicConfig.Config | FlatConfig.Config,
+): Promise<Rules> {
   const rules = { ...config.rules };
-  for (const override of config.overrides || []) {
-    Object.assign(rules, override.rules);
-    const extendedRulesFromOverride = await resolveConfigExtends(
-      override.extends || [],
-    );
-    Object.assign(rules, extendedRulesFromOverride);
+  if ('overrides' in config && config.overrides) {
+    for (const override of config.overrides) {
+      Object.assign(rules, override.rules);
+      const extendedRulesFromOverride = await resolveConfigExtends(
+        override.extends || [],
+      );
+      Object.assign(rules, extendedRulesFromOverride);
+    }
   }
-  const extendedRules = await resolveConfigExtends(config.extends || []);
-  Object.assign(rules, extendedRules);
+  if ('extends' in config && config.extends) {
+    const extendedRules = await resolveConfigExtends(config.extends);
+    Object.assign(rules, extendedRules);
+  }
   return rules;
 }
 

--- a/test/lib/generate/__snapshots__/configs-test.ts.snap
+++ b/test/lib/generate/__snapshots__/configs-test.ts.snap
@@ -1,5 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`generate (configs) config as flat config updates the documentation 1`] = `
+"<!-- begin auto-generated rules list -->
+
+💼 Configurations enabled in.\\
+✅ Set in the \`recommended\` configuration.
+
+| Name                           | Description            | 💼 |
+| :----------------------------- | :--------------------- | :- |
+| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | ✅  |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅  |
+
+<!-- end auto-generated rules list -->"
+`;
+
+exports[`generate (configs) config as flat config updates the documentation 2`] = `
+"# Description of no-foo (\`test/no-foo\`)
+
+💼 This rule is enabled in the ✅ \`recommended\` config.
+
+<!-- end auto-generated rule header -->
+"
+`;
+
 exports[`generate (configs) config with overrides generates the documentation 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->

--- a/test/lib/generate/__snapshots__/configs-test.ts.snap
+++ b/test/lib/generate/__snapshots__/configs-test.ts.snap
@@ -23,6 +23,15 @@ exports[`generate (configs) config as flat config updates the documentation 2`] 
 "
 `;
 
+exports[`generate (configs) config as flat config updates the documentation 3`] = `
+"# Description of no-bar (\`test/no-bar\`)
+
+💼 This rule is enabled in the ✅ \`recommended\` config.
+
+<!-- end auto-generated rule header -->
+"
+`;
+
 exports[`generate (configs) config with overrides generates the documentation 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->

--- a/test/lib/generate/configs-test.ts
+++ b/test/lib/generate/configs-test.ts
@@ -547,6 +547,7 @@ describe('generate (configs)', function () {
       expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
 
       expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
+      expect(readFileSync('docs/rules/no-bar.md', 'utf8')).toMatchSnapshot();
     });
   });
 });

--- a/test/lib/generate/configs-test.ts
+++ b/test/lib/generate/configs-test.ts
@@ -488,4 +488,65 @@ describe('generate (configs)', function () {
       expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
     });
   });
+  describe('config as flat config', () => {
+    beforeEach(function () {
+      mockFs({
+        'package.json': JSON.stringify({
+          name: 'eslint-plugin-test',
+          exports: 'index.js',
+          type: 'module',
+        }),
+
+        'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: { docs: { description: 'Description of no-foo.' }, },
+                create(context) {},
+              },
+              'no-bar': {
+                meta: { docs: { description: 'Description of no-bar.' }, },
+                create(context) {},
+              },
+            },
+            configs: {
+              recommended: [
+                {
+                  rules: {
+                    'test/no-foo': 'error',
+                  }
+                },
+                {
+                  rules: {
+                    'test/no-bar': 'error',
+                  }
+                }
+              ]
+            }
+          };`,
+
+        'README.md':
+          '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
+
+        'docs/rules/no-foo.md': '',
+        'docs/rules/no-bar.md': '',
+
+        // Needed for some of the test infrastructure to work.
+        node_modules: mockFs.load(PATH_NODE_MODULES),
+      });
+    });
+
+    afterEach(function () {
+      mockFs.restore();
+      jest.resetModules();
+    });
+
+    it('updates the documentation', async function () {
+      await generate('.');
+
+      expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
+
+      expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
+    });
+  });
 });


### PR DESCRIPTION
**Purpose**
As described in: https://github.com/bmish/eslint-doc-generator/issues/376#issuecomment-2863306783, creators of eslint plugins with flat configs currently can not benefit from eslint-doc-generator to the fullest. Specifically, rules will not be listed as part of a config if said config is of the new Flat Config type. With this change rules will be correctly listed as part of a config regardless of the config type.

**Reviewer aid:**
I recommend you check out the changes to ```types.ts``` first. The three broader types set for RuleModule, Plugin, and Config are the single source that necessitated all other changes.

Fixes #376.