### PR TITLE
feat: receive plugin name via plugin metadata

### DIFF
--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -3,10 +3,11 @@ import { dirname, join, relative, resolve } from 'node:path';
 import { getAllNamedOptions, hasOptions } from './rule-options.js';
 import {
   loadPlugin,
-  getPluginPrefix,
+  getPluginName,
   getPluginRoot,
   getPathWithExactFileNameCasing,
 } from './package-json.js';
+import { getPluginPrefix } from './plugin-prefix.js';
 import { updateRulesList } from './rule-list.js';
 import { updateConfigsList } from './config-list.js';
 import { generateRuleHeaderLines } from './rule-doc-notices.js';
@@ -67,7 +68,9 @@ export async function generate(path: string, options?: GenerateOptions) {
   const { endOfLine } = context;
 
   const plugin = await loadPlugin(path);
-  const pluginPrefix = await getPluginPrefix(path);
+  const pluginPrefix = getPluginPrefix(
+    plugin.meta?.name ?? (await getPluginName(path)),
+  );
   const configsToRules = await resolveConfigsToRules(plugin);
 
   if (!plugin.rules) {

--- a/lib/package-json.ts
+++ b/lib/package-json.ts
@@ -119,16 +119,17 @@ export async function loadPlugin(path: string): Promise<Plugin> {
   }
 }
 
-export async function getPluginPrefix(path: string): Promise<string> {
+/**
+ * Get the plugin name by reading the `name` field in the package.json file.
+ */
+export async function getPluginName(path: string): Promise<string> {
   const pluginPackageJson = await loadPackageJson(path);
   if (!pluginPackageJson.name) {
     throw new Error(
       "Could not find `name` field in ESLint plugin's package.json.",
     );
   }
-  return pluginPackageJson.name.endsWith('/eslint-plugin')
-    ? pluginPackageJson.name.split('/')[0] // Scoped plugin name like @my-scope/eslint-plugin.
-    : pluginPackageJson.name.replace('eslint-plugin-', ''); // Unscoped name like eslint-plugin-foo or scoped name like @my-scope/eslint-plugin-foo.
+  return pluginPackageJson.name;
 }
 
 /**

--- a/lib/plugin-prefix.ts
+++ b/lib/plugin-prefix.ts
@@ -1,0 +1,8 @@
+/**
+ * Construct the plugin prefix out of the plugin's name.
+ */
+export function getPluginPrefix(name: string): string {
+  return name.endsWith('/eslint-plugin')
+    ? name.split('/')[0] // Scoped plugin name like @my-scope/eslint-plugin.
+    : name.replace('eslint-plugin-', ''); // Unscoped name like eslint-plugin-foo or scoped name like @my-scope/eslint-plugin-foo.
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,8 @@
         "node": "^18.18.0 || ^20.9.0 || >=22.0.0"
       },
       "peerDependencies": {
-        "eslint": ">= 8.57.1"
+        "eslint": ">= 8.57.1",
+        "prettier": ">= 3.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -105,6 +106,7 @@
       "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -1734,6 +1736,7 @@
       "integrity": "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.8.0"
       }
@@ -1799,6 +1802,7 @@
       "integrity": "sha512-2X3mwqsj9Bd3Ciz508ZUtoQQYpOhU/kWoUqIf49H8Z0+Vbh6UF/y0OEYp0Q0axOGzaBGs7QxRwq0knSQ8khQNA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "8.26.1",
@@ -1829,6 +1833,7 @@
       "integrity": "sha512-w6HZUV4NWxqd8BdeFf81t07d7/YV9s7TCWrQQbG5uhuvGUAW+fq1usZ1Hmz9UPNLniFnD8GLSsDpjP0hm1S4lQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.26.1",
         "@typescript-eslint/types": "8.26.1",
@@ -1985,6 +1990,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2019,6 +2025,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2469,6 +2476,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -3539,6 +3547,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.29.0.tgz",
       "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3616,6 +3625,7 @@
       "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5671,6 +5681,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -8339,6 +8350,7 @@
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9667,6 +9679,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9817,6 +9830,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10018,6 +10032,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/test/lib/generate/__snapshots__/general-test.ts.snap
+++ b/test/lib/generate/__snapshots__/general-test.ts.snap
@@ -57,3 +57,53 @@ exports[`generate (general) basic updates the documentation 4`] = `
 ## Rule details
 details"
 `;
+
+exports[`generate (general) plugin prefix uses \`plugin.meta.name\` as source for rule prefix 1`] = `
+"# eslint-plugin-test
+Description.
+## Rules
+<!-- begin auto-generated rules list -->
+
+🔧 Automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\\
+💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
+
+| Name                           | Description            | 🔧 | 💡 |
+| :----------------------------- | :--------------------- | :- | :- |
+| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | 🔧 |    |
+| [no-baz](docs/rules/no-baz.md) | Description of no-boz. |    |    |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | 🔧 | 💡 |
+
+<!-- end auto-generated rules list -->
+more content."
+`;
+
+exports[`generate (general) plugin prefix uses \`plugin.meta.name\` as source for rule prefix 2`] = `
+"# Description of no-foo (\`custom/no-foo\`)
+
+🔧💡 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) and manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
+
+<!-- end auto-generated rule header -->
+## Rule details
+details
+## Options
+optionToDoSomething1 - explanation
+optionToDoSomething2 - explanation"
+`;
+
+exports[`generate (general) plugin prefix uses \`plugin.meta.name\` as source for rule prefix 3`] = `
+"# Description of no-bar (\`custom/no-bar\`)
+
+🔧 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
+## Rule details
+details"
+`;
+
+exports[`generate (general) plugin prefix uses \`plugin.meta.name\` as source for rule prefix 4`] = `
+"# Description of no-boz (\`custom/no-baz\`)
+
+<!-- end auto-generated rule header -->
+## Rule details
+details"
+`;

--- a/test/lib/generate/general-test.ts
+++ b/test/lib/generate/general-test.ts
@@ -154,4 +154,149 @@ describe('generate (general)', function () {
       expect(readFileSync('docs/rules/no-baz.md', 'utf8')).toMatchSnapshot();
     });
   });
+
+  describe('plugin prefix', function () {
+    beforeEach(function () {
+      mockFs({
+        // package.json
+        'package.json': JSON.stringify({
+          name: 'eslint-plugin-test',
+          exports: 'index.js',
+          type: 'module',
+        }),
+
+        // entry point
+        'index.js': `
+            export default {
+              meta: {
+                name: 'custom',
+              },
+              rules: {
+                'no-foo': {
+                  meta: {
+                    docs: { description: 'Description of no-foo.' },
+                    fixable: 'code',
+                    hasSuggestions: true,
+                    schema: [
+                      {
+                        type: 'object',
+                        properties: {
+                          optionToDoSomething1: {
+                            type: 'boolean',
+                            default: false,
+                          },
+                        },
+                        additionalProperties: false,
+                      },
+                      {
+                        type: 'array',
+                        minItems: 1,
+                        maxItems: 1,
+                        items: [
+                          {
+                            type: 'object',
+                            properties: {
+                              optionToDoSomething2: {
+                                type: 'boolean',
+                                default: false,
+                              },
+                            },
+                            additionalProperties: false,
+                          },
+                        ],
+                      },
+                      {
+                        type: 'array',
+                      },
+                    ]
+                  },
+                  create(context) {}
+                },
+                'no-bar': {
+                  meta: {
+                    docs: { description: 'Description of no-bar.' },
+                    fixable: 'code',
+                    schema: [],
+                  },
+                  create(context) {},
+                },
+                'no-baz': {
+                  meta: { docs: { description: 'Description of no-boz.' }, },
+                  create(context) {}
+                },
+              },
+              configs: {
+                all: {
+                  rules: {
+                    'test/no-foo': 'error',
+                    'test/no-bar': 'error',
+                    // test/no-baz rule intentionally not in any config.
+                  }
+                },
+                recommended: {
+                  rules: {
+                    'test/no-foo': 'error',
+                  }
+                },
+                style: {
+                  rules: {
+                    'test/no-bar': 'error',
+                  }
+                }
+              }
+            };`,
+
+        // README.md
+        'README.md': outdent`
+          # eslint-plugin-test
+          Description.
+          ## Rules
+          <!-- begin auto-generated rules list -->
+          ...
+          <!-- end auto-generated rules list -->
+          more content.
+        `,
+
+        // RULE DOC FILES
+
+        'docs/rules/no-foo.md': outdent`
+          # title (rule-name)
+          description
+          <!-- end auto-generated rule header -->
+          ## Rule details
+          details
+          ## Options
+          optionToDoSomething1 - explanation
+          optionToDoSomething2 - explanation
+        `, // rule doc with incorrect header content
+        'docs/rules/no-bar.md': outdent`
+          <!-- end auto-generated rule header -->
+          ## Rule details
+          details
+        `, // marker but no header content
+        'docs/rules/no-baz.md': outdent`
+          ## Rule details
+          details
+        `, // content but missing marker
+
+        // Needed for some of the test infrastructure to work.
+        node_modules: mockFs.load(PATH_NODE_MODULES),
+      });
+    });
+
+    afterEach(function () {
+      mockFs.restore();
+      jest.resetModules();
+    });
+
+    it('uses `plugin.meta.name` as source for rule prefix', async function () {
+      await generate('.');
+
+      expect(readFileSync('README.md', 'utf8')).toMatchSnapshot();
+
+      expect(readFileSync('docs/rules/no-foo.md', 'utf8')).toMatchSnapshot();
+      expect(readFileSync('docs/rules/no-bar.md', 'utf8')).toMatchSnapshot();
+      expect(readFileSync('docs/rules/no-baz.md', 'utf8')).toMatchSnapshot();
+    });
+  });
 });


### PR DESCRIPTION
This is another (see #680), rather simple approach to solve cases as outlined in #610.

It works by trying to get the plugin name from the `<plugin>.meta.name` field. If this isn't defined, it falls back to the current method of using the `name` field of the plugin's `package.json` file.

Most plugins have `<plugin>.meta.name` set to the same value as the package name.
Some prominent examples would be: [vue](https://github.com/vuejs/eslint-plugin-vue/blob/917787c46a268b1910b9c77e091656a428d70a89/lib/meta.js#L3), [markdown](https://github.com/eslint/markdown/blob/c099b70630b12ea37771a0e68c6be3dcf770b939/src/index.js#L55), [unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/396a8fa27d26ca77838f43ae4cdf2d98c7d52fef/index.js#L67), ...
In these cases, `eslint-doc-generator` will work exactly as before.

For plugins having a value at `<plugin>.meta.name` that differs from the package name, this is either a way resp. indicator that the rules should be prefixed with that varying value, or is it already the shorthand (package name: `eslint-plugin-x`, meta name: `x`). In the latter case, `eslint-doc-generator` will again produce exactly the same result as before.
In the first case, it would help to achieve the desired result for the docs (as described in #610) without having to introduce a new option. 
Examples would be: [vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/977022f567c79f662c645b21f41a74e04e16cc2d/src/index.ts#L269), [antfu](https://github.com/antfu/eslint-plugin-antfu/blob/4730648ffb113d0aa4740859a12bd64d7bb6d6ba/src/index.ts#L17), ...

I feel like this approach might not even be considered as a breaking change (although I'd still leave a corresponding note in the changelog).

---

Fixes #610

BEGIN_COMMIT_OVERRIDE
feat: receive plugin name via plugin metadata
END_COMMIT_OVERRIDE