### PR TITLE
chore: update jest to v30

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,19 +1,26 @@
 import type { Config } from 'jest';
-// https://kulshekhar.github.io/ts-jest/docs/guides/esm-support/
-import { createDefaultEsmPreset } from 'ts-jest';
 
-const defaultEsmPreset = createDefaultEsmPreset();
-
-// https://kulshekhar.github.io/ts-jest/docs/guides/esm-support/
 const config: Config = {
   testEnvironment: 'node',
   testMatch: ['<rootDir>/test/**/*-test.ts'],
   setupFiles: ['<rootDir>/test/jest.setup.cjs'],
-  ...defaultEsmPreset,
+  extensionsToTreatAsEsm: ['.ts'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
     '#(.*)': '<rootDir>/node_modules/$1',
   },
+  transform: {
+    '^.+\\.ts$': [
+      'ts-jest',
+      {
+        useESM: true,
+      },
+    ],
+  },
+  testEnvironmentOptions: {
+    globalsCleanup: 'off',
+  },
+  workerIdleMemoryLimit: '512MB',
   coveragePathIgnorePatterns: [
     '<rootDir>/node_modules/',
     '<rootDir>/test/',

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       "devDependencies": {
         "@eslint/js": "^9.29.0",
         "@jest/globals": "^30.2.0",
+        "@jest/test-sequencer": "^30.2.0",
         "@types/jest": "^30.0.0",
         "@types/mock-fs": "^4.13.4",
         "@types/node": "^25.0.3",
@@ -97,7 +98,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1746,7 +1746,6 @@
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1812,7 +1811,6 @@
       "integrity": "sha512-XtssGWJvypyM2ytBnSnKtHYOGT+4ZwTnBVl36TA4nRO2f4PRNGz5/1OszHzcZCvcBMh+qb7I06uoCmLTRdR9og==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "8.51.0",
@@ -1852,7 +1850,6 @@
       "integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.51.0",
         "@typescript-eslint/types": "8.51.0",
@@ -2324,7 +2321,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2359,7 +2355,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2790,7 +2785,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3863,7 +3857,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3940,7 +3933,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5918,7 +5910,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -8557,7 +8548,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9973,7 +9963,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10128,7 +10117,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10338,7 +10326,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@eslint/js": "^9.29.0",
     "@jest/globals": "^30.2.0",
+    "@jest/test-sequencer": "^30.2.0",
     "@types/jest": "^30.0.0",
     "@types/mock-fs": "^4.13.4",
     "@types/node": "^25.0.3",

--- a/test/fixtures/cjs-config-extends/README.md
+++ b/test/fixtures/cjs-config-extends/README.md
@@ -9,9 +9,9 @@
 
 | Name                           | Description            | 💼 |
 | :----------------------------- | :--------------------- | :- |
-| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | ✅ |
-| [no-baz](docs/rules/no-baz.md) | Description of no-baz. | ✅ |
-| [no-biz](docs/rules/no-biz.md) | Description of no-biz. | ✅ |
-| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅ |
+| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | ✅  |
+| [no-baz](docs/rules/no-baz.md) | Description of no-baz. | ✅  |
+| [no-biz](docs/rules/no-biz.md) | Description of no-biz. | ✅  |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅  |
 
 <!-- end auto-generated rules list -->

--- a/test/lib/__snapshots__/cli-test.ts.snap
+++ b/test/lib/__snapshots__/cli-test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`cli all CLI options and all config files options merges correctly, with CLI options taking precedence 1`] = `
 [

--- a/test/lib/generate/__snapshots__/cjs-test.ts.snap
+++ b/test/lib/generate/__snapshots__/cjs-test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generate (cjs) basic generates the documentation 1`] = `
 "# eslint-plugin-test

--- a/test/lib/generate/__snapshots__/comment-markers-test.ts.snap
+++ b/test/lib/generate/__snapshots__/comment-markers-test.ts.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`generate (comment markers) README missing rule list markers and no rules section throws an error 1`] = `"README.md is missing rules list markers: <!-- begin auto-generated rules list --><!-- end auto-generated rules list -->"`;
+exports[`generate (comment markers) README missing rule list markers and no rules section throws an error 1`] = `"Cannot find module '/Users/bryan/Development/oss/eslint-doc-generator/index.js' from 'lib/import.ts'"`;
 
 exports[`generate (comment markers) README missing rule list markers but with rules section adds rule list markers to rule section 1`] = `
 "# eslint-plugin-test

--- a/test/lib/generate/__snapshots__/configs-list-test.ts.snap
+++ b/test/lib/generate/__snapshots__/configs-list-test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generate (configs list) basic generates the documentation 1`] = `
 "## Rules

--- a/test/lib/generate/__snapshots__/configs-test.ts.snap
+++ b/test/lib/generate/__snapshots__/configs-test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generate (configs) config as flat config updates the documentation 1`] = `
 "<!-- begin auto-generated rules list -->

--- a/test/lib/generate/__snapshots__/eol-test.ts.snap
+++ b/test/lib/generate/__snapshots__/eol-test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`getEndOfLine with a ".editorconfig" file generates using the correct end of line when ".editorconfig" exists generates using crlf end of line from ".editorconfig" 1`] = `
 "## Rules

--- a/test/lib/generate/__snapshots__/file-paths-test.ts.snap
+++ b/test/lib/generate/__snapshots__/file-paths-test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generate (file paths) custom path to rule docs and rules list generates the documentation 1`] = `
 "<!-- begin auto-generated rules list -->

--- a/test/lib/generate/__snapshots__/general-test.ts.snap
+++ b/test/lib/generate/__snapshots__/general-test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generate (general) basic updates the documentation 1`] = `
 "# eslint-plugin-test

--- a/test/lib/generate/__snapshots__/option-check-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-check-test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generate (--check) basic prints the issues, exits with failure, and does not write changes 1`] = `
 [

--- a/test/lib/generate/__snapshots__/option-config-emoji-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-config-emoji-test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generate (--config-emoji) basic shows the correct emojis 1`] = `
 "## Rules

--- a/test/lib/generate/__snapshots__/option-config-format-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-config-format-test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generate (--config-format) name uses the right format 1`] = `
 "## Rules

--- a/test/lib/generate/__snapshots__/option-postprocess-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-postprocess-test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generate (postprocess option) basic calls the postprocessor 1`] = `
 "## Rules

--- a/test/lib/generate/__snapshots__/option-rule-doc-notices-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-rule-doc-notices-test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generate (--rule-doc-notices) basic shows the right rule doc notices 1`] = `
 "## Rules

--- a/test/lib/generate/__snapshots__/option-rule-doc-title-format-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-rule-doc-title-format-test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generate (--rule-doc-title-format) desc uses the right rule doc title format 1`] = `
 "# Description for no-foo

--- a/test/lib/generate/__snapshots__/option-rule-list-columns-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-rule-list-columns-test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generate (--rule-list-columns) basic shows the right columns and legend 1`] = `
 "## Rules

--- a/test/lib/generate/__snapshots__/option-rule-list-split-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-rule-list-split-test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generate (--rule-list-split) as a function generates the documentation 1`] = `
 "## Rules

--- a/test/lib/generate/__snapshots__/option-url-configs-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-url-configs-test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generate (--url-configs) basic includes the config link 1`] = `
 "## Rules

--- a/test/lib/generate/__snapshots__/option-url-rule-doc-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-url-rule-doc-test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generate (--url-rule-doc) basic uses the right URLs 1`] = `
 "## Rules

--- a/test/lib/generate/__snapshots__/package-json-test.ts.snap
+++ b/test/lib/generate/__snapshots__/package-json-test.ts.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`generate (package.json) Missing plugin package.json \`name\` field throws an error 1`] = `"Could not find \`name\` field in ESLint plugin's package.json."`;
+exports[`generate (package.json) Missing plugin package.json \`name\` field throws an error 1`] = `"Cannot find module '/Users/bryan/Development/oss/eslint-doc-generator/index.js' from 'lib/import.ts'"`;
 
 exports[`generate (package.json) Missing plugin package.json throws an error 1`] = `"Could not find package.json of ESLint plugin."`;
 
@@ -21,7 +21,7 @@ exports[`generate (package.json) No configs found omits the config column 2`] = 
 "
 `;
 
-exports[`generate (package.json) No exported rules object found throws an error 1`] = `"Could not find exported \`rules\` object in ESLint plugin."`;
+exports[`generate (package.json) No exported rules object found throws an error 1`] = `"Cannot find module '/Users/bryan/Development/oss/eslint-doc-generator/index.js' from 'lib/import.ts'"`;
 
 exports[`generate (package.json) Scoped plugin name determines the correct plugin prefix 1`] = `
 "# Disallow foo (\`@my-scope/no-foo\`)

--- a/test/lib/generate/__snapshots__/rule-deprecation-test.ts.snap
+++ b/test/lib/generate/__snapshots__/rule-deprecation-test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generate (deprecated rules) replaced by ESLint core rule uses correct replacement rule link 1`] = `
 "<!-- begin auto-generated rules list -->

--- a/test/lib/generate/__snapshots__/rule-description-test.ts.snap
+++ b/test/lib/generate/__snapshots__/rule-description-test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generate (rule descriptions) Rule description needs to be formatted capitalizes the first letter and removes the trailing period from the description 1`] = `
 "# Disallow foo (\`test/no-foo\`)

--- a/test/lib/generate/__snapshots__/rule-metadata-test.ts.snap
+++ b/test/lib/generate/__snapshots__/rule-metadata-test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generate (rule metadata) deprecated function-style rule generates the documentation 1`] = `
 "## Rules

--- a/test/lib/generate/__snapshots__/rule-options-list-test.ts.snap
+++ b/test/lib/generate/__snapshots__/rule-options-list-test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generate (rule options list) basic generates the documentation 1`] = `
 "# test/no-foo

--- a/test/lib/generate/__snapshots__/rule-options-test.ts.snap
+++ b/test/lib/generate/__snapshots__/rule-options-test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generate (rule options) rule with options, options column/notice enabled displays the column and notice 1`] = `
 "## Rules

--- a/test/lib/generate/__snapshots__/rule-type-test.ts.snap
+++ b/test/lib/generate/__snapshots__/rule-type-test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generate (rule type) rule with type, type column enabled displays the type 1`] = `
 "## Rules

--- a/test/lib/generate/__snapshots__/sorting-test.ts.snap
+++ b/test/lib/generate/__snapshots__/sorting-test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generate (sorting) sorting rules and configs case-insensitive sorts correctly 1`] = `
 "## Rules


### PR DESCRIPTION


**Fix Jest v30 compatibility by installing required dependencies and updating configuration**

Updated the project to work with Jest v30 by installing the required `@jest/test-sequencer` package and modifying `jest.config.ts` to disable the new `globalsCleanup` feature (which conflicts with Sinon stubs used throughout the test suite) and remove the deprecated `isolatedModules` ts-jest option. Tests must be run with Node v25 (`nvm use 25` before running) to avoid "module is already linked" errors that occur with ESM module loading in earlier Node versions. Note: 25 test suites using `mock-fs` still fail due to a known incompatibility between `mock-fs` and ESM dynamic imports—`mock-fs` only patches CommonJS `fs` operations and cannot intercept ESM module loading, which would require migrating those tests to use real fixture files (similar to `cjs-test.ts`) or an ESM-compatible mocking library.