### PR TITLE
refactor: EOL constant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ dist/
 
 # Mac
 .DS_Store
+
+# Agents
+.claude

--- a/lib/config-list.ts
+++ b/lib/config-list.ts
@@ -5,9 +5,7 @@ import {
 import { markdownTable } from 'markdown-table';
 import type { ConfigsToRules, ConfigEmojis, Plugin, Config } from './types.js';
 import { ConfigFormat, configNameToDisplay } from './config-format.js';
-import { getEndOfLine, sanitizeMarkdownTable } from './string.js';
-
-const EOL = getEndOfLine();
+import { EOL, sanitizeMarkdownTable } from './string.js';
 
 /**
  * Check potential locations for the config description.

--- a/lib/rule-doc-notices.ts
+++ b/lib/rule-doc-notices.ts
@@ -26,11 +26,9 @@ import {
   toSentenceCase,
   removeTrailingPeriod,
   addTrailingPeriod,
-  getEndOfLine,
+  EOL,
 } from './string.js';
 import { ConfigFormat, configNameToDisplay } from './config-format.js';
-
-const EOL = getEndOfLine();
 
 function severityToTerminology(severity: SEVERITY_TYPE) {
   switch (severity) {

--- a/lib/rule-list-legend.ts
+++ b/lib/rule-list-legend.ts
@@ -17,9 +17,7 @@ import {
 } from './types.js';
 import { RULE_TYPE_MESSAGES_LEGEND, RULE_TYPES } from './rule-type.js';
 import { ConfigFormat, configNameToDisplay } from './config-format.js';
-import { getEndOfLine } from './string.js';
-
-const EOL = getEndOfLine();
+import { EOL } from './string.js';
 
 export const SEVERITY_TYPE_TO_WORD: {
   [key in SEVERITY_TYPE]: string;

--- a/lib/rule-options-list.ts
+++ b/lib/rule-options-list.ts
@@ -5,9 +5,7 @@ import {
 import { markdownTable } from 'markdown-table';
 import type { RuleModule } from './types.js';
 import { RuleOption, getAllNamedOptions } from './rule-options.js';
-import { getEndOfLine, sanitizeMarkdownTable } from './string.js';
-
-const EOL = getEndOfLine();
+import { EOL, sanitizeMarkdownTable } from './string.js';
 
 export enum COLUMN_TYPE {
   // Alphabetical order.

--- a/lib/string.ts
+++ b/lib/string.ts
@@ -1,7 +1,12 @@
-import { EOL } from 'node:os';
+import { EOL as NodeEOL } from 'node:os';
 import editorconfig from 'editorconfig';
 
-const endOfLine = getEndOfLine();
+/**
+ * The cached result of the `getEndOfLine` function. Unfortunately, this cannot
+ * be used everywhere in the codebase since in tests, the file system can
+ * change after this constant is initialized.
+ */
+export const EOL = getEndOfLine();
 
 export function toSentenceCase(str: string) {
   return str.replace(/^\w/u, function (txt) {
@@ -27,7 +32,7 @@ export function capitalizeOnlyFirstLetter(str: string) {
 function sanitizeMarkdownTableCell(text: string): string {
   return text
     .replaceAll('|', String.raw`\|`)
-    .replaceAll(new RegExp(endOfLine, 'gu'), '<br/>');
+    .replaceAll(new RegExp(EOL, 'gu'), '<br/>');
 }
 
 export function sanitizeMarkdownTable(
@@ -36,21 +41,23 @@ export function sanitizeMarkdownTable(
   return text.map((row) => row.map((col) => sanitizeMarkdownTableCell(col)));
 }
 
-// Gets the end of line string while respecting the
-// `.editorconfig` and falling back to `EOL` from `node:os`.
+/**
+ * Gets the end of line string while respecting the `.editorconfig` and falling
+ * back to `EOL` from `node:os`.
+ */
 export function getEndOfLine() {
-  // The passed `markdown.md` argument is used as an example
-  // of a markdown file in the plugin root folder in order to
-  // check for any specific markdown configurations.
-  const config = editorconfig.parseSync('markdown.md');
+  // The passed `markdown.md` argument is used as an example of a markdown file
+  // in the plugin root folder in order to check for any specific markdown
+  // configurations.
+  const editorconfigProps = editorconfig.parseSync('markdown.md');
 
-  let endOfLine = EOL;
-
-  if (config.end_of_line === 'lf') {
-    endOfLine = '\n';
-  } else if (config.end_of_line === 'crlf') {
-    endOfLine = '\r\n';
+  if (editorconfigProps.end_of_line === 'lf') {
+    return '\n';
   }
 
-  return endOfLine;
+  if (editorconfigProps.end_of_line === 'crlf') {
+    return '\r\n';
+  }
+
+  return NodeEOL;
 }


### PR DESCRIPTION
This is some prep work before addressing #725.

I noticed some duplication around the codebase, so this is my attempt to clean it up.
All of the root level `getEndOfLine` invocations can be cached, since it duplicates work.
Usually, when a constant is imported in more than one place, I put it in a "constants.ts" file, but that isn't ideal here because one cached copy needs to exist in the "string.ts" function, and we couldn't import from a "constants.ts" in that case since it would cause circular imports.

Some remaining questions though:

It seems buggy/unintended that sometimes, EOL is cached, and other times it is calculated dynamically. One case where it seems buggy is the `sanitizeMarkdownTable` function. It uses the cached version, but that is used in the `generate` function, which is the main function of the tool. Do you know if that is intended?

I actually tried to refactor it to be cached everywhere, but then that caused the tests to fail, because the value was cached before the mock FS editorconfig got initialized. Tricky!

I suspect a better state of affairs would be for the tool to calculate the EOL at the start of the `generate` function, and then have it be explicitly passed to child functions. (Instead of using a module-level variable or a global-level variable, which is how it works now.)

Let me know if you want me to go with that approach instead, and I can close this PR.