### PR TITLE
docs: add eslint-plugin-testing-library to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ This tool is used by popular ESLint plugins like:
 - [eslint-plugin-promise](https://github.com/eslint-community/eslint-plugin-promise#rules)
 - [eslint-plugin-qunit](https://github.com/platinumazure/eslint-plugin-qunit#rules)
 - [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react#list-of-supported-rules)
-- [eslint-plugin-unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn#rules)
 - [eslint-plugin-testing-library](https://github.com/testing-library/eslint-plugin-testing-library)
+- [eslint-plugin-unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn#rules)
 
 ## Configuration options
 


### PR DESCRIPTION
Just adding the `eslint-plungin-testing-library` plugin to the _Users_ section within the `README`