### PR TITLE
refactor: use context object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,13 +8,16 @@ node_modules
 
 # Test output:
 .nyc_output
-coverage/
+coverage
 
 # ESLint
 .eslintcache
 
 # TypeScript output
-dist/
+dist
 
 # Mac
 .DS_Store
+
+# Agents
+.claude

--- a/lib/config-list.ts
+++ b/lib/config-list.ts
@@ -5,9 +5,8 @@ import {
 import { markdownTable } from 'markdown-table';
 import type { ConfigsToRules, ConfigEmojis, Plugin, Config } from './types.js';
 import { ConfigFormat, configNameToDisplay } from './config-format.js';
-import { getEndOfLine, sanitizeMarkdownTable } from './string.js';
-
-const EOL = getEndOfLine();
+import { sanitizeMarkdownTable } from './string.js';
+import { Context } from './context.js';
 
 /**
  * Check potential locations for the config description.
@@ -31,6 +30,7 @@ function configToDescription(config: Config): string | undefined {
 }
 
 function generateConfigListMarkdown(
+  context: Context,
   plugin: Plugin,
   configsToRules: ConfigsToRules,
   pluginPrefix: string,
@@ -64,12 +64,13 @@ function generateConfigListMarkdown(
   ];
 
   return markdownTable(
-    sanitizeMarkdownTable(rows),
+    sanitizeMarkdownTable(context, rows),
     { align: 'l' }, // Left-align headers.
   );
 }
 
 export function updateConfigsList(
+  context: Context,
   markdown: string,
   plugin: Plugin,
   configsToRules: ConfigsToRules,
@@ -78,6 +79,8 @@ export function updateConfigsList(
   configFormat: ConfigFormat,
   ignoreConfig: readonly string[],
 ): string {
+  const { endOfLine } = context;
+
   const listStartIndex = markdown.indexOf(BEGIN_CONFIG_LIST_MARKER);
   let listEndIndex = markdown.indexOf(END_CONFIG_LIST_MARKER);
 
@@ -103,6 +106,7 @@ export function updateConfigsList(
 
   // New config list.
   const list = generateConfigListMarkdown(
+    context,
     plugin,
     configsToRules,
     pluginPrefix,
@@ -111,5 +115,5 @@ export function updateConfigsList(
     ignoreConfig,
   );
 
-  return `${preList}${BEGIN_CONFIG_LIST_MARKER}${EOL}${EOL}${list}${EOL}${EOL}${END_CONFIG_LIST_MARKER}${postList}`;
+  return `${preList}${BEGIN_CONFIG_LIST_MARKER}${endOfLine}${endOfLine}${list}${endOfLine}${endOfLine}${END_CONFIG_LIST_MARKER}${postList}`;
 }

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -1,0 +1,37 @@
+import { EOL } from 'node:os';
+import editorconfig from 'editorconfig';
+
+/**
+ * Context about the current invocation of the program, like what end-of-line
+ * character to use.
+ */
+export interface Context {
+  endOfLine: string;
+}
+
+export function getContext() {
+  return {
+    endOfLine: getEndOfLine(),
+  };
+}
+
+/**
+ * Gets the end of line string while respecting the `.editorconfig` and falling
+ * back to `EOL` from `node:os`.
+ */
+export function getEndOfLine() {
+  // The passed `markdown.md` argument is used as an example of a markdown file
+  // in the plugin root folder in order to check for any specific markdown
+  // configurations.
+  const config = editorconfig.parseSync('markdown.md');
+
+  if (config.end_of_line === 'lf') {
+    return '\n';
+  }
+
+  if (config.end_of_line === 'crlf') {
+    return '\r\n';
+  }
+
+  return EOL;
+}

--- a/lib/rule-doc-notices.ts
+++ b/lib/rule-doc-notices.ts
@@ -26,11 +26,9 @@ import {
   toSentenceCase,
   removeTrailingPeriod,
   addTrailingPeriod,
-  getEndOfLine,
 } from './string.js';
 import { ConfigFormat, configNameToDisplay } from './config-format.js';
-
-const EOL = getEndOfLine();
+import { Context } from './context.js';
 
 function severityToTerminology(severity: SEVERITY_TYPE) {
   switch (severity) {
@@ -494,6 +492,7 @@ function makeRuleDocTitle(
  * @returns {string} - new header including marker
  */
 export function generateRuleHeaderLines(
+  context: Context,
   description: string | undefined,
   name: string,
   plugin: Plugin,
@@ -509,6 +508,8 @@ export function generateRuleHeaderLines(
   urlConfigs?: string,
   urlRuleDoc?: string | UrlRuleDocFunction,
 ): string {
+  const { endOfLine } = context;
+
   return [
     makeRuleDocTitle(name, description, pluginPrefix, ruleDocTitleFormat),
     ...getRuleNoticeLines(
@@ -527,5 +528,5 @@ export function generateRuleHeaderLines(
     ),
     '',
     END_RULE_HEADER_MARKER,
-  ].join(EOL);
+  ].join(endOfLine);
 }

--- a/lib/rule-list-legend.ts
+++ b/lib/rule-list-legend.ts
@@ -17,9 +17,7 @@ import {
 } from './types.js';
 import { RULE_TYPE_MESSAGES_LEGEND, RULE_TYPES } from './rule-type.js';
 import { ConfigFormat, configNameToDisplay } from './config-format.js';
-import { getEndOfLine } from './string.js';
-
-const EOL = getEndOfLine();
+import { Context } from './context.js';
 
 export const SEVERITY_TYPE_TO_WORD: {
   [key in SEVERITY_TYPE]: string;
@@ -233,6 +231,7 @@ function getLegendsForIndividualConfigs({
 }
 
 export function generateLegend(
+  context: Context,
   columns: Record<COLUMN_TYPE, boolean>,
   plugin: Plugin,
   configsToRules: ConfigsToRules,
@@ -242,6 +241,8 @@ export function generateLegend(
   ignoreConfig: readonly string[],
   urlConfigs?: string,
 ) {
+  const { endOfLine } = context;
+
   const legends = (
     Object.entries(columns) as readonly [COLUMN_TYPE, boolean][]
   ).flatMap(([columnType, enabled]) => {
@@ -290,5 +291,6 @@ export function generateLegend(
     );
   }
 
-  return legends.join(`\\${EOL}`); // Back slash ensures these end up displayed on separate lines.
+  // The backslashes ensure that they end up displayed on separate lines.
+  return legends.join(`\\${endOfLine}`);
 }

--- a/lib/rule-options-list.ts
+++ b/lib/rule-options-list.ts
@@ -5,9 +5,8 @@ import {
 import { markdownTable } from 'markdown-table';
 import type { RuleModule } from './types.js';
 import { RuleOption, getAllNamedOptions } from './rule-options.js';
-import { getEndOfLine, sanitizeMarkdownTable } from './string.js';
-
-const EOL = getEndOfLine();
+import { sanitizeMarkdownTable } from './string.js';
+import { Context } from './context.js';
 
 export enum COLUMN_TYPE {
   // Alphabetical order.
@@ -111,7 +110,10 @@ function ruleOptionsToColumnsToDisplay(ruleOptions: readonly RuleOption[]): {
   return columnsToDisplay;
 }
 
-function generateRuleOptionsListMarkdown(rule: RuleModule): string {
+function generateRuleOptionsListMarkdown(
+  context: Context,
+  rule: RuleModule,
+): string {
   const ruleOptions = getAllNamedOptions(rule.meta?.schema);
 
   if (ruleOptions.length === 0) {
@@ -135,15 +137,18 @@ function generateRuleOptionsListMarkdown(rule: RuleModule): string {
     });
 
   return markdownTable(
-    sanitizeMarkdownTable([listHeaderRow, ...rows]),
+    sanitizeMarkdownTable(context, [listHeaderRow, ...rows]),
     { align: 'l' }, // Left-align headers.
   );
 }
 
 export function updateRuleOptionsList(
+  context: Context,
   markdown: string,
   rule: RuleModule,
 ): string {
+  const { endOfLine } = context;
+
   const listStartIndex = markdown.indexOf(BEGIN_RULE_OPTIONS_LIST_MARKER);
   let listEndIndex = markdown.indexOf(END_RULE_OPTIONS_LIST_MARKER);
 
@@ -159,7 +164,7 @@ export function updateRuleOptionsList(
   const postList = markdown.slice(Math.max(0, listEndIndex));
 
   // New rule options list.
-  const list = generateRuleOptionsListMarkdown(rule);
+  const list = generateRuleOptionsListMarkdown(context, rule);
 
-  return `${preList}${BEGIN_RULE_OPTIONS_LIST_MARKER}${EOL}${EOL}${list}${EOL}${EOL}${END_RULE_OPTIONS_LIST_MARKER}${postList}`;
+  return `${preList}${BEGIN_RULE_OPTIONS_LIST_MARKER}${endOfLine}${endOfLine}${list}${endOfLine}${endOfLine}${END_RULE_OPTIONS_LIST_MARKER}${postList}`;
 }

--- a/lib/string.ts
+++ b/lib/string.ts
@@ -36,21 +36,23 @@ export function sanitizeMarkdownTable(
   return text.map((row) => row.map((col) => sanitizeMarkdownTableCell(col)));
 }
 
-// Gets the end of line string while respecting the
-// `.editorconfig` and falling back to `EOL` from `node:os`.
+/**
+ * Gets the end of line string while respecting the
+ * `.editorconfig` and falling back to `EOL` from `node:os`.
+ */
 export function getEndOfLine() {
   // The passed `markdown.md` argument is used as an example
   // of a markdown file in the plugin root folder in order to
   // check for any specific markdown configurations.
   const config = editorconfig.parseSync('markdown.md');
 
-  let endOfLine = EOL;
-
   if (config.end_of_line === 'lf') {
-    endOfLine = '\n';
-  } else if (config.end_of_line === 'crlf') {
-    endOfLine = '\r\n';
+    return '\n';
   }
 
-  return endOfLine;
+  if (config.end_of_line === 'crlf') {
+    return '\r\n';
+  }
+
+  return EOL;
 }

--- a/lib/string.ts
+++ b/lib/string.ts
@@ -1,7 +1,4 @@
-import { EOL } from 'node:os';
-import editorconfig from 'editorconfig';
-
-const endOfLine = getEndOfLine();
+import { Context } from './context.js';
 
 export function toSentenceCase(str: string) {
   return str.replace(/^\w/u, function (txt) {
@@ -24,35 +21,19 @@ export function capitalizeOnlyFirstLetter(str: string) {
   return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 }
 
-function sanitizeMarkdownTableCell(text: string): string {
+function sanitizeMarkdownTableCell(context: Context, text: string): string {
+  const { endOfLine } = context;
+
   return text
     .replaceAll('|', String.raw`\|`)
     .replaceAll(new RegExp(endOfLine, 'gu'), '<br/>');
 }
 
 export function sanitizeMarkdownTable(
+  context: Context,
   text: readonly (readonly string[])[],
 ): readonly (readonly string[])[] {
-  return text.map((row) => row.map((col) => sanitizeMarkdownTableCell(col)));
-}
-
-/**
- * Gets the end of line string while respecting the
- * `.editorconfig` and falling back to `EOL` from `node:os`.
- */
-export function getEndOfLine() {
-  // The passed `markdown.md` argument is used as an example
-  // of a markdown file in the plugin root folder in order to
-  // check for any specific markdown configurations.
-  const config = editorconfig.parseSync('markdown.md');
-
-  if (config.end_of_line === 'lf') {
-    return '\n';
-  }
-
-  if (config.end_of_line === 'crlf') {
-    return '\r\n';
-  }
-
-  return EOL;
+  return text.map((row) =>
+    row.map((col) => sanitizeMarkdownTableCell(context, col)),
+  );
 }

--- a/lib/string.ts
+++ b/lib/string.ts
@@ -9,12 +9,12 @@ export function toSentenceCase(str: string) {
   });
 }
 
-export function removeTrailingPeriod(str: string) {
-  return str.replace(/\.$/u, '');
-}
-
 export function addTrailingPeriod(str: string) {
   return str.replace(/\.?$/u, '.');
+}
+
+export function removeTrailingPeriod(str: string) {
+  return str.replace(/\.$/u, '');
 }
 
 /**

--- a/test/lib/generate/editor-config-test.ts
+++ b/test/lib/generate/editor-config-test.ts
@@ -1,16 +1,21 @@
-import { getEndOfLine } from '../../../lib/string.js';
+import { getEndOfLine } from '../../../lib/context.js';
 import { generate } from '../../../lib/generator.js';
 import mockFs from 'mock-fs';
 import { jest } from '@jest/globals';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
+import { EOL } from 'node:os';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const PATH_NODE_MODULES = resolve(__dirname, '..', '..', '..', 'node_modules');
 
 describe('string (getEndOfLine)', function () {
+  it('handles when .editorconfig is not available and fallbacks to `EOL` from `node:os`', function () {
+    expect(getEndOfLine()).toStrictEqual(EOL);
+  });
+
   describe('returns the correct end of line when .editorconfig exists', function () {
     afterEach(function () {
       mockFs.restore();

--- a/test/lib/markdown-test.ts
+++ b/test/lib/markdown-test.ts
@@ -1,31 +1,35 @@
 import { outdent } from 'outdent';
 import { findSectionHeader } from '../../lib/markdown.js';
+import { getContext } from '../../lib/context.js';
 
 describe('markdown', function () {
   describe('#findSectionHeader', function () {
+    const context = getContext();
+
     it('handles standard section title', function () {
       const title = '## Rules\n';
-      expect(findSectionHeader(title, 'rules')).toBe(title);
+      expect(findSectionHeader(context, title, 'rules')).toBe(title);
     });
 
     it('handles section title with leading emoji', function () {
       const title = '## 🍟 Rules\n';
-      expect(findSectionHeader(title, 'rules')).toBe(title);
+      expect(findSectionHeader(context, title, 'rules')).toBe(title);
     });
 
     it('handles section title with html', function () {
       const title = "## <a name='Rules'></a>Rules\n";
-      expect(findSectionHeader(title, 'rules')).toBe(title);
+      expect(findSectionHeader(context, title, 'rules')).toBe(title);
     });
 
     it('handles sentential section title', function () {
       const title = '## List of supported rules\n';
-      expect(findSectionHeader(title, 'rules')).toBe(title);
+      expect(findSectionHeader(context, title, 'rules')).toBe(title);
     });
 
     it('handles doc with multiple sections', function () {
       expect(
         findSectionHeader(
+          context,
           outdent`
             # eslint-plugin-test
             Description.
@@ -42,6 +46,7 @@ describe('markdown', function () {
     it('handles doc with multiple rules-related sections', function () {
       expect(
         findSectionHeader(
+          context,
           outdent`
             # eslint-plugin-test
             Description.

--- a/test/lib/string-test.ts
+++ b/test/lib/string-test.ts
@@ -2,9 +2,7 @@ import {
   addTrailingPeriod,
   removeTrailingPeriod,
   toSentenceCase,
-  getEndOfLine,
 } from '../../lib/string.js';
-import { EOL } from 'node:os';
 
 describe('strings', function () {
   describe('#addTrailingPeriod', function () {
@@ -34,12 +32,6 @@ describe('strings', function () {
 
     it('handles when uppercase first letter', function () {
       expect(toSentenceCase('Hello World')).toStrictEqual('Hello World');
-    });
-  });
-
-  describe('#getEndOfLine', function () {
-    it('handles when .editorconfig is not available and fallbacks to `EOL` from `node:os`', function () {
-      expect(getEndOfLine()).toStrictEqual(EOL);
     });
   });
 });


### PR DESCRIPTION
- This pull request implements the `context` object described in #798.
- I tried to make this PR as small as possible. It just refactors `EOL`/`endOfLine` to come from the context in all situations.

Also, please recommend other variables that you are passing around between functions that I can add to the context object in order to simplify the code. (I can do that in a follow-up PR in order to keep this one small.)

After you approve this PR, I plan to do more changes to make the `getEndOfLine` function more robust.