### PR TITLE
chore: tweak release-please action config

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,24 +13,10 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           release-type: node
-          package-name: 'eslint-doc-generator'
-          pull-request-title-pattern: 'chore: release${component} ${version}'
-          changelog-types: >
-            [
-              { "type": "feat", "section": "Features", "hidden": false },
-              { "type": "fix", "section": "Bug Fixes", "hidden": false },
-              { "type": "docs", "section": "Documentation", "hidden": false },
-              { "type": "build", "section": "Chores", "hidden": false },
-              { "type": "chore", "section": "Chores", "hidden": false },
-              { "type": "perf", "section": "Chores", "hidden": false },
-              { "type": "ci", "section": "Chores", "hidden": false },
-              { "type": "refactor", "section": "Chores", "hidden": false },
-              { "type": "test", "section": "Chores", "hidden": false }
-            ]
       - uses: actions/checkout@v4
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v4


### PR DESCRIPTION
> release-pleasegoogle-github-actions/release-please-action is deprecated, please use googleapis/release-please-action instead.


> release-pleaseUnexpected input(s) 'package-name', 'pull-request-title-pattern', 'changelog-types', valid inputs are ['token', 'release-type', 'path', 'target-branch', 'config-file', 'manifest-file', 'repo-url', 'github-api-url', 'github-graphql-url', 'fork', 'include-component-in-tag', 'proxy-server', 'skip-github-release', 'skip-github-pull-request', 'changelog-host']

Follow-up to: 
- https://github.com/bmish/eslint-doc-generator/pull/736