### PR TITLE
Add default emoji for `base` config

### DIFF
--- a/lib/emojis.ts
+++ b/lib/emojis.ts
@@ -12,6 +12,7 @@ export const EMOJI_CONFIGS = {
   a11y: EMOJI_A11Y,
   accessibility: EMOJI_A11Y,
   all: '🌐',
+  base: '🧱',
   error: EMOJI_ERROR,
   errors: EMOJI_ERROR,
   recommended: '✅',


### PR DESCRIPTION
`base` is commonly a config that other configs extend or build upon.

Fixes #497.

BEGIN_COMMIT_OVERRIDE
feat!: Add default emoji for `base` config
END_COMMIT_OVERRIDE