### PR TITLE
chore: fix release-please permission for provenance generation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 name: release-please
 

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,0 @@
-{
-    "bootstrap-sha": "00c4fa10229546903a76fa6d3ba204db0a7fab2b",
-    ".": "2.2.1"
-}


### PR DESCRIPTION
```
npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access
npm error code EUSAGE
npm error Provenance generation in GitHub Actions requires "write" access to the "id-token" permission
```