### PR TITLE
chore: enable tsconfig verbatimModuleSyntax

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,6 +35,7 @@ export default tseslint.config(
       'unicorn/prevent-abbreviations': 'off',
 
       // typescript-eslint rules:
+      '@typescript-eslint/consistent-type-imports': 'error',
       '@typescript-eslint/no-unnecessary-condition': 'off', // Dozens of places where the rule's `meta` property needs optional chaining get flagged by this.
       '@typescript-eslint/no-unused-vars': 'off',
       '@typescript-eslint/prefer-readonly': 'error',

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -4,12 +4,8 @@ import { OPTION_DEFAULTS } from './options.js';
 import { cosmiconfig } from 'cosmiconfig';
 import Ajv from 'ajv';
 import merge from 'deepmerge';
-import {
-  COLUMN_TYPE,
-  NOTICE_TYPE,
-  GenerateOptions,
-  OPTION_TYPE,
-} from './types.js';
+import type { GenerateOptions } from './types.js';
+import { COLUMN_TYPE, NOTICE_TYPE, OPTION_TYPE } from './types.js';
 import { getCurrentPackageVersion } from './package-json.js';
 import { boolean, isBooleanable } from './boolean.js';
 import { CONFIG_FORMATS } from './config-format.js';

--- a/lib/config-list.ts
+++ b/lib/config-list.ts
@@ -4,7 +4,8 @@ import {
 } from './comment-markers.js';
 import { markdownTable } from 'markdown-table';
 import type { ConfigsToRules, ConfigEmojis, Plugin, Config } from './types.js';
-import { ConfigFormat, configNameToDisplay } from './config-format.js';
+import type { ConfigFormat } from './config-format.js';
+import { configNameToDisplay } from './config-format.js';
 import { getEndOfLine, sanitizeMarkdownTable } from './string.js';
 
 const EOL = getEndOfLine();

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -28,8 +28,8 @@ import {
 import { resolveConfigsToRules } from './plugin-config-resolution.js';
 import { OPTION_DEFAULTS } from './options.js';
 import { diff } from 'jest-diff';
-import type { GenerateOptions } from './types.js';
-import { OPTION_TYPE, RuleModule } from './types.js';
+import type { GenerateOptions, RuleModule } from './types.js';
+import { OPTION_TYPE } from './types.js';
 import { replaceRulePlaceholder } from './rule-link.js';
 import { updateRuleOptionsList } from './rule-options-list.js';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
-import { ConfigFormat } from './config-format.js';
-import { RuleDocTitleFormat } from './rule-doc-title-format.js';
+import type { ConfigFormat } from './config-format.js';
+import type { RuleDocTitleFormat } from './rule-doc-title-format.js';
 import { COLUMN_TYPE, NOTICE_TYPE, OPTION_TYPE } from './types.js';
 
 export const COLUMN_TYPE_DEFAULT_PRESENCE_AND_ORDERING: {

--- a/lib/plugin-config-resolution.ts
+++ b/lib/plugin-config-resolution.ts
@@ -1,12 +1,11 @@
 import { existsSync } from 'node:fs';
 import { importAbs } from './import.js';
 import type { Plugin, Config, Rules, ConfigsToRules } from './types.js';
-import { TSESLint } from '@typescript-eslint/utils';
+import type { TSESLint } from '@typescript-eslint/utils';
 
-import {
+import type {
   ClassicConfig,
   FlatConfig,
-  // eslint-disable-next-line import/extensions -- false positive
 } from '@typescript-eslint/utils/dist/ts-eslint';
 
 /**

--- a/lib/rule-doc-notices.ts
+++ b/lib/rule-doc-notices.ts
@@ -8,18 +8,18 @@ import {
   EMOJI_OPTIONS,
 } from './emojis.js';
 import { findConfigEmoji, getConfigsForRule } from './plugin-configs.js';
-import {
+import type {
   RuleModule,
   Plugin,
   ConfigsToRules,
   ConfigEmojis,
-  SEVERITY_TYPE,
-  NOTICE_TYPE,
   UrlRuleDocFunction,
   PathRuleDocFunction,
 } from './types.js';
-import { RULE_TYPE, RULE_TYPE_MESSAGES_NOTICES } from './rule-type.js';
-import { RuleDocTitleFormat } from './rule-doc-title-format.js';
+import { SEVERITY_TYPE, NOTICE_TYPE } from './types.js';
+import type { RULE_TYPE } from './rule-type.js';
+import { RULE_TYPE_MESSAGES_NOTICES } from './rule-type.js';
+import type { RuleDocTitleFormat } from './rule-doc-title-format.js';
 import { hasOptions } from './rule-options.js';
 import { getLinkToRule, replaceRulePlaceholder } from './rule-link.js';
 import {
@@ -28,7 +28,8 @@ import {
   addTrailingPeriod,
   getEndOfLine,
 } from './string.js';
-import { ConfigFormat, configNameToDisplay } from './config-format.js';
+import type { ConfigFormat } from './config-format.js';
+import { configNameToDisplay } from './config-format.js';
 
 const EOL = getEndOfLine();
 

--- a/lib/rule-link.ts
+++ b/lib/rule-link.ts
@@ -1,10 +1,10 @@
 import { join, sep, relative, dirname } from 'node:path';
-import {
+import type {
   PathRuleDocFunction,
   Plugin,
-  RULE_SOURCE,
   UrlRuleDocFunction,
 } from './types.js';
+import { RULE_SOURCE } from './types.js';
 import { getPluginRoot } from './package-json.js';
 
 export function replaceRulePlaceholder(

--- a/lib/rule-list-legend.ts
+++ b/lib/rule-list-legend.ts
@@ -8,15 +8,11 @@ import {
   EMOJI_CONFIG_FROM_SEVERITY,
 } from './emojis.js';
 import { findConfigEmoji, getConfigsThatSetARule } from './plugin-configs.js';
-import {
-  COLUMN_TYPE,
-  ConfigEmojis,
-  Plugin,
-  ConfigsToRules,
-  SEVERITY_TYPE,
-} from './types.js';
+import type { ConfigEmojis, Plugin, ConfigsToRules } from './types.js';
+import { COLUMN_TYPE, SEVERITY_TYPE } from './types.js';
 import { RULE_TYPE_MESSAGES_LEGEND, RULE_TYPES } from './rule-type.js';
-import { ConfigFormat, configNameToDisplay } from './config-format.js';
+import type { ConfigFormat } from './config-format.js';
+import { configNameToDisplay } from './config-format.js';
 import { getEndOfLine } from './string.js';
 
 const EOL = getEndOfLine();

--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -15,13 +15,7 @@ import { findSectionHeader, findFinalHeaderLevel } from './markdown.js';
 import { getPluginRoot } from './package-json.js';
 import { generateLegend } from './rule-list-legend.js';
 import { relative } from 'node:path';
-import {
-  COLUMN_TYPE,
-  RuleListSplitFunction,
-  RuleModule,
-  SEVERITY_TYPE,
-  UrlRuleDocFunction,
-} from './types.js';
+import { COLUMN_TYPE, SEVERITY_TYPE } from './types.js';
 import { markdownTable } from 'markdown-table';
 import type {
   Plugin,
@@ -29,6 +23,9 @@ import type {
   ConfigEmojis,
   RuleNamesAndRules,
   PathRuleDocFunction,
+  RuleListSplitFunction,
+  RuleModule,
+  UrlRuleDocFunction,
 } from './types.js';
 import { EMOJIS_TYPE } from './rule-type.js';
 import { hasOptions } from './rule-options.js';
@@ -42,7 +39,7 @@ import { noCase } from 'change-case';
 import { getProperty } from 'dot-prop';
 import { boolean, isBooleanable } from './boolean.js';
 import Ajv from 'ajv';
-import { ConfigFormat } from './config-format.js';
+import type { ConfigFormat } from './config-format.js';
 
 function isBooleanableTrue(value: unknown): boolean {
   return isBooleanable(value) && boolean(value);

--- a/lib/rule-options-list.ts
+++ b/lib/rule-options-list.ts
@@ -4,7 +4,8 @@ import {
 } from './comment-markers.js';
 import { markdownTable } from 'markdown-table';
 import type { RuleModule } from './types.js';
-import { RuleOption, getAllNamedOptions } from './rule-options.js';
+import type { RuleOption } from './rule-options.js';
+import { getAllNamedOptions } from './rule-options.js';
 import { getEndOfLine, sanitizeMarkdownTable } from './string.js';
 
 const EOL = getEndOfLine();

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,6 +1,6 @@
 import type { RuleDocTitleFormat } from './rule-doc-title-format.js';
 import type { TSESLint } from '@typescript-eslint/utils';
-import { ConfigFormat } from './config-format.js';
+import type { ConfigFormat } from './config-format.js';
 
 // Standard ESLint types.
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
       "node",
       "jest"
     ],
+    "verbatimModuleSyntax": true
   },
   "include": [
     "bin/**/*",


### PR DESCRIPTION
- https://www.typescriptlang.org/tsconfig/#erasableSyntaxOnly
- https://typescript-eslint.io/rules/consistent-type-imports/

After this:
- Enable [erasableSyntaxOnly](https://www.typescriptlang.org/tsconfig/#erasableSyntaxOnly)