### PR TITLE
feat: add support for mdx files

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ Alternatively, you can configure your scripts to run `prettier` after this tool:
 
 ### File Types
 
-ESLint Doc Generator supports both regular Markdown (`md`) and Extended Markdown (`mdx`) file types.
+This tool supports both regular Markdown (`md`) and Extended Markdown (`mdx`) file types.
 In both the rule doc path option and rule list path option, you can use either.
 And in the case of the rule doc path, if the path for a specific rule isn't found at generation time with the configured file type, but the other file type is present in the same place, it will fallback to that automatically.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Also performs [configurable](#configuration-options) section consistency checks 
   - [Build tools](#build-tools)
   - [markdownlint](#markdownlint)
   - [prettier](#prettier)
+  - [File Types](#file-types)
 - [Semantic versioning policy](#semantic-versioning-policy)
 - [Related](#related)
 
@@ -441,6 +442,12 @@ Alternatively, you can configure your scripts to run `prettier` after this tool:
   "update:eslint-docs": "eslint-doc-generator && npm run format"
 }
 ```
+
+### File Types
+
+ESLint Doc Generator supports both regular Markdown (`md`) and Extended Markdown (`mdx`) file types.
+In both the rule doc path option and rule list path option, you can use either.
+And in the case of the rule doc path, if the path for a specific rule isn't found at generation time with the configured file type, but the other file type is present in the same place, it will fallback to that automatically.
 
 ## Semantic versioning policy
 

--- a/lib/comment-markers.ts
+++ b/lib/comment-markers.ts
@@ -1,19 +1,26 @@
 // Markers so that the rules table list can be automatically updated.
-export const BEGIN_RULE_LIST_MARKER =
-  '<!-- begin auto-generated rules list -->';
-export const END_RULE_LIST_MARKER = '<!-- end auto-generated rules list -->';
+export const BEGIN_RULE_LIST_MARKER = 'begin auto-generated rules list';
+export const END_RULE_LIST_MARKER = 'end auto-generated rules list';
 
 // Marker so that rule doc header (title/notices) can be automatically updated.
-export const END_RULE_HEADER_MARKER = '<!-- end auto-generated rule header -->';
+export const END_RULE_HEADER_MARKER = 'end auto-generated rule header';
 
 // Markers so that the configs table list can be automatically updated.
-export const BEGIN_CONFIG_LIST_MARKER =
-  '<!-- begin auto-generated configs list -->';
-export const END_CONFIG_LIST_MARKER =
-  '<!-- end auto-generated configs list -->';
+export const BEGIN_CONFIG_LIST_MARKER = 'begin auto-generated configs list';
+export const END_CONFIG_LIST_MARKER = 'end auto-generated configs list';
 
 // Markers so that the rule options table list can be automatically updated.
 export const BEGIN_RULE_OPTIONS_LIST_MARKER =
-  '<!-- begin auto-generated rule options list -->';
+  'begin auto-generated rule options list';
 export const END_RULE_OPTIONS_LIST_MARKER =
-  '<!-- end auto-generated rule options list -->';
+  'end auto-generated rule options list';
+
+/**
+ * Format a comment string for the appropriate comment syntax based on whether the file is MDX or not.
+ * @param comment - the comment content, without comment syntax
+ * @param isMdx - whether the comment is for an MDX file (true) or a plain markdown file (false)
+ * @returns the formatted comment string
+ */
+export function formatComment(comment: string, isMdx: boolean): string {
+  return isMdx ? `{/* ${comment} */}` : `<!-- ${comment} -->`;
+}

--- a/lib/config-list.ts
+++ b/lib/config-list.ts
@@ -1,6 +1,7 @@
 import {
   BEGIN_CONFIG_LIST_MARKER,
   END_CONFIG_LIST_MARKER,
+  formatComment,
 } from './comment-markers.js';
 import { markdownTable } from 'markdown-table';
 import type { Config } from './types.js';
@@ -64,12 +65,25 @@ function generateConfigListMarkdown(context: Context): string {
   );
 }
 
-export function updateConfigsList(context: Context, markdown: string): string {
+export function updateConfigsList(
+  context: Context,
+  markdown: string,
+  isMdx: boolean,
+): string {
   const { configsToRules, endOfLine, options } = context;
   const { ignoreConfig } = options;
 
-  const listStartIndex = markdown.indexOf(BEGIN_CONFIG_LIST_MARKER);
-  let listEndIndex = markdown.indexOf(END_CONFIG_LIST_MARKER);
+  const formattedConfigListMarkerBegin = formatComment(
+    BEGIN_CONFIG_LIST_MARKER,
+    isMdx,
+  );
+  const formattedConfigListMarkerEnd = formatComment(
+    END_CONFIG_LIST_MARKER,
+    isMdx,
+  );
+
+  const listStartIndex = markdown.indexOf(formattedConfigListMarkerBegin);
+  let listEndIndex = markdown.indexOf(formattedConfigListMarkerEnd);
 
   if (listStartIndex === -1 || listEndIndex === -1) {
     // No config list found.
@@ -86,7 +100,7 @@ export function updateConfigsList(context: Context, markdown: string): string {
   }
 
   // Account for length of pre-existing marker.
-  listEndIndex += END_CONFIG_LIST_MARKER.length;
+  listEndIndex += formattedConfigListMarkerEnd.length;
 
   const preList = markdown.slice(0, Math.max(0, listStartIndex));
   const postList = markdown.slice(Math.max(0, listEndIndex));
@@ -94,5 +108,5 @@ export function updateConfigsList(context: Context, markdown: string): string {
   // New config list.
   const list = generateConfigListMarkdown(context);
 
-  return `${preList}${BEGIN_CONFIG_LIST_MARKER}${endOfLine}${endOfLine}${list}${endOfLine}${endOfLine}${END_CONFIG_LIST_MARKER}${postList}`;
+  return `${preList}${formattedConfigListMarkerBegin}${endOfLine}${endOfLine}${list}${endOfLine}${endOfLine}${formattedConfigListMarkerEnd}${postList}`;
 }

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { dirname, join, relative, resolve } from 'node:path';
+import { dirname, extname, join, relative, resolve } from 'node:path';
 import { getAllNamedOptions, hasOptions } from './rule-options.js';
 import {
   getPluginRoot,
@@ -30,7 +30,32 @@ import { generateSuggestedEmojis } from './suggest-emojis.js';
 import { generateFrontmatterLines } from './frontmatter.js';
 
 function isMdx(path: string): boolean {
-  return path.toLowerCase().endsWith('.mdx');
+  return extname(path).toLowerCase() === '.mdx';
+}
+
+function resolveDocPath(configuredPath: string): string | undefined {
+  if (existsSync(configuredPath)) {
+    return configuredPath;
+  }
+
+  // If the configured path ends in .md, see if an .mdx version exists
+  if (configuredPath.endsWith('.md')) {
+    const mdxPath = configuredPath.replace(/\.md$/i, '.mdx');
+    if (existsSync(mdxPath)) {
+      return mdxPath;
+    }
+  }
+
+  // If the configured path ends in .mdx, see if an .md version exists
+  if (configuredPath.endsWith('.mdx')) {
+    const mdPath = configuredPath.replace(/\.mdx$/i, '.md');
+    if (existsSync(mdPath)) {
+      return mdPath;
+    }
+  }
+
+  // If neither exist, return nothing.  The configured path will be created if `--init-rule-docs` is enabled.
+  return undefined;
 }
 
 // eslint-disable-next-line complexity
@@ -96,49 +121,46 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     const metaDefaultOptions = rule.meta?.defaultOptions;
     const description = rule.meta?.docs?.description;
     const pathCurrentPage = replaceRulePlaceholder(pathRuleDoc, name);
-    let pathToDoc = join(path, pathCurrentPage);
+    const configuredPathToDoc = join(path, pathCurrentPage);
+    let pathToDoc = resolveDocPath(configuredPathToDoc);
     const ruleHasOptions = hasOptions(schema);
 
-    if (!existsSync(pathToDoc)) {
-      // Check if an `mdx` file exists with the same name, in case the rule doc was created with an `mdx` extension for starlight compatibility.
-      const pathToDocMdx = pathToDoc.replace(/\.md$/iu, '.mdx');
-      if (existsSync(pathToDocMdx)) {
-        pathToDoc = pathToDocMdx;
-      } else {
-        if (!initRuleDocs) {
-          throw new Error(
-            `Could not find rule doc (run with --init-rule-docs to create): ${relative(
-              getPluginRoot(path),
-              pathToDoc,
-            )}`,
-          );
-        }
-
-        // Determine content for fresh rule doc, including any mandatory sections.
-        // The rule doc header will be added later.
-        const isRuleDocMdx = isMdx(pathToDoc);
-        let newRuleDocContents = [
-          ruleDocSectionInclude.length > 0
-            ? ruleDocSectionInclude
-                .map((title) => `## ${title}`)
-                .join(`${endOfLine}${endOfLine}`)
-            : undefined,
-          /* istanbul ignore next -- both branches tested but coverage has instrumentation issue with ternary in array */
-          ruleHasOptions
-            ? `## Options${endOfLine}${endOfLine}${formatComment(BEGIN_RULE_OPTIONS_LIST_MARKER, isRuleDocMdx)}${endOfLine}${formatComment(END_RULE_OPTIONS_LIST_MARKER, isRuleDocMdx)}`
-            : undefined,
-        ]
-          .filter((section) => section !== undefined)
-          .join(`${endOfLine}${endOfLine}`);
-        /* istanbul ignore next -- V8 branch coverage doesn't detect this branch is tested */
-        if (newRuleDocContents !== '') {
-          newRuleDocContents = `${endOfLine}${newRuleDocContents}${endOfLine}`;
-        }
-
-        await mkdir(dirname(pathToDoc), { recursive: true });
-        await writeFile(pathToDoc, newRuleDocContents);
-        initializedRuleDoc = true;
+    if (!pathToDoc) {
+      if (!initRuleDocs) {
+        throw new Error(
+          `Could not find rule doc (run with --init-rule-docs to create): ${relative(
+            getPluginRoot(path),
+            configuredPathToDoc,
+          )}`,
+        );
       }
+
+      pathToDoc = configuredPathToDoc;
+
+      // Determine content for fresh rule doc, including any mandatory sections.
+      // The rule doc header will be added later.
+      const isRuleDocMdx = isMdx(pathToDoc);
+      let newRuleDocContents = [
+        ruleDocSectionInclude.length > 0
+          ? ruleDocSectionInclude
+              .map((title) => `## ${title}`)
+              .join(`${endOfLine}${endOfLine}`)
+          : undefined,
+        /* istanbul ignore next -- both branches tested but coverage has instrumentation issue with ternary in array */
+        ruleHasOptions
+          ? `## Options${endOfLine}${endOfLine}${formatComment(BEGIN_RULE_OPTIONS_LIST_MARKER, isRuleDocMdx)}${endOfLine}${formatComment(END_RULE_OPTIONS_LIST_MARKER, isRuleDocMdx)}`
+          : undefined,
+      ]
+        .filter((section) => section !== undefined)
+        .join(`${endOfLine}${endOfLine}`);
+      /* istanbul ignore next -- V8 branch coverage doesn't detect this branch is tested */
+      if (newRuleDocContents !== '') {
+        newRuleDocContents = `${endOfLine}${newRuleDocContents}${endOfLine}`;
+      }
+
+      await mkdir(dirname(pathToDoc), { recursive: true });
+      await writeFile(pathToDoc, newRuleDocContents);
+      initializedRuleDoc = true;
     }
 
     const isRuleDocMdx = isMdx(pathToDoc);

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -40,7 +40,7 @@ function resolveDocPath(configuredPath: string): string | undefined {
 
   // If the configured path ends in .md, see if an .mdx version exists
   if (configuredPath.endsWith('.md')) {
-    const mdxPath = configuredPath.replace(/\.md$/i, '.mdx');
+    const mdxPath = configuredPath.replace(/\.md$/iu, '.mdx');
     if (existsSync(mdxPath)) {
       return mdxPath;
     }
@@ -48,7 +48,7 @@ function resolveDocPath(configuredPath: string): string | undefined {
 
   // If the configured path ends in .mdx, see if an .md version exists
   if (configuredPath.endsWith('.mdx')) {
-    const mdPath = configuredPath.replace(/\.mdx$/i, '.md');
+    const mdPath = configuredPath.replace(/\.mdx$/iu, '.md');
     if (existsSync(mdPath)) {
       return mdPath;
     }

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -10,8 +10,8 @@ import { updateConfigsList } from './config-list.js';
 import { generateRuleHeaderLines } from './rule-doc-notices.js';
 import {
   BEGIN_RULE_OPTIONS_LIST_MARKER,
-  END_RULE_HEADER_MARKER,
   END_RULE_OPTIONS_LIST_MARKER,
+  formatComment,
 } from './comment-markers.js';
 import {
   extractFrontmatter,
@@ -28,6 +28,10 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { getContext } from './context.js';
 import { generateSuggestedEmojis } from './suggest-emojis.js';
 import { generateFrontmatterLines } from './frontmatter.js';
+
+function isMdx(path: string): boolean {
+  return path.toLowerCase().endsWith('.mdx');
+}
 
 // eslint-disable-next-line complexity
 export async function generate(path: string, userOptions?: GenerateOptions) {
@@ -92,50 +96,63 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     const metaDefaultOptions = rule.meta?.defaultOptions;
     const description = rule.meta?.docs?.description;
     const pathCurrentPage = replaceRulePlaceholder(pathRuleDoc, name);
-    const pathToDoc = join(path, pathCurrentPage);
+    let pathToDoc = join(path, pathCurrentPage);
     const ruleHasOptions = hasOptions(schema);
 
     if (!existsSync(pathToDoc)) {
-      if (!initRuleDocs) {
-        throw new Error(
-          `Could not find rule doc (run with --init-rule-docs to create): ${relative(
-            getPluginRoot(path),
-            pathToDoc,
-          )}`,
-        );
-      }
+      // Check if an `mdx` file exists with the same name, in case the rule doc was created with an `mdx` extension for starlight compatibility.
+      const pathToDocMdx = pathToDoc.replace(/\.md$/iu, '.mdx');
+      if (existsSync(pathToDocMdx)) {
+        pathToDoc = pathToDocMdx;
+      } else {
+        if (!initRuleDocs) {
+          throw new Error(
+            `Could not find rule doc (run with --init-rule-docs to create): ${relative(
+              getPluginRoot(path),
+              pathToDoc,
+            )}`,
+          );
+        }
 
-      // Determine content for fresh rule doc, including any mandatory sections.
-      // The rule doc header will be added later.
-      let newRuleDocContents = [
-        ruleDocSectionInclude.length > 0
-          ? ruleDocSectionInclude
-              .map((title) => `## ${title}`)
-              .join(`${endOfLine}${endOfLine}`)
-          : undefined,
-        /* istanbul ignore next -- both branches tested but coverage has instrumentation issue with ternary in array */
-        ruleHasOptions
-          ? `## Options${endOfLine}${endOfLine}${BEGIN_RULE_OPTIONS_LIST_MARKER}${endOfLine}${END_RULE_OPTIONS_LIST_MARKER}`
-          : undefined,
-      ]
-        .filter((section) => section !== undefined)
-        .join(`${endOfLine}${endOfLine}`);
-      /* istanbul ignore next -- V8 branch coverage doesn't detect this branch is tested */
-      if (newRuleDocContents !== '') {
-        newRuleDocContents = `${endOfLine}${newRuleDocContents}${endOfLine}`;
-      }
+        // Determine content for fresh rule doc, including any mandatory sections.
+        // The rule doc header will be added later.
+        const isRuleDocMdx = isMdx(pathToDoc);
+        let newRuleDocContents = [
+          ruleDocSectionInclude.length > 0
+            ? ruleDocSectionInclude
+                .map((title) => `## ${title}`)
+                .join(`${endOfLine}${endOfLine}`)
+            : undefined,
+          /* istanbul ignore next -- both branches tested but coverage has instrumentation issue with ternary in array */
+          ruleHasOptions
+            ? `## Options${endOfLine}${endOfLine}${formatComment(BEGIN_RULE_OPTIONS_LIST_MARKER, isRuleDocMdx)}${endOfLine}${formatComment(END_RULE_OPTIONS_LIST_MARKER, isRuleDocMdx)}`
+            : undefined,
+        ]
+          .filter((section) => section !== undefined)
+          .join(`${endOfLine}${endOfLine}`);
+        /* istanbul ignore next -- V8 branch coverage doesn't detect this branch is tested */
+        if (newRuleDocContents !== '') {
+          newRuleDocContents = `${endOfLine}${newRuleDocContents}${endOfLine}`;
+        }
 
-      await mkdir(dirname(pathToDoc), { recursive: true });
-      await writeFile(pathToDoc, newRuleDocContents);
-      initializedRuleDoc = true;
+        await mkdir(dirname(pathToDoc), { recursive: true });
+        await writeFile(pathToDoc, newRuleDocContents);
+        initializedRuleDoc = true;
+      }
     }
 
+    const isRuleDocMdx = isMdx(pathToDoc);
     const contentsOldBuffer = await readFile(pathToDoc);
     const contentsOld = contentsOldBuffer.toString();
     const frontmatterOld = extractFrontmatter(context, contentsOld);
 
     // Regenerate the header (title/notices) and frontmatter of each rule doc.
-    const newHeaderLines = generateRuleHeaderLines(context, description, name);
+    const newHeaderLines = generateRuleHeaderLines(
+      context,
+      description,
+      name,
+      isRuleDocMdx,
+    );
     const newFrontmatterLines = generateFrontmatterLines(
       context,
       name,
@@ -153,9 +170,14 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
       context,
       contentsNew,
       newHeaderLines,
-      END_RULE_HEADER_MARKER,
+      isRuleDocMdx,
     );
-    contentsNew = updateRuleOptionsList(context, contentsNew, rule);
+    contentsNew = updateRuleOptionsList(
+      context,
+      contentsNew,
+      rule,
+      isRuleDocMdx,
+    );
     contentsNew = await postprocess(contentsNew, resolve(pathToDoc));
 
     if (check) {
@@ -239,6 +261,8 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
       );
     }
 
+    const isRuleListMdx = isMdx(pathToFile);
+
     // Update the rules list in this file.
     const fileContents = await readFile(pathToFile, 'utf8');
     const rulesList = updateRulesList(
@@ -248,7 +272,7 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
       pathToFile,
     );
     const fileContentsNew = await postprocess(
-      updateConfigsList(context, rulesList),
+      updateConfigsList(context, rulesList, isRuleListMdx),
       resolve(pathToFile),
     );
 

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -1,5 +1,6 @@
 // General helpers for dealing with markdown files / content.
 
+import { END_RULE_HEADER_MARKER, formatComment } from './comment-markers.js';
 import type { Context } from './context.js';
 
 export function extractFrontmatter(context: Context, markdown: string) {
@@ -56,20 +57,22 @@ export function replaceOrCreateFrontmatter(
  * @param context - execution context
  * @param markdown - doc content
  * @param newHeader - new header including marker
- * @param marker - marker to indicate end of header
+ * @param isMdx - is the file we're working on mdx or just regular md
  */
 export function replaceOrCreateHeader(
   context: Context,
   markdown: string,
   newHeader: string,
-  marker: string,
+  isMdx: boolean,
 ) {
   const { endOfLine } = context;
 
   const lines = markdown.split(endOfLine);
 
   const titleLineIndex = lines.findIndex((line) => line.startsWith('# '));
-  const markerLineIndex = lines.indexOf(marker);
+  const markerLineIndex = lines.indexOf(
+    formatComment(END_RULE_HEADER_MARKER, isMdx),
+  );
   const dashesLineIndex1 = lines.indexOf('---');
   const dashesLineIndex2 = lines.indexOf('---', dashesLineIndex1 + 1);
 

--- a/lib/rule-doc-notices.ts
+++ b/lib/rule-doc-notices.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { END_RULE_HEADER_MARKER } from './comment-markers.js';
+import { END_RULE_HEADER_MARKER, formatComment } from './comment-markers.js';
 import {
   EMOJI_DEPRECATED,
   EMOJI_DESCRIPTION,
@@ -478,6 +478,7 @@ export function generateRuleHeaderLines(
   context: Context,
   description: string | undefined,
   name: string,
+  isMdx: boolean,
 ): string {
   const {
     endOfLine,
@@ -490,6 +491,6 @@ export function generateRuleHeaderLines(
     ...(framework === 'starlight' ? [] : [`# ${title}`]),
     ...getRuleNoticeLines(context, name),
     '',
-    END_RULE_HEADER_MARKER,
+    formatComment(END_RULE_HEADER_MARKER, isMdx),
   ].join(endOfLine);
 }

--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -1,6 +1,7 @@
 import {
   BEGIN_RULE_LIST_MARKER,
   END_RULE_LIST_MARKER,
+  formatComment,
 } from './comment-markers.js';
 import {
   EMOJI_DEPRECATED,
@@ -307,8 +308,15 @@ export function updateRulesList(
   const { endOfLine, path, options } = context;
   const { ruleListSplit } = options;
 
-  let listStartIndex = markdown.indexOf(BEGIN_RULE_LIST_MARKER);
-  let listEndIndex = markdown.indexOf(END_RULE_LIST_MARKER);
+  const isMdx = pathToFile.endsWith('.mdx');
+  const formattedRuleListMarkerBegin = formatComment(
+    BEGIN_RULE_LIST_MARKER,
+    isMdx,
+  );
+  const formattedRuleListMarkerEnd = formatComment(END_RULE_LIST_MARKER, isMdx);
+
+  let listStartIndex = markdown.indexOf(formattedRuleListMarkerBegin);
+  let listEndIndex = markdown.indexOf(formattedRuleListMarkerEnd);
 
   // Find the best possible section to insert the rules list into if the markers are missing.
   const rulesSectionHeader = findSectionHeader(context, markdown, 'rules');
@@ -327,7 +335,7 @@ export function updateRulesList(
     listEndIndex = rulesSectionIndex + rulesSectionHeader.length - 1;
   } else {
     // Account for length of pre-existing marker.
-    listEndIndex += END_RULE_LIST_MARKER.length;
+    listEndIndex += formattedRuleListMarkerEnd.length;
   }
 
   if (listStartIndex === -1 || listEndIndex === -1) {
@@ -335,7 +343,7 @@ export function updateRulesList(
       `${relative(
         getPluginRoot(path),
         pathToFile,
-      )} is missing rules list markers: ${BEGIN_RULE_LIST_MARKER}${END_RULE_LIST_MARKER}`,
+      )} is missing rules list markers: ${formattedRuleListMarkerBegin}${formattedRuleListMarkerEnd}`,
     );
   }
 
@@ -424,5 +432,5 @@ export function updateRulesList(
 
   const newContent = `${legend ? `${legend}${endOfLine}${endOfLine}` : ''}${list}`;
 
-  return `${preList}${BEGIN_RULE_LIST_MARKER}${endOfLine}${endOfLine}${newContent}${endOfLine}${endOfLine}${END_RULE_LIST_MARKER}${postList}`;
+  return `${preList}${formattedRuleListMarkerBegin}${endOfLine}${endOfLine}${newContent}${endOfLine}${endOfLine}${formattedRuleListMarkerEnd}${postList}`;
 }

--- a/lib/rule-options-list.ts
+++ b/lib/rule-options-list.ts
@@ -1,6 +1,7 @@
 import {
   BEGIN_RULE_OPTIONS_LIST_MARKER,
   END_RULE_OPTIONS_LIST_MARKER,
+  formatComment,
 } from './comment-markers.js';
 import { markdownTable } from 'markdown-table';
 import type { RuleModule } from './types.js';
@@ -153,11 +154,21 @@ export function updateRuleOptionsList(
   context: Context,
   markdown: string,
   rule: RuleModule,
+  isMdx: boolean,
 ): string {
   const { endOfLine } = context;
 
-  const listStartIndex = markdown.indexOf(BEGIN_RULE_OPTIONS_LIST_MARKER);
-  let listEndIndex = markdown.indexOf(END_RULE_OPTIONS_LIST_MARKER);
+  const formattedRuleOptionsListMarkerBegin = formatComment(
+    BEGIN_RULE_OPTIONS_LIST_MARKER,
+    isMdx,
+  );
+  const formattedRuleOptionsListMarkerEnd = formatComment(
+    END_RULE_OPTIONS_LIST_MARKER,
+    isMdx,
+  );
+
+  const listStartIndex = markdown.indexOf(formattedRuleOptionsListMarkerBegin);
+  let listEndIndex = markdown.indexOf(formattedRuleOptionsListMarkerEnd);
 
   if (listStartIndex === -1 || listEndIndex === -1) {
     // No rule options list found.
@@ -165,7 +176,7 @@ export function updateRuleOptionsList(
   }
 
   // Account for length of pre-existing marker.
-  listEndIndex += END_RULE_OPTIONS_LIST_MARKER.length;
+  listEndIndex += formattedRuleOptionsListMarkerEnd.length;
 
   const preList = markdown.slice(0, Math.max(0, listStartIndex));
   const postList = markdown.slice(Math.max(0, listEndIndex));
@@ -173,5 +184,5 @@ export function updateRuleOptionsList(
   // New rule options list.
   const list = generateRuleOptionsListMarkdown(context, rule);
 
-  return `${preList}${BEGIN_RULE_OPTIONS_LIST_MARKER}${endOfLine}${endOfLine}${list}${endOfLine}${endOfLine}${END_RULE_OPTIONS_LIST_MARKER}${postList}`;
+  return `${preList}${formattedRuleOptionsListMarkerBegin}${endOfLine}${endOfLine}${list}${endOfLine}${endOfLine}${formattedRuleOptionsListMarkerEnd}${postList}`;
 }

--- a/test/fixtures/esm-base-mdx/README.md
+++ b/test/fixtures/esm-base-mdx/README.md
@@ -1,0 +1,6 @@
+# eslint-plugin-test
+
+## Rules
+
+<!-- begin auto-generated rules list -->
+<!-- end auto-generated rules list -->

--- a/test/fixtures/esm-base-mdx/index.js
+++ b/test/fixtures/esm-base-mdx/index.js
@@ -1,0 +1,11 @@
+export default {
+  rules: {
+    'no-foo': {
+      meta: {
+        docs: { description: 'Description of no-foo.' },
+      },
+      create(context) {},
+    },
+  },
+};
+

--- a/test/fixtures/esm-base-mdx/package.json
+++ b/test/fixtures/esm-base-mdx/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "eslint-plugin-test",
+  "exports": "index.js",
+  "type": "module"
+}
+

--- a/test/lib/generate/__snapshots__/configs-list-test.ts.snap
+++ b/test/lib/generate/__snapshots__/configs-list-test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`generate (configs list) > basic > generates the documentation 1`] = `
+exports[`generate (configs list) > for md files > basic > generates the documentation 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->
 
@@ -19,7 +19,7 @@ exports[`generate (configs list) > basic > generates the documentation 1`] = `
 <!-- end auto-generated configs list -->"
 `;
 
-exports[`generate (configs list) > when a config description needs to be escaped in table > generates the documentation 1`] = `
+exports[`generate (configs list) > for md files > when a config description needs to be escaped in table > generates the documentation 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->
 
@@ -38,7 +38,7 @@ exports[`generate (configs list) > when a config description needs to be escaped
 <!-- end auto-generated configs list -->"
 `;
 
-exports[`generate (configs list) > when a config exports a description > property=description > generates the documentation 1`] = `
+exports[`generate (configs list) > for md files > when a config exports a description > property=description > generates the documentation 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->
 
@@ -58,7 +58,7 @@ exports[`generate (configs list) > when a config exports a description > propert
 <!-- end auto-generated configs list -->"
 `;
 
-exports[`generate (configs list) > when a config exports a description > property=meta.description > generates the documentation 1`] = `
+exports[`generate (configs list) > for md files > when a config exports a description > property=meta.description > generates the documentation 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->
 
@@ -78,7 +78,7 @@ exports[`generate (configs list) > when a config exports a description > propert
 <!-- end auto-generated configs list -->"
 `;
 
-exports[`generate (configs list) > when a config exports a description > property=meta.docs.description > generates the documentation 1`] = `
+exports[`generate (configs list) > for md files > when a config exports a description > property=meta.docs.description > generates the documentation 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->
 
@@ -98,7 +98,7 @@ exports[`generate (configs list) > when a config exports a description > propert
 <!-- end auto-generated configs list -->"
 `;
 
-exports[`generate (configs list) > when all configs are ignored > generates the documentation 1`] = `
+exports[`generate (configs list) > for md files > when all configs are ignored > generates the documentation 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->
 
@@ -112,7 +112,7 @@ exports[`generate (configs list) > when all configs are ignored > generates the 
 <!-- end auto-generated configs list -->"
 `;
 
-exports[`generate (configs list) > when there are no configs > generates the documentation 1`] = `
+exports[`generate (configs list) > for md files > when there are no configs > generates the documentation 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->
 
@@ -126,7 +126,7 @@ exports[`generate (configs list) > when there are no configs > generates the doc
 <!-- end auto-generated configs list -->"
 `;
 
-exports[`generate (configs list) > with --config-format > generates the documentation 1`] = `
+exports[`generate (configs list) > for md files > with --config-format > generates the documentation 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->
 
@@ -145,7 +145,7 @@ exports[`generate (configs list) > with --config-format > generates the document
 <!-- end auto-generated configs list -->"
 `;
 
-exports[`generate (configs list) > with --ignore-config > generates the documentation 1`] = `
+exports[`generate (configs list) > for md files > with --ignore-config > generates the documentation 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->
 
@@ -164,7 +164,7 @@ exports[`generate (configs list) > with --ignore-config > generates the document
 <!-- end auto-generated configs list -->"
 `;
 
-exports[`generate (configs list) > with configs not defined in alphabetical order > generates the documentation 1`] = `
+exports[`generate (configs list) > for md files > with configs not defined in alphabetical order > generates the documentation 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->
 
@@ -182,4 +182,188 @@ exports[`generate (configs list) > with configs not defined in alphabetical orde
 | ✅  | \`recommended\` |
 
 <!-- end auto-generated configs list -->"
+`;
+
+exports[`generate (configs list) > for mdx files > basic > generates the documentation 1`] = `
+"## Rules
+{/* begin auto-generated rules list */}
+
+| Name                       | Description            |
+| :------------------------- | :--------------------- |
+| [no-foo](rules/no-foo.mdx) | Description of no-foo. |
+
+{/* end auto-generated rules list */}
+## Configs
+{/* begin auto-generated configs list */}
+
+|    | Name          |
+| :- | :------------ |
+| ✅  | \`recommended\` |
+
+{/* end auto-generated configs list */}"
+`;
+
+exports[`generate (configs list) > for mdx files > when a config description needs to be escaped in table > generates the documentation 1`] = `
+"## Rules
+{/* begin auto-generated rules list */}
+
+| Name                       | Description         |
+| :------------------------- | :------------------ |
+| [no-foo](rules/no-foo.mdx) | Description no-foo. |
+
+{/* end auto-generated rules list */}
+## Configs
+{/* begin auto-generated configs list */}
+
+|    | Name          | Description |
+| :- | :------------ | :---------- |
+| ✅  | \`recommended\` | Foo\\|Bar    |
+
+{/* end auto-generated configs list */}"
+`;
+
+exports[`generate (configs list) > for mdx files > when a config exports a description > property=description > generates the documentation 1`] = `
+"## Rules
+{/* begin auto-generated rules list */}
+
+| Name                       | Description            |
+| :------------------------- | :--------------------- |
+| [no-foo](rules/no-foo.mdx) | Description of no-foo. |
+
+{/* end auto-generated rules list */}
+## Configs
+{/* begin auto-generated configs list */}
+
+|    | Name          | Description                              |
+| :- | :------------ | :--------------------------------------- |
+|    | \`foo\`         |                                          |
+| ✅  | \`recommended\` | This config has the recommended rules... |
+
+{/* end auto-generated configs list */}"
+`;
+
+exports[`generate (configs list) > for mdx files > when a config exports a description > property=meta.description > generates the documentation 1`] = `
+"## Rules
+{/* begin auto-generated rules list */}
+
+| Name                       | Description            |
+| :------------------------- | :--------------------- |
+| [no-foo](rules/no-foo.mdx) | Description of no-foo. |
+
+{/* end auto-generated rules list */}
+## Configs
+{/* begin auto-generated configs list */}
+
+|    | Name          | Description                              |
+| :- | :------------ | :--------------------------------------- |
+|    | \`foo\`         |                                          |
+| ✅  | \`recommended\` | This config has the recommended rules... |
+
+{/* end auto-generated configs list */}"
+`;
+
+exports[`generate (configs list) > for mdx files > when a config exports a description > property=meta.docs.description > generates the documentation 1`] = `
+"## Rules
+{/* begin auto-generated rules list */}
+
+| Name                       | Description            |
+| :------------------------- | :--------------------- |
+| [no-foo](rules/no-foo.mdx) | Description of no-foo. |
+
+{/* end auto-generated rules list */}
+## Configs
+{/* begin auto-generated configs list */}
+
+|    | Name          | Description                              |
+| :- | :------------ | :--------------------------------------- |
+|    | \`foo\`         |                                          |
+| ✅  | \`recommended\` | This config has the recommended rules... |
+
+{/* end auto-generated configs list */}"
+`;
+
+exports[`generate (configs list) > for mdx files > when all configs are ignored > generates the documentation 1`] = `
+"## Rules
+{/* begin auto-generated rules list */}
+
+| Name                       | Description            |
+| :------------------------- | :--------------------- |
+| [no-foo](rules/no-foo.mdx) | Description of no-foo. |
+
+{/* end auto-generated rules list */}
+## Configs
+{/* begin auto-generated configs list */}
+{/* end auto-generated configs list */}"
+`;
+
+exports[`generate (configs list) > for mdx files > when there are no configs > generates the documentation 1`] = `
+"## Rules
+{/* begin auto-generated rules list */}
+
+| Name                       | Description            |
+| :------------------------- | :--------------------- |
+| [no-foo](rules/no-foo.mdx) | Description of no-foo. |
+
+{/* end auto-generated rules list */}
+## Configs
+{/* begin auto-generated configs list */}
+{/* end auto-generated configs list */}"
+`;
+
+exports[`generate (configs list) > for mdx files > with --config-format > generates the documentation 1`] = `
+"## Rules
+{/* begin auto-generated rules list */}
+
+| Name                       | Description            |
+| :------------------------- | :--------------------- |
+| [no-foo](rules/no-foo.mdx) | Description of no-foo. |
+
+{/* end auto-generated rules list */}
+## Configs
+{/* begin auto-generated configs list */}
+
+|    | Name               |
+| :- | :----------------- |
+| ✅  | \`test/recommended\` |
+
+{/* end auto-generated configs list */}"
+`;
+
+exports[`generate (configs list) > for mdx files > with --ignore-config > generates the documentation 1`] = `
+"## Rules
+{/* begin auto-generated rules list */}
+
+| Name                       | Description            |
+| :------------------------- | :--------------------- |
+| [no-foo](rules/no-foo.mdx) | Description of no-foo. |
+
+{/* end auto-generated rules list */}
+## Configs
+{/* begin auto-generated configs list */}
+
+|    | Name          |
+| :- | :------------ |
+| ✅  | \`recommended\` |
+
+{/* end auto-generated configs list */}"
+`;
+
+exports[`generate (configs list) > for mdx files > with configs not defined in alphabetical order > generates the documentation 1`] = `
+"## Rules
+{/* begin auto-generated rules list */}
+
+| Name                       | Description            |
+| :------------------------- | :--------------------- |
+| [no-foo](rules/no-foo.mdx) | Description of no-foo. |
+
+{/* end auto-generated rules list */}
+## Configs
+{/* begin auto-generated configs list */}
+
+|    | Name          |
+| :- | :------------ |
+|    | \`foo\`         |
+| ✅  | \`recommended\` |
+
+{/* end auto-generated configs list */}"
 `;

--- a/test/lib/generate/__snapshots__/option-rule-doc-notices-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-rule-doc-notices-test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`generate (--rule-doc-notices) > basic > shows description before other notices when using default notice ordering 1`] = `
+exports[`generate (--rule-doc-notices) > for md files > basic > shows description before other notices when using default notice ordering 1`] = `
 "# test/no-foo
 
 📝 Description for no-foo.
@@ -13,7 +13,7 @@ exports[`generate (--rule-doc-notices) > basic > shows description before other 
 "
 `;
 
-exports[`generate (--rule-doc-notices) > basic > shows the right rule doc notices 1`] = `
+exports[`generate (--rule-doc-notices) > for md files > basic > shows the right rule doc notices 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->
 
@@ -29,7 +29,7 @@ exports[`generate (--rule-doc-notices) > basic > shows the right rule doc notice
 "
 `;
 
-exports[`generate (--rule-doc-notices) > basic > shows the right rule doc notices 2`] = `
+exports[`generate (--rule-doc-notices) > for md files > basic > shows the right rule doc notices 2`] = `
 "# test/no-foo
 
 💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
@@ -46,11 +46,50 @@ exports[`generate (--rule-doc-notices) > basic > shows the right rule doc notice
 "
 `;
 
-exports[`generate (--rule-doc-notices) > hasSuggestions only (without fixable) using fixableAndHasSuggestions notice > shows only hasSuggestions notice 1`] = `
+exports[`generate (--rule-doc-notices) > for md files > hasSuggestions only (without fixable) using fixableAndHasSuggestions notice > shows only hasSuggestions notice 1`] = `
 "# test/no-foo
 
 💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
 
 <!-- end auto-generated rule header -->
+"
+`;
+
+exports[`generate (--rule-doc-notices) > for mdx files > basic > shows description before other notices when using default notice ordering 1`] = `
+"# test/no-foo
+
+📝 Description for no-foo.
+
+❌ This rule is deprecated.
+
+🔧💡 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) and manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
+
+{/* end auto-generated rule header */}
+"
+`;
+
+exports[`generate (--rule-doc-notices) > for mdx files > basic > shows the right rule doc notices 1`] = `
+"# test/no-foo
+
+💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
+
+🔧 This rule is automatically fixable by the [\`--fix\` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+❌ This rule is deprecated.
+
+📝 Description for no-foo.
+
+❗ This rule identifies problems that could cause errors or unexpected behavior.
+
+{/* end auto-generated rule header */}
+"
+`;
+
+exports[`generate (--rule-doc-notices) > for mdx files > hasSuggestions only (without fixable) using fixableAndHasSuggestions notice > shows only hasSuggestions notice 1`] = `
+"# test/no-foo
+
+💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
+
+{/* end auto-generated rule header */}
 "
 `;

--- a/test/lib/generate/__snapshots__/rule-options-list-test.ts.snap
+++ b/test/lib/generate/__snapshots__/rule-options-list-test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`generate (rule options list) > basic > generates the documentation 1`] = `
+exports[`generate (rule options list) > for md files > basic > generates the documentation 1`] = `
 "# test/no-foo
 
 <!-- end auto-generated rule header -->
@@ -24,7 +24,7 @@ exports[`generate (rule options list) > basic > generates the documentation 1`] 
 <!-- end auto-generated rule options list -->"
 `;
 
-exports[`generate (rule options list) > displays default column even when only falsy value, hiding deprecated/required cols with only falsy value > generates the documentation 1`] = `
+exports[`generate (rule options list) > for md files > displays default column even when only falsy value, hiding deprecated/required cols with only falsy value > generates the documentation 1`] = `
 "# test/no-foo
 
 <!-- end auto-generated rule header -->
@@ -38,7 +38,7 @@ exports[`generate (rule options list) > displays default column even when only f
 <!-- end auto-generated rule options list -->"
 `;
 
-exports[`generate (rule options list) > with no marker comments > generates the documentation 1`] = `
+exports[`generate (rule options list) > for md files > with no marker comments > generates the documentation 1`] = `
 "# test/no-foo
 
 <!-- end auto-generated rule header -->
@@ -46,7 +46,7 @@ exports[`generate (rule options list) > with no marker comments > generates the 
 foo"
 `;
 
-exports[`generate (rule options list) > with no options > generates the documentation 1`] = `
+exports[`generate (rule options list) > for md files > with no options > generates the documentation 1`] = `
 "# test/no-foo
 
 <!-- end auto-generated rule header -->
@@ -58,7 +58,7 @@ exports[`generate (rule options list) > with no options > generates the document
 <!-- end auto-generated rule options list -->"
 `;
 
-exports[`generate (rule options list) > with string that needs to be escaped in table > generates the documentation 1`] = `
+exports[`generate (rule options list) > for md files > with string that needs to be escaped in table > generates the documentation 1`] = `
 "# test/no-foo
 
 <!-- end auto-generated rule header -->
@@ -70,4 +70,76 @@ exports[`generate (rule options list) > with string that needs to be escaped in 
 | \`foo\` | test<br/>                  desc | String\\|number |
 
 <!-- end auto-generated rule options list -->"
+`;
+
+exports[`generate (rule options list) > for mdx files > basic > generates the documentation 1`] = `
+"# test/no-foo
+
+{/* end auto-generated rule header */}
+## Options
+{/* begin auto-generated rule options list */}
+
+| Name                       | Description                   | Type                | Choices           | Default                                | Required | Deprecated |
+| :------------------------- | :---------------------------- | :------------------ | :---------------- | :------------------------------------- | :------- | :--------- |
+| \`arr1\`                     |                               | Array               |                   |                                        |          |            |
+| \`arrWithArrType\`           |                               | String, Boolean     |                   |                                        |          |            |
+| \`arrWithArrTypeSingleItem\` |                               | String              |                   |                                        |          |            |
+| \`arrWithDefault\`           |                               | Array               |                   | [\`hello world\`, \`1\`, \`2\`, \`3\`, \`true\`] |          |            |
+| \`arrWithDefaultEmpty\`      |                               | Array               |                   | \`[]\`                                   |          |            |
+| \`arrWithItemsArrayType\`    |                               | (String, Boolean)[] |                   |                                        |          |            |
+| \`arrWithItemsType\`         |                               | String[]            |                   |                                        |          |            |
+| \`bar\`                      | Choose how to use the rule.   | String              | \`always\`, \`never\` | \`always\`                               | Yes      |            |
+| \`baz\`                      |                               |                     |                   | \`true\`                                 | Yes      |            |
+| \`biz\`                      |                               |                     |                   |                                        |          |            |
+| \`foo\`                      | Enable some kind of behavior. | Boolean             |                   | \`false\`                                |          | Yes        |
+
+{/* end auto-generated rule options list */}"
+`;
+
+exports[`generate (rule options list) > for mdx files > displays default column even when only falsy value, hiding deprecated/required cols with only falsy value > generates the documentation 1`] = `
+"# test/no-foo
+
+{/* end auto-generated rule header */}
+## Options
+{/* begin auto-generated rule options list */}
+
+| Name  | Default |
+| :---- | :------ |
+| \`foo\` | \`false\` |
+
+{/* end auto-generated rule options list */}"
+`;
+
+exports[`generate (rule options list) > for mdx files > with no marker comments > generates the documentation 1`] = `
+"# test/no-foo
+
+{/* end auto-generated rule header */}
+## Options
+foo"
+`;
+
+exports[`generate (rule options list) > for mdx files > with no options > generates the documentation 1`] = `
+"# test/no-foo
+
+{/* end auto-generated rule header */}
+
+{/* begin auto-generated rule options list */}
+
+
+
+{/* end auto-generated rule options list */}"
+`;
+
+exports[`generate (rule options list) > for mdx files > with string that needs to be escaped in table > generates the documentation 1`] = `
+"# test/no-foo
+
+{/* end auto-generated rule header */}
+## Options
+{/* begin auto-generated rule options list */}
+
+| Name  | Description                     | Type           |
+| :---- | :------------------------------ | :------------- |
+| \`foo\` | test<br/>                  desc | String\\|number |
+
+{/* end auto-generated rule options list */}"
 `;

--- a/test/lib/generate/configs-list-test.ts
+++ b/test/lib/generate/configs-list-test.ts
@@ -1,163 +1,10 @@
 import { generate } from '../../../lib/generator.js';
+import type { GenerateOptions } from '../../../lib/types.js';
 import { setupFixture, type FixtureContext } from '../../helpers/fixture.js';
 
 describe('generate (configs list)', function () {
-  describe('basic', function () {
-    let fixture: FixtureContext;
-
-    beforeAll(async function () {
-      fixture = await setupFixture({
-        fixture: 'esm-base',
-        overrides: {
-          'index.js': `
-          export default {
-            rules: {
-              'no-foo': {
-                meta: { docs: { description: 'Description of no-foo.' }, },
-                create(context) {}
-              },
-            },
-            configs: {
-              recommended: {},
-            }
-          };`,
-          'README.md': `## Rules
-## Configs
-<!-- begin auto-generated configs list -->
-<!-- end auto-generated configs list -->`,
-          'docs/rules/no-foo.md': '',
-        },
-      });
-    });
-
-    afterAll(async function () {
-      await fixture.cleanup();
-    });
-
-    it('generates the documentation', async function () {
-      await generate(fixture.path);
-      expect(await fixture.readFile('README.md')).toMatchSnapshot();
-    });
-  });
-
-  describe('with --ignore-config', function () {
-    let fixture: FixtureContext;
-
-    beforeAll(async function () {
-      fixture = await setupFixture({
-        fixture: 'esm-base',
-        overrides: {
-          'index.js': `
-          export default {
-            rules: {
-              'no-foo': {
-                meta: { docs: { description: 'Description of no-foo.' }, },
-                create(context) {}
-              },
-            },
-            configs: {
-              foo: {},
-              recommended: {},
-            }
-          };`,
-          'README.md': `## Rules
-## Configs
-<!-- begin auto-generated configs list -->
-<!-- end auto-generated configs list -->`,
-          'docs/rules/no-foo.md': '',
-        },
-      });
-    });
-
-    afterAll(async function () {
-      await fixture.cleanup();
-    });
-
-    it('generates the documentation', async function () {
-      await generate(fixture.path, { ignoreConfig: ['foo'] });
-      expect(await fixture.readFile('README.md')).toMatchSnapshot();
-    });
-  });
-
-  describe('with --config-format', function () {
-    let fixture: FixtureContext;
-
-    beforeAll(async function () {
-      fixture = await setupFixture({
-        fixture: 'esm-base',
-        overrides: {
-          'index.js': `
-          export default {
-            rules: {
-              'no-foo': {
-                meta: { docs: { description: 'Description of no-foo.' }, },
-                create(context) {}
-              },
-            },
-            configs: {
-              recommended: {},
-            }
-          };`,
-          'README.md': `## Rules
-## Configs
-<!-- begin auto-generated configs list -->
-<!-- end auto-generated configs list -->`,
-          'docs/rules/no-foo.md': '',
-        },
-      });
-    });
-
-    afterAll(async function () {
-      await fixture.cleanup();
-    });
-
-    it('generates the documentation', async function () {
-      await generate(fixture.path, { configFormat: 'prefix-name' });
-      expect(await fixture.readFile('README.md')).toMatchSnapshot();
-    });
-  });
-
-  describe('with configs not defined in alphabetical order', function () {
-    let fixture: FixtureContext;
-
-    beforeAll(async function () {
-      fixture = await setupFixture({
-        fixture: 'esm-base',
-        overrides: {
-          'index.js': `
-          export default {
-            rules: {
-              'no-foo': {
-                meta: { docs: { description: 'Description of no-foo.' }, },
-                create(context) {}
-              },
-            },
-            configs: {
-              recommended: {},
-              foo: {},
-            }
-          };`,
-          'README.md': `## Rules
-## Configs
-<!-- begin auto-generated configs list -->
-<!-- end auto-generated configs list -->`,
-          'docs/rules/no-foo.md': '',
-        },
-      });
-    });
-
-    afterAll(async function () {
-      await fixture.cleanup();
-    });
-
-    it('generates the documentation', async function () {
-      await generate(fixture.path);
-      expect(await fixture.readFile('README.md')).toMatchSnapshot();
-    });
-  });
-
-  describe('when a config exports a description', function () {
-    describe('property=description', function () {
+  describe('for md files', () => {
+    describe('basic', function () {
       let fixture: FixtureContext;
 
       beforeAll(async function () {
@@ -165,6 +12,161 @@ describe('generate (configs list)', function () {
           fixture: 'esm-base',
           overrides: {
             'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: { docs: { description: 'Description of no-foo.' }, },
+                create(context) {}
+              },
+            },
+            configs: {
+              recommended: {},
+            }
+          };`,
+            'README.md': `## Rules
+## Configs
+<!-- begin auto-generated configs list -->
+<!-- end auto-generated configs list -->`,
+            'docs/rules/no-foo.md': '',
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('generates the documentation', async function () {
+        await generate(fixture.path);
+        expect(await fixture.readFile('README.md')).toMatchSnapshot();
+      });
+    });
+
+    describe('with --ignore-config', function () {
+      let fixture: FixtureContext;
+
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base',
+          overrides: {
+            'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: { docs: { description: 'Description of no-foo.' }, },
+                create(context) {}
+              },
+            },
+            configs: {
+              foo: {},
+              recommended: {},
+            }
+          };`,
+            'README.md': `## Rules
+## Configs
+<!-- begin auto-generated configs list -->
+<!-- end auto-generated configs list -->`,
+            'docs/rules/no-foo.md': '',
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('generates the documentation', async function () {
+        await generate(fixture.path, { ignoreConfig: ['foo'] });
+        expect(await fixture.readFile('README.md')).toMatchSnapshot();
+      });
+    });
+
+    describe('with --config-format', function () {
+      let fixture: FixtureContext;
+
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base',
+          overrides: {
+            'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: { docs: { description: 'Description of no-foo.' }, },
+                create(context) {}
+              },
+            },
+            configs: {
+              recommended: {},
+            }
+          };`,
+            'README.md': `## Rules
+## Configs
+<!-- begin auto-generated configs list -->
+<!-- end auto-generated configs list -->`,
+            'docs/rules/no-foo.md': '',
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('generates the documentation', async function () {
+        await generate(fixture.path, { configFormat: 'prefix-name' });
+        expect(await fixture.readFile('README.md')).toMatchSnapshot();
+      });
+    });
+
+    describe('with configs not defined in alphabetical order', function () {
+      let fixture: FixtureContext;
+
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base',
+          overrides: {
+            'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: { docs: { description: 'Description of no-foo.' }, },
+                create(context) {}
+              },
+            },
+            configs: {
+              recommended: {},
+              foo: {},
+            }
+          };`,
+            'README.md': `## Rules
+## Configs
+<!-- begin auto-generated configs list -->
+<!-- end auto-generated configs list -->`,
+            'docs/rules/no-foo.md': '',
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('generates the documentation', async function () {
+        await generate(fixture.path);
+        expect(await fixture.readFile('README.md')).toMatchSnapshot();
+      });
+    });
+
+    describe('when a config exports a description', function () {
+      describe('property=description', function () {
+        let fixture: FixtureContext;
+
+        beforeAll(async function () {
+          fixture = await setupFixture({
+            fixture: 'esm-base',
+            overrides: {
+              'index.js': `
             export default {
               rules: {
                 'no-foo': {
@@ -177,33 +179,33 @@ describe('generate (configs list)', function () {
                 recommended: { description: 'This config has the recommended rules...' },
               }
             };`,
-            'README.md': `## Rules
+              'README.md': `## Rules
   ## Configs
   <!-- begin auto-generated configs list -->
   <!-- end auto-generated configs list -->`,
-            'docs/rules/no-foo.md': '',
-          },
+              'docs/rules/no-foo.md': '',
+            },
+          });
+        });
+
+        afterAll(async function () {
+          await fixture.cleanup();
+        });
+
+        it('generates the documentation', async function () {
+          await generate(fixture.path);
+          expect(await fixture.readFile('README.md')).toMatchSnapshot();
         });
       });
 
-      afterAll(async function () {
-        await fixture.cleanup();
-      });
+      describe('property=meta.description', function () {
+        let fixture: FixtureContext;
 
-      it('generates the documentation', async function () {
-        await generate(fixture.path);
-        expect(await fixture.readFile('README.md')).toMatchSnapshot();
-      });
-    });
-
-    describe('property=meta.description', function () {
-      let fixture: FixtureContext;
-
-      beforeAll(async function () {
-        fixture = await setupFixture({
-          fixture: 'esm-base',
-          overrides: {
-            'index.js': `
+        beforeAll(async function () {
+          fixture = await setupFixture({
+            fixture: 'esm-base',
+            overrides: {
+              'index.js': `
             export default {
               rules: {
                 'no-foo': {
@@ -216,33 +218,33 @@ describe('generate (configs list)', function () {
                 recommended: { meta: { description: 'This config has the recommended rules...' } },
               }
             };`,
-            'README.md': `## Rules
+              'README.md': `## Rules
   ## Configs
   <!-- begin auto-generated configs list -->
   <!-- end auto-generated configs list -->`,
-            'docs/rules/no-foo.md': '',
-          },
+              'docs/rules/no-foo.md': '',
+            },
+          });
+        });
+
+        afterAll(async function () {
+          await fixture.cleanup();
+        });
+
+        it('generates the documentation', async function () {
+          await generate(fixture.path);
+          expect(await fixture.readFile('README.md')).toMatchSnapshot();
         });
       });
 
-      afterAll(async function () {
-        await fixture.cleanup();
-      });
+      describe('property=meta.docs.description', function () {
+        let fixture: FixtureContext;
 
-      it('generates the documentation', async function () {
-        await generate(fixture.path);
-        expect(await fixture.readFile('README.md')).toMatchSnapshot();
-      });
-    });
-
-    describe('property=meta.docs.description', function () {
-      let fixture: FixtureContext;
-
-      beforeAll(async function () {
-        fixture = await setupFixture({
-          fixture: 'esm-base',
-          overrides: {
-            'index.js': `
+        beforeAll(async function () {
+          fixture = await setupFixture({
+            fixture: 'esm-base',
+            overrides: {
+              'index.js': `
             export default {
               rules: {
                 'no-foo': {
@@ -255,10 +257,49 @@ describe('generate (configs list)', function () {
                 recommended: { meta: { docs: { description: 'This config has the recommended rules...' } } },
               }
             };`,
-            'README.md': `## Rules
+              'README.md': `## Rules
   ## Configs
   <!-- begin auto-generated configs list -->
   <!-- end auto-generated configs list -->`,
+              'docs/rules/no-foo.md': '',
+            },
+          });
+        });
+
+        afterAll(async function () {
+          await fixture.cleanup();
+        });
+
+        it('generates the documentation', async function () {
+          await generate(fixture.path);
+          expect(await fixture.readFile('README.md')).toMatchSnapshot();
+        });
+      });
+    });
+
+    describe('when a config description needs to be escaped in table', function () {
+      let fixture: FixtureContext;
+
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base',
+          overrides: {
+            'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: { docs: { description: 'Description no-foo.' }, },
+                create(context) {}
+              },
+            },
+            configs: {
+              recommended: { description: 'Foo|Bar' },
+            }
+          };`,
+            'README.md': `## Rules
+## Configs
+<!-- begin auto-generated configs list -->
+<!-- end auto-generated configs list -->`,
             'docs/rules/no-foo.md': '',
           },
         });
@@ -273,54 +314,15 @@ describe('generate (configs list)', function () {
         expect(await fixture.readFile('README.md')).toMatchSnapshot();
       });
     });
-  });
 
-  describe('when a config description needs to be escaped in table', function () {
-    let fixture: FixtureContext;
+    describe('when there are no configs', function () {
+      let fixture: FixtureContext;
 
-    beforeAll(async function () {
-      fixture = await setupFixture({
-        fixture: 'esm-base',
-        overrides: {
-          'index.js': `
-          export default {
-            rules: {
-              'no-foo': {
-                meta: { docs: { description: 'Description no-foo.' }, },
-                create(context) {}
-              },
-            },
-            configs: {
-              recommended: { description: 'Foo|Bar' },
-            }
-          };`,
-          'README.md': `## Rules
-## Configs
-<!-- begin auto-generated configs list -->
-<!-- end auto-generated configs list -->`,
-          'docs/rules/no-foo.md': '',
-        },
-      });
-    });
-
-    afterAll(async function () {
-      await fixture.cleanup();
-    });
-
-    it('generates the documentation', async function () {
-      await generate(fixture.path);
-      expect(await fixture.readFile('README.md')).toMatchSnapshot();
-    });
-  });
-
-  describe('when there are no configs', function () {
-    let fixture: FixtureContext;
-
-    beforeAll(async function () {
-      fixture = await setupFixture({
-        fixture: 'esm-base',
-        overrides: {
-          'index.js': `
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base',
+          overrides: {
+            'index.js': `
           export default {
             rules: {
               'no-foo': {
@@ -329,33 +331,33 @@ describe('generate (configs list)', function () {
               },
             },
          };`,
-          'README.md': `## Rules
+            'README.md': `## Rules
 ## Configs
 <!-- begin auto-generated configs list -->
 <!-- end auto-generated configs list -->`,
-          'docs/rules/no-foo.md': '',
-        },
+            'docs/rules/no-foo.md': '',
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('generates the documentation', async function () {
+        await generate(fixture.path);
+        expect(await fixture.readFile('README.md')).toMatchSnapshot();
       });
     });
 
-    afterAll(async function () {
-      await fixture.cleanup();
-    });
+    describe('when all configs are ignored', function () {
+      let fixture: FixtureContext;
 
-    it('generates the documentation', async function () {
-      await generate(fixture.path);
-      expect(await fixture.readFile('README.md')).toMatchSnapshot();
-    });
-  });
-
-  describe('when all configs are ignored', function () {
-    let fixture: FixtureContext;
-
-    beforeAll(async function () {
-      fixture = await setupFixture({
-        fixture: 'esm-base',
-        overrides: {
-          'index.js': `
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base',
+          overrides: {
+            'index.js': `
           export default {
             rules: {
               'no-foo': {
@@ -367,22 +369,426 @@ describe('generate (configs list)', function () {
               recommended: {},
             }
          };`,
-          'README.md': `## Rules
+            'README.md': `## Rules
 ## Configs
 <!-- begin auto-generated configs list -->
 <!-- end auto-generated configs list -->`,
-          'docs/rules/no-foo.md': '',
-        },
+            'docs/rules/no-foo.md': '',
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('generates the documentation', async function () {
+        await generate(fixture.path, { ignoreConfig: ['recommended'] });
+        expect(await fixture.readFile('README.md')).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('for mdx files', () => {
+    const options: GenerateOptions = {
+      pathRuleDoc: 'docs/rules/{name}.mdx',
+      pathRuleList: 'docs/rule-list.mdx',
+    };
+
+    describe('basic', function () {
+      let fixture: FixtureContext;
+
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base-mdx',
+          overrides: {
+            'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: { docs: { description: 'Description of no-foo.' }, },
+                create(context) {}
+              },
+            },
+            configs: {
+              recommended: {},
+            }
+          };`,
+            'docs/rule-list.mdx': `## Rules
+## Configs
+{/* begin auto-generated configs list */}
+{/* end auto-generated configs list */}`,
+            'docs/rules/no-foo.mdx': '',
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('generates the documentation', async function () {
+        await generate(fixture.path, options);
+        expect(await fixture.readFile('docs/rule-list.mdx')).toMatchSnapshot();
       });
     });
 
-    afterAll(async function () {
-      await fixture.cleanup();
+    describe('with --ignore-config', function () {
+      let fixture: FixtureContext;
+
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base-mdx',
+          overrides: {
+            'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: { docs: { description: 'Description of no-foo.' }, },
+                create(context) {}
+              },
+            },
+            configs: {
+              foo: {},
+              recommended: {},
+            }
+          };`,
+            'docs/rule-list.mdx': `## Rules
+## Configs
+{/* begin auto-generated configs list */}
+{/* end auto-generated configs list */}`,
+            'docs/rules/no-foo.mdx': '',
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('generates the documentation', async function () {
+        await generate(fixture.path, { ...options, ignoreConfig: ['foo'] });
+        expect(await fixture.readFile('docs/rule-list.mdx')).toMatchSnapshot();
+      });
     });
 
-    it('generates the documentation', async function () {
-      await generate(fixture.path, { ignoreConfig: ['recommended'] });
-      expect(await fixture.readFile('README.md')).toMatchSnapshot();
+    describe('with --config-format', function () {
+      let fixture: FixtureContext;
+
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base',
+          overrides: {
+            'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: { docs: { description: 'Description of no-foo.' }, },
+                create(context) {}
+              },
+            },
+            configs: {
+              recommended: {},
+            }
+          };`,
+            'docs/rule-list.mdx': `## Rules
+## Configs
+{/* begin auto-generated configs list */}
+{/* end auto-generated configs list */}`,
+            'docs/rules/no-foo.mdx': '',
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('generates the documentation', async function () {
+        await generate(fixture.path, {
+          ...options,
+          configFormat: 'prefix-name',
+        });
+        expect(await fixture.readFile('docs/rule-list.mdx')).toMatchSnapshot();
+      });
+    });
+
+    describe('with configs not defined in alphabetical order', function () {
+      let fixture: FixtureContext;
+
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base-mdx',
+          overrides: {
+            'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: { docs: { description: 'Description of no-foo.' }, },
+                create(context) {}
+              },
+            },
+            configs: {
+              recommended: {},
+              foo: {},
+            }
+          };`,
+            'docs/rule-list.mdx': `## Rules
+## Configs
+{/* begin auto-generated configs list */}
+{/* end auto-generated configs list */}`,
+            'docs/rules/no-foo.mdx': '',
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('generates the documentation', async function () {
+        await generate(fixture.path, options);
+        expect(await fixture.readFile('docs/rule-list.mdx')).toMatchSnapshot();
+      });
+    });
+
+    describe('when a config exports a description', function () {
+      describe('property=description', function () {
+        let fixture: FixtureContext;
+
+        beforeAll(async function () {
+          fixture = await setupFixture({
+            fixture: 'esm-base-mdx',
+            overrides: {
+              'index.js': `
+            export default {
+              rules: {
+                'no-foo': {
+                  meta: { docs: { description: 'Description of no-foo.' }, },
+                  create(context) {}
+                },
+              },
+              configs: {
+                foo: {},
+                recommended: { description: 'This config has the recommended rules...' },
+              }
+            };`,
+              'docs/rule-list.mdx': `## Rules
+## Configs
+{/* begin auto-generated configs list */}
+{/* end auto-generated configs list */}`,
+              'docs/rules/no-foo.mdx': '',
+            },
+          });
+        });
+
+        afterAll(async function () {
+          await fixture.cleanup();
+        });
+
+        it('generates the documentation', async function () {
+          await generate(fixture.path, options);
+          expect(
+            await fixture.readFile('docs/rule-list.mdx'),
+          ).toMatchSnapshot();
+        });
+      });
+
+      describe('property=meta.description', function () {
+        let fixture: FixtureContext;
+
+        beforeAll(async function () {
+          fixture = await setupFixture({
+            fixture: 'esm-base-mdx',
+            overrides: {
+              'index.js': `
+            export default {
+              rules: {
+                'no-foo': {
+                  meta: { docs: { description: 'Description of no-foo.' }, },
+                  create(context) {}
+                },
+              },
+              configs: {
+                foo: {},
+                recommended: { meta: { description: 'This config has the recommended rules...' } },
+              }
+            };`,
+              'docs/rule-list.mdx': `## Rules
+## Configs
+{/* begin auto-generated configs list */}
+{/* end auto-generated configs list */}`,
+              'docs/rules/no-foo.md': '',
+            },
+          });
+        });
+
+        afterAll(async function () {
+          await fixture.cleanup();
+        });
+
+        it('generates the documentation', async function () {
+          await generate(fixture.path, options);
+          expect(
+            await fixture.readFile('docs/rule-list.mdx'),
+          ).toMatchSnapshot();
+        });
+      });
+
+      describe('property=meta.docs.description', function () {
+        let fixture: FixtureContext;
+
+        beforeAll(async function () {
+          fixture = await setupFixture({
+            fixture: 'esm-base-mdx',
+            overrides: {
+              'index.js': `
+            export default {
+              rules: {
+                'no-foo': {
+                  meta: { docs: { description: 'Description of no-foo.' }, },
+                  create(context) {}
+                },
+              },
+              configs: {
+                foo: {},
+                recommended: { meta: { docs: { description: 'This config has the recommended rules...' } } },
+              }
+            };`,
+              'docs/rule-list.mdx': `## Rules
+## Configs
+{/* begin auto-generated configs list */}
+{/* end auto-generated configs list */}`,
+              'docs/rules/no-foo.mdx': '',
+            },
+          });
+        });
+
+        afterAll(async function () {
+          await fixture.cleanup();
+        });
+
+        it('generates the documentation', async function () {
+          await generate(fixture.path, options);
+          expect(
+            await fixture.readFile('docs/rule-list.mdx'),
+          ).toMatchSnapshot();
+        });
+      });
+    });
+
+    describe('when a config description needs to be escaped in table', function () {
+      let fixture: FixtureContext;
+
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base-mdx',
+          overrides: {
+            'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: { docs: { description: 'Description no-foo.' }, },
+                create(context) {}
+              },
+            },
+            configs: {
+              recommended: { description: 'Foo|Bar' },
+            }
+          };`,
+            'docs/rule-list.mdx': `## Rules
+## Configs
+{/* begin auto-generated configs list */}
+{/* end auto-generated configs list */}`,
+            'docs/rules/no-foo.mdx': '',
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('generates the documentation', async function () {
+        await generate(fixture.path, options);
+        expect(await fixture.readFile('docs/rule-list.mdx')).toMatchSnapshot();
+      });
+    });
+
+    describe('when there are no configs', function () {
+      let fixture: FixtureContext;
+
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base-mdx',
+          overrides: {
+            'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: { docs: { description: 'Description of no-foo.' }, },
+                create(context) {}
+              },
+            },
+         };`,
+            'docs/rule-list.mdx': `## Rules
+## Configs
+{/* begin auto-generated configs list */}
+{/* end auto-generated configs list */}`,
+            'docs/rules/no-foo.mdx': '',
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('generates the documentation', async function () {
+        await generate(fixture.path, options);
+        expect(await fixture.readFile('docs/rule-list.mdx')).toMatchSnapshot();
+      });
+    });
+
+    describe('when all configs are ignored', function () {
+      let fixture: FixtureContext;
+
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base',
+          overrides: {
+            'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: { docs: { description: 'Description of no-foo.' }, },
+                create(context) {}
+              },
+            },
+            configs: {
+              recommended: {},
+            }
+         };`,
+            'docs/rule-list.mdx': `## Rules
+## Configs
+{/* begin auto-generated configs list */}
+{/* end auto-generated configs list */}`,
+            'docs/rules/no-foo.mdx': '',
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('generates the documentation', async function () {
+        await generate(fixture.path, {
+          ...options,
+          ignoreConfig: ['recommended'],
+        });
+        expect(await fixture.readFile('docs/rule-list.mdx')).toMatchSnapshot();
+      });
     });
   });
 });

--- a/test/lib/generate/option-rule-doc-notices-test.ts
+++ b/test/lib/generate/option-rule-doc-notices-test.ts
@@ -3,14 +3,15 @@ import { setupFixture, type FixtureContext } from '../../helpers/fixture.js';
 import { NOTICE_TYPE } from '../../../lib/types.js';
 
 describe('generate (--rule-doc-notices)', function () {
-  describe('basic', function () {
-    let fixture: FixtureContext;
+  describe('for md files', () => {
+    describe('basic', function () {
+      let fixture: FixtureContext;
 
-    beforeAll(async function () {
-      fixture = await setupFixture({
-        fixture: 'esm-base',
-        overrides: {
-          'index.js': `
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base',
+          overrides: {
+            'index.js': `
           export default {
             rules: {
               'no-foo': {
@@ -25,109 +26,113 @@ describe('generate (--rule-doc-notices)', function () {
               },
             },
           };`,
-          'README.md': '## Rules\n',
-          'docs/rules/no-foo.md': '',
-        },
+            'README.md': '## Rules\n',
+            'docs/rules/no-foo.md': '',
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('shows description before other notices when using default notice ordering', async function () {
+        await generate(fixture.path);
+        expect(
+          await fixture.readFile('docs/rules/no-foo.md'),
+        ).toMatchSnapshot();
+      });
+
+      it('shows the right rule doc notices', async function () {
+        await generate(fixture.path, {
+          ruleDocNotices: [
+            NOTICE_TYPE.HAS_SUGGESTIONS,
+            NOTICE_TYPE.FIXABLE,
+            NOTICE_TYPE.DEPRECATED,
+            NOTICE_TYPE.DESCRIPTION,
+            NOTICE_TYPE.TYPE,
+          ], // Random values including all the optional notices.
+        });
+        expect(await fixture.readFile('README.md')).toMatchSnapshot();
+        expect(
+          await fixture.readFile('docs/rules/no-foo.md'),
+        ).toMatchSnapshot();
       });
     });
 
-    afterAll(async function () {
-      await fixture.cleanup();
-    });
+    describe('non-existent notice', function () {
+      let fixture: FixtureContext;
 
-    it('shows description before other notices when using default notice ordering', async function () {
-      await generate(fixture.path);
-      expect(await fixture.readFile('docs/rules/no-foo.md')).toMatchSnapshot();
-    });
-
-    it('shows the right rule doc notices', async function () {
-      await generate(fixture.path, {
-        ruleDocNotices: [
-          NOTICE_TYPE.HAS_SUGGESTIONS,
-          NOTICE_TYPE.FIXABLE,
-          NOTICE_TYPE.DEPRECATED,
-          NOTICE_TYPE.DESCRIPTION,
-          NOTICE_TYPE.TYPE,
-        ], // Random values including all the optional notices.
-      });
-      expect(await fixture.readFile('README.md')).toMatchSnapshot();
-      expect(await fixture.readFile('docs/rules/no-foo.md')).toMatchSnapshot();
-    });
-  });
-
-  describe('non-existent notice', function () {
-    let fixture: FixtureContext;
-
-    beforeAll(async function () {
-      fixture = await setupFixture({
-        fixture: 'esm-base',
-        overrides: {
-          'index.js': `
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base',
+          overrides: {
+            'index.js': `
           export default {
             rules: {
               'no-foo': { meta: { docs: { description: 'Description for no-foo.'} }, create(context) {} },
             },
           };`,
-          'README.md': '## Rules\n',
-          'docs/rules/no-foo.md': '',
-        },
+            'README.md': '## Rules\n',
+            'docs/rules/no-foo.md': '',
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('throws an error', async function () {
+        await expect(
+          generate(fixture.path, {
+            // @ts-expect-error -- testing non-existent notice type
+            ruleDocNotices: [NOTICE_TYPE.FIXABLE, 'non-existent'],
+          }),
+        ).rejects.toThrow('Invalid ruleDocNotices option: non-existent');
       });
     });
 
-    afterAll(async function () {
-      await fixture.cleanup();
-    });
+    describe('duplicate notice', function () {
+      let fixture: FixtureContext;
 
-    it('throws an error', async function () {
-      await expect(
-        generate(fixture.path, {
-          // @ts-expect-error -- testing non-existent notice type
-          ruleDocNotices: [NOTICE_TYPE.FIXABLE, 'non-existent'],
-        }),
-      ).rejects.toThrow('Invalid ruleDocNotices option: non-existent');
-    });
-  });
-
-  describe('duplicate notice', function () {
-    let fixture: FixtureContext;
-
-    beforeAll(async function () {
-      fixture = await setupFixture({
-        fixture: 'esm-base',
-        overrides: {
-          'index.js': `
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base',
+          overrides: {
+            'index.js': `
           export default {
             rules: {
               'no-foo': { meta: { docs: { description: 'Description for no-foo.'} }, create(context) {} },
             },
           };`,
-          'README.md': '## Rules\n',
-          'docs/rules/no-foo.md': '',
-        },
+            'README.md': '## Rules\n',
+            'docs/rules/no-foo.md': '',
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('throws an error', async function () {
+        await expect(
+          generate(fixture.path, {
+            ruleDocNotices: [NOTICE_TYPE.FIXABLE, NOTICE_TYPE.FIXABLE],
+          }),
+        ).rejects.toThrow('Duplicate value detected in ruleDocNotices option.');
       });
     });
 
-    afterAll(async function () {
-      await fixture.cleanup();
-    });
+    describe('hasSuggestions only (without fixable) using fixableAndHasSuggestions notice', function () {
+      let fixture: FixtureContext;
 
-    it('throws an error', async function () {
-      await expect(
-        generate(fixture.path, {
-          ruleDocNotices: [NOTICE_TYPE.FIXABLE, NOTICE_TYPE.FIXABLE],
-        }),
-      ).rejects.toThrow('Duplicate value detected in ruleDocNotices option.');
-    });
-  });
-
-  describe('hasSuggestions only (without fixable) using fixableAndHasSuggestions notice', function () {
-    let fixture: FixtureContext;
-
-    beforeAll(async function () {
-      fixture = await setupFixture({
-        fixture: 'esm-base',
-        overrides: {
-          'index.js': `
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base',
+          overrides: {
+            'index.js': `
           export default {
             rules: {
               'no-foo': {
@@ -139,21 +144,185 @@ describe('generate (--rule-doc-notices)', function () {
               },
             },
           };`,
-          'README.md': '## Rules\n',
-          'docs/rules/no-foo.md': '',
-        },
+            'README.md': '## Rules\n',
+            'docs/rules/no-foo.md': '',
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('shows only hasSuggestions notice', async function () {
+        await generate(fixture.path, {
+          ruleDocNotices: [NOTICE_TYPE.FIXABLE_AND_HAS_SUGGESTIONS],
+        });
+        expect(
+          await fixture.readFile('docs/rules/no-foo.md'),
+        ).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('for mdx files', () => {
+    describe('basic', function () {
+      let fixture: FixtureContext;
+
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base-mdx',
+          overrides: {
+            'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: {
+                  docs: { description: 'Description for no-foo.' },
+                  hasSuggestions: true,
+                  fixable: 'code',
+                  deprecated: true,
+                  type: 'problem'
+                },
+                create(context) {}
+              },
+            },
+          };`,
+            'README.md': '## Rules\n',
+            'docs/rules/no-foo.mdx': '',
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('shows description before other notices when using default notice ordering', async function () {
+        await generate(fixture.path);
+        expect(
+          await fixture.readFile('docs/rules/no-foo.mdx'),
+        ).toMatchSnapshot();
+      });
+
+      it('shows the right rule doc notices', async function () {
+        await generate(fixture.path, {
+          ruleDocNotices: [
+            NOTICE_TYPE.HAS_SUGGESTIONS,
+            NOTICE_TYPE.FIXABLE,
+            NOTICE_TYPE.DEPRECATED,
+            NOTICE_TYPE.DESCRIPTION,
+            NOTICE_TYPE.TYPE,
+          ], // Random values including all the optional notices.
+        });
+        expect(
+          await fixture.readFile('docs/rules/no-foo.mdx'),
+        ).toMatchSnapshot();
       });
     });
 
-    afterAll(async function () {
-      await fixture.cleanup();
+    describe('non-existent notice', function () {
+      let fixture: FixtureContext;
+
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base-mdx',
+          overrides: {
+            'index.js': `
+          export default {
+            rules: {
+              'no-foo': { meta: { docs: { description: 'Description for no-foo.'} }, create(context) {} },
+            },
+          };`,
+            'README.md': '## Rules\n',
+            'docs/rules/no-foo.mdx': '',
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('throws an error', async function () {
+        await expect(
+          generate(fixture.path, {
+            // @ts-expect-error -- testing non-existent notice type
+            ruleDocNotices: [NOTICE_TYPE.FIXABLE, 'non-existent'],
+          }),
+        ).rejects.toThrow('Invalid ruleDocNotices option: non-existent');
+      });
     });
 
-    it('shows only hasSuggestions notice', async function () {
-      await generate(fixture.path, {
-        ruleDocNotices: [NOTICE_TYPE.FIXABLE_AND_HAS_SUGGESTIONS],
+    describe('duplicate notice', function () {
+      let fixture: FixtureContext;
+
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base-mdx',
+          overrides: {
+            'index.js': `
+          export default {
+            rules: {
+              'no-foo': { meta: { docs: { description: 'Description for no-foo.'} }, create(context) {} },
+            },
+          };`,
+            'README.md': '## Rules\n',
+            'docs/rules/no-foo.mdx': '',
+          },
+        });
       });
-      expect(await fixture.readFile('docs/rules/no-foo.md')).toMatchSnapshot();
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('throws an error', async function () {
+        await expect(
+          generate(fixture.path, {
+            ruleDocNotices: [NOTICE_TYPE.FIXABLE, NOTICE_TYPE.FIXABLE],
+          }),
+        ).rejects.toThrow('Duplicate value detected in ruleDocNotices option.');
+      });
+    });
+
+    describe('hasSuggestions only (without fixable) using fixableAndHasSuggestions notice', function () {
+      let fixture: FixtureContext;
+
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base-mdx',
+          overrides: {
+            'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: {
+                  docs: { description: 'Description for no-foo.' },
+                  hasSuggestions: true,
+                },
+                create(context) {}
+              },
+            },
+          };`,
+            'README.md': '## Rules\n',
+            'docs/rules/no-foo.mdx': '',
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('shows only hasSuggestions notice', async function () {
+        await generate(fixture.path, {
+          ruleDocNotices: [NOTICE_TYPE.FIXABLE_AND_HAS_SUGGESTIONS],
+        });
+        expect(
+          await fixture.readFile('docs/rules/no-foo.mdx'),
+        ).toMatchSnapshot();
+      });
     });
   });
 

--- a/test/lib/generate/rule-options-list-test.ts
+++ b/test/lib/generate/rule-options-list-test.ts
@@ -3,14 +3,15 @@ import { setupFixture, type FixtureContext } from '../../helpers/fixture.js';
 import * as sinon from 'sinon';
 
 describe('generate (rule options list)', function () {
-  describe('basic', function () {
-    let fixture: FixtureContext;
+  describe('for md files', () => {
+    describe('basic', function () {
+      let fixture: FixtureContext;
 
-    beforeAll(async function () {
-      fixture = await setupFixture({
-        fixture: 'esm-base',
-        overrides: {
-          'index.js': `
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base',
+          overrides: {
+            'index.js': `
           export default {
             rules: {
               'no-foo': {
@@ -76,35 +77,37 @@ describe('generate (rule options list)', function () {
               recommended: {},
             }
           };`,
-          'README.md': '## Rules\n',
-          'docs/rules/no-foo.md': `## Options
+            'README.md': '## Rules\n',
+            'docs/rules/no-foo.md': `## Options
 <!-- begin auto-generated rule options list -->
 <!-- end auto-generated rule options list -->`,
-        },
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('generates the documentation', async function () {
+        const consoleErrorStub = sinon.stub(console, 'error');
+        await generate(fixture.path);
+        expect(consoleErrorStub.callCount).toBe(0);
+        consoleErrorStub.restore();
+        expect(
+          await fixture.readFile('docs/rules/no-foo.md'),
+        ).toMatchSnapshot();
       });
     });
 
-    afterAll(async function () {
-      await fixture.cleanup();
-    });
+    describe('displays default column even when only falsy value, hiding deprecated/required cols with only falsy value', function () {
+      let fixture: FixtureContext;
 
-    it('generates the documentation', async function () {
-      const consoleErrorStub = sinon.stub(console, 'error');
-      await generate(fixture.path);
-      expect(consoleErrorStub.callCount).toBe(0);
-      consoleErrorStub.restore();
-      expect(await fixture.readFile('docs/rules/no-foo.md')).toMatchSnapshot();
-    });
-  });
-
-  describe('displays default column even when only falsy value, hiding deprecated/required cols with only falsy value', function () {
-    let fixture: FixtureContext;
-
-    beforeAll(async function () {
-      fixture = await setupFixture({
-        fixture: 'esm-base',
-        overrides: {
-          'index.js': `
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base',
+          overrides: {
+            'index.js': `
           export default {
             rules: {
               'no-foo': {
@@ -124,35 +127,37 @@ describe('generate (rule options list)', function () {
               },
             },
           };`,
-          'README.md': '## Rules\n',
-          'docs/rules/no-foo.md': `## Options
+            'README.md': '## Rules\n',
+            'docs/rules/no-foo.md': `## Options
 <!-- begin auto-generated rule options list -->
 <!-- end auto-generated rule options list -->`,
-        },
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('generates the documentation', async function () {
+        const consoleErrorStub = sinon.stub(console, 'error');
+        await generate(fixture.path);
+        expect(consoleErrorStub.callCount).toBe(0);
+        consoleErrorStub.restore();
+        expect(
+          await fixture.readFile('docs/rules/no-foo.md'),
+        ).toMatchSnapshot();
       });
     });
 
-    afterAll(async function () {
-      await fixture.cleanup();
-    });
+    describe('with no options', function () {
+      let fixture: FixtureContext;
 
-    it('generates the documentation', async function () {
-      const consoleErrorStub = sinon.stub(console, 'error');
-      await generate(fixture.path);
-      expect(consoleErrorStub.callCount).toBe(0);
-      consoleErrorStub.restore();
-      expect(await fixture.readFile('docs/rules/no-foo.md')).toMatchSnapshot();
-    });
-  });
-
-  describe('with no options', function () {
-    let fixture: FixtureContext;
-
-    beforeAll(async function () {
-      fixture = await setupFixture({
-        fixture: 'esm-base',
-        overrides: {
-          'index.js': `
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base',
+          overrides: {
+            'index.js': `
           export default {
             rules: {
               'no-foo': {
@@ -164,35 +169,37 @@ describe('generate (rule options list)', function () {
               recommended: {},
             }
           };`,
-          'README.md': '## Rules\n',
-          'docs/rules/no-foo.md': `
+            'README.md': '## Rules\n',
+            'docs/rules/no-foo.md': `
 <!-- begin auto-generated rule options list -->
 <!-- end auto-generated rule options list -->`,
-        },
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('generates the documentation', async function () {
+        const consoleErrorStub = sinon.stub(console, 'error');
+        await generate(fixture.path);
+        expect(consoleErrorStub.callCount).toBe(0);
+        consoleErrorStub.restore();
+        expect(
+          await fixture.readFile('docs/rules/no-foo.md'),
+        ).toMatchSnapshot();
       });
     });
 
-    afterAll(async function () {
-      await fixture.cleanup();
-    });
+    describe('prefers meta.defaultOptions over schema defaults', function () {
+      let fixture: FixtureContext;
 
-    it('generates the documentation', async function () {
-      const consoleErrorStub = sinon.stub(console, 'error');
-      await generate(fixture.path);
-      expect(consoleErrorStub.callCount).toBe(0);
-      consoleErrorStub.restore();
-      expect(await fixture.readFile('docs/rules/no-foo.md')).toMatchSnapshot();
-    });
-  });
-
-  describe('prefers meta.defaultOptions over schema defaults', function () {
-    let fixture: FixtureContext;
-
-    beforeAll(async function () {
-      fixture = await setupFixture({
-        fixture: 'esm-base',
-        overrides: {
-          'index.js': `
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base',
+          overrides: {
+            'index.js': `
           export default {
             rules: {
               'no-foo': {
@@ -214,40 +221,40 @@ describe('generate (rule options list)', function () {
               },
             },
           };`,
-          'README.md': '## Rules\n',
-          'docs/rules/no-foo.md': `## Options
+            'README.md': '## Rules\n',
+            'docs/rules/no-foo.md': `## Options
 <!-- begin auto-generated rule options list -->
 <!-- end auto-generated rule options list -->`,
-        },
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('generates the documentation with defaults from meta.defaultOptions', async function () {
+        const consoleErrorStub = sinon.stub(console, 'error');
+        await generate(fixture.path);
+        expect(consoleErrorStub.callCount).toBe(0);
+        consoleErrorStub.restore();
+        expect(await fixture.readFile('docs/rules/no-foo.md')).toContain(
+          '`true`',
+        );
+        expect(await fixture.readFile('docs/rules/no-foo.md')).not.toContain(
+          '`false`',
+        );
       });
     });
 
-    afterAll(async function () {
-      await fixture.cleanup();
-    });
+    describe('with no marker comments', function () {
+      let fixture: FixtureContext;
 
-    it('generates the documentation with defaults from meta.defaultOptions', async function () {
-      const consoleErrorStub = sinon.stub(console, 'error');
-      await generate(fixture.path);
-      expect(consoleErrorStub.callCount).toBe(0);
-      consoleErrorStub.restore();
-      expect(await fixture.readFile('docs/rules/no-foo.md')).toContain(
-        '`true`',
-      );
-      expect(await fixture.readFile('docs/rules/no-foo.md')).not.toContain(
-        '`false`',
-      );
-    });
-  });
-
-  describe('with no marker comments', function () {
-    let fixture: FixtureContext;
-
-    beforeAll(async function () {
-      fixture = await setupFixture({
-        fixture: 'esm-base',
-        overrides: {
-          'index.js': `
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base',
+          overrides: {
+            'index.js': `
           export default {
             rules: {
               'no-foo': {
@@ -258,33 +265,35 @@ describe('generate (rule options list)', function () {
               },
             },
           };`,
-          'README.md': '## Rules\n',
-          'docs/rules/no-foo.md': '## Options\nfoo',
-        },
+            'README.md': '## Rules\n',
+            'docs/rules/no-foo.md': '## Options\nfoo',
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('generates the documentation', async function () {
+        const consoleErrorStub = sinon.stub(console, 'error');
+        await generate(fixture.path);
+        expect(consoleErrorStub.callCount).toBe(0);
+        consoleErrorStub.restore();
+        expect(
+          await fixture.readFile('docs/rules/no-foo.md'),
+        ).toMatchSnapshot();
       });
     });
 
-    afterAll(async function () {
-      await fixture.cleanup();
-    });
+    describe('with string that needs to be escaped in table', function () {
+      let fixture: FixtureContext;
 
-    it('generates the documentation', async function () {
-      const consoleErrorStub = sinon.stub(console, 'error');
-      await generate(fixture.path);
-      expect(consoleErrorStub.callCount).toBe(0);
-      consoleErrorStub.restore();
-      expect(await fixture.readFile('docs/rules/no-foo.md')).toMatchSnapshot();
-    });
-  });
-
-  describe('with string that needs to be escaped in table', function () {
-    let fixture: FixtureContext;
-
-    beforeAll(async function () {
-      fixture = await setupFixture({
-        fixture: 'esm-base',
-        overrides: {
-          'index.js': `
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base',
+          overrides: {
+            'index.js': `
           export default {
             rules: {
               'no-foo': {
@@ -296,24 +305,353 @@ describe('generate (rule options list)', function () {
               },
             },
           };`,
-          'README.md': '## Rules\n',
-          'docs/rules/no-foo.md': `## Options
+            'README.md': '## Rules\n',
+            'docs/rules/no-foo.md': `## Options
 <!-- begin auto-generated rule options list -->
 <!-- end auto-generated rule options list -->`,
-        },
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('generates the documentation', async function () {
+        const consoleErrorStub = sinon.stub(console, 'error');
+        await generate(fixture.path);
+        expect(consoleErrorStub.callCount).toBe(0);
+        consoleErrorStub.restore();
+        expect(
+          await fixture.readFile('docs/rules/no-foo.md'),
+        ).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('for mdx files', () => {
+    describe('basic', function () {
+      let fixture: FixtureContext;
+
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base-mdx',
+          overrides: {
+            'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: {
+                  schema: [{
+                    type: "object",
+                    properties: {
+                        foo: {
+                            type: "boolean",
+                            description: "Enable some kind of behavior.",
+                            deprecated: true,
+                            default: false
+                        },
+                        bar: {
+                            description: "Choose how to use the rule.",
+                            type: "string",
+                            enum: ["always", "never"],
+                            default: "always"
+                        },
+                        baz: {
+                            default: true,
+                            required: true,
+                        },
+                        biz: {},
+                        arr1: {
+                          type: "array",
+                        },
+                        arrWithArrType: {
+                          type: ["string", "boolean"],
+                        },
+                        arrWithArrTypeSingleItem: {
+                          type: ["string"],
+                        },
+                        arrWithItemsType: {
+                          type: "array",
+                          items: {
+                            type: "string"
+                          }
+                        },
+                        arrWithItemsArrayType: {
+                          type: "array",
+                          items: {
+                            type: ["string", "boolean"]
+                          }
+                        },
+                        arrWithDefaultEmpty: {
+                          type: "array",
+                          default: [],
+                        },
+                        arrWithDefault: {
+                          type: "array",
+                          default: ['hello world', 1, 2, 3, true],
+                        },
+                    },
+                    required: ["bar"],
+                    additionalProperties: false
+                 }],
+                },
+                create(context) {}
+              },
+            },
+            configs: {
+              recommended: {},
+            }
+          };`,
+            'README.md': '## Rules\n',
+            'docs/rules/no-foo.mdx': `## Options
+{/* begin auto-generated rule options list */}
+{/* end auto-generated rule options list */}`,
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('generates the documentation', async function () {
+        const consoleErrorStub = sinon.stub(console, 'error');
+        await generate(fixture.path);
+        expect(consoleErrorStub.callCount).toBe(0);
+        consoleErrorStub.restore();
+        expect(
+          await fixture.readFile('docs/rules/no-foo.mdx'),
+        ).toMatchSnapshot();
       });
     });
 
-    afterAll(async function () {
-      await fixture.cleanup();
+    describe('displays default column even when only falsy value, hiding deprecated/required cols with only falsy value', function () {
+      let fixture: FixtureContext;
+
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base-mdx',
+          overrides: {
+            'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: {
+                  schema: [{
+                    type: "object",
+                    properties: {
+                        foo: {
+                            default: false,
+                            required: false,
+                            deprecated: false,
+                        },
+                    },
+                 }],
+                },
+                create(context) {}
+              },
+            },
+          };`,
+            'README.md': '## Rules\n',
+            'docs/rules/no-foo.mdx': `## Options
+{/* begin auto-generated rule options list */}
+{/* end auto-generated rule options list */}`,
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('generates the documentation', async function () {
+        const consoleErrorStub = sinon.stub(console, 'error');
+        await generate(fixture.path);
+        expect(consoleErrorStub.callCount).toBe(0);
+        consoleErrorStub.restore();
+        expect(
+          await fixture.readFile('docs/rules/no-foo.mdx'),
+        ).toMatchSnapshot();
+      });
     });
 
-    it('generates the documentation', async function () {
-      const consoleErrorStub = sinon.stub(console, 'error');
-      await generate(fixture.path);
-      expect(consoleErrorStub.callCount).toBe(0);
-      consoleErrorStub.restore();
-      expect(await fixture.readFile('docs/rules/no-foo.md')).toMatchSnapshot();
+    describe('with no options', function () {
+      let fixture: FixtureContext;
+
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base-mdx',
+          overrides: {
+            'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: {},
+                create(context) {}
+              },
+            },
+            configs: {
+              recommended: {},
+            }
+          };`,
+            'README.md': '## Rules\n',
+            'docs/rules/no-foo.mdx': `
+{/* begin auto-generated rule options list */}
+{/* end auto-generated rule options list */}`,
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('generates the documentation', async function () {
+        const consoleErrorStub = sinon.stub(console, 'error');
+        await generate(fixture.path);
+        expect(consoleErrorStub.callCount).toBe(0);
+        consoleErrorStub.restore();
+        expect(
+          await fixture.readFile('docs/rules/no-foo.mdx'),
+        ).toMatchSnapshot();
+      });
+    });
+
+    describe('prefers meta.defaultOptions over schema defaults', function () {
+      let fixture: FixtureContext;
+
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base-mdx',
+          overrides: {
+            'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: {
+                  schema: [{
+                    type: "object",
+                    properties: {
+                        foo: {
+                            type: "boolean",
+                            default: false,
+                        },
+                    },
+                 }],
+                  defaultOptions: [{
+                    foo: true,
+                  }],
+                },
+                create(context) {}
+              },
+            },
+          };`,
+            'README.md': '## Rules\n',
+            'docs/rules/no-foo.mdx': `## Options
+{/* begin auto-generated rule options list */}
+{/* end auto-generated rule options list */}`,
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('generates the documentation with defaults from meta.defaultOptions', async function () {
+        const consoleErrorStub = sinon.stub(console, 'error');
+        await generate(fixture.path);
+        expect(consoleErrorStub.callCount).toBe(0);
+        consoleErrorStub.restore();
+        expect(await fixture.readFile('docs/rules/no-foo.mdx')).toContain(
+          '`true`',
+        );
+        expect(await fixture.readFile('docs/rules/no-foo.mdx')).not.toContain(
+          '`false`',
+        );
+      });
+    });
+
+    describe('with no marker comments', function () {
+      let fixture: FixtureContext;
+
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base-mdx',
+          overrides: {
+            'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: {
+                  schema: [{ type: "object", properties: { foo: { description: 'some desc' } } }]
+                },
+                create(context) {}
+              },
+            },
+          };`,
+            'README.md': '## Rules\n',
+            'docs/rules/no-foo.mdx': '## Options\nfoo',
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('generates the documentation', async function () {
+        const consoleErrorStub = sinon.stub(console, 'error');
+        await generate(fixture.path);
+        expect(consoleErrorStub.callCount).toBe(0);
+        consoleErrorStub.restore();
+        expect(
+          await fixture.readFile('docs/rules/no-foo.mdx'),
+        ).toMatchSnapshot();
+      });
+    });
+
+    describe('with string that needs to be escaped in table', function () {
+      let fixture: FixtureContext;
+
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base-mdx',
+          overrides: {
+            'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: {
+                  schema: [{ type: "object", properties: { foo: { description: \`test
+                  desc\`, type: 'string|number' } } }]
+                },
+                create(context) {}
+              },
+            },
+          };`,
+            'README.md': '## Rules\n',
+            'docs/rules/no-foo.mdx': `## Options
+{/* begin auto-generated rule options list */}
+{/* end auto-generated rule options list */}`,
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('generates the documentation', async function () {
+        const consoleErrorStub = sinon.stub(console, 'error');
+        await generate(fixture.path);
+        expect(consoleErrorStub.callCount).toBe(0);
+        consoleErrorStub.restore();
+        expect(
+          await fixture.readFile('docs/rules/no-foo.mdx'),
+        ).toMatchSnapshot();
+      });
     });
   });
 });

--- a/test/lib/markdown-test.ts
+++ b/test/lib/markdown-test.ts
@@ -135,7 +135,7 @@ describe('markdown', function () {
         outdent`
           # Rule
           Intro sentence.
-          <!-- marker -->
+          <!-- end auto-generated rule header -->
           Rule description.
         `,
       );
@@ -154,7 +154,7 @@ describe('markdown', function () {
           ---
           # Rule
           Intro sentence.
-          <!-- marker -->
+          <!-- end auto-generated rule header -->
           Rule description.
         `,
       );
@@ -207,143 +207,274 @@ describe('markdown', function () {
   });
 
   describe('replaceOrCreateHeader', function () {
-    it('should create a new header when no existing header or marker exists', function () {
-      const markdown = normalize(
-        outdent`
-          This is the content of the rule doc.
-        `,
-      );
-      const newHeader = normalize(
-        outdent`
-          # New Rule
-          <!-- marker -->
-        `,
-      );
+    describe('for md files', function () {
+      it('should create a new header when no existing header or marker exists', function () {
+        const markdown = normalize(
+          outdent`
+            This is the content of the rule doc.
+          `,
+        );
+        const newHeader = normalize(
+          outdent`
+            # New Rule
+            <!-- end auto-generated rule header -->
+          `,
+        );
 
-      expect(
-        replaceOrCreateHeader(context, markdown, newHeader, '<!-- marker -->'),
-      ).toBe(`${newHeader}${context.endOfLine}${markdown}`);
+        expect(replaceOrCreateHeader(context, markdown, newHeader, false)).toBe(
+          `${newHeader}${context.endOfLine}${markdown}`,
+        );
+      });
+
+      it('should replace an existing title header and preserve the original body', function () {
+        const markdown = normalize(
+          outdent`
+            # Old Rule
+            Rule description.
+          `,
+        );
+        const newHeader = normalize(
+          outdent`
+            # New Rule
+            <!-- end auto-generated rule header -->
+          `,
+        );
+
+        expect(replaceOrCreateHeader(context, markdown, newHeader, false)).toBe(
+          `${newHeader}${context.endOfLine}Rule description.`,
+        );
+      });
+
+      it('should replace everything up to the marker and keep content after the marker', function () {
+        const markdown = normalize(
+          outdent`
+            # Old Rule
+            Intro sentence.
+            <!-- end auto-generated rule header -->
+            Rule description.
+          `,
+        );
+        const newHeader = normalize(
+          outdent`
+            # New Rule
+            <!-- end auto-generated rule header -->
+          `,
+        );
+
+        expect(replaceOrCreateHeader(context, markdown, newHeader, false)).toBe(
+          `${newHeader}${context.endOfLine}Rule description.`,
+        );
+      });
+
+      it('should preserve frontmatter and doc body when replacing header', function () {
+        const frontmatter = normalize(
+          outdent`
+            ---
+            title: Old Rule
+            ---
+          `,
+        );
+        const markdown = normalize(
+          outdent`
+            ${frontmatter}
+            # Old Rule
+            Rule description.
+          `,
+        );
+        const newHeader = normalize(
+          outdent`
+            # New Rule
+            <!-- end auto-generated rule header -->
+          `,
+        );
+
+        expect(replaceOrCreateHeader(context, markdown, newHeader, false)).toBe(
+          `${frontmatter}${context.endOfLine}${newHeader}${context.endOfLine}Rule description.`,
+        );
+      });
+
+      it('should should preserve additional content between frontmatter and header', function () {
+        const frontmatter = normalize(
+          outdent`
+            ---
+            title: Old Rule
+            ---
+          `,
+        );
+        const markdown = normalize(
+          outdent`
+            ${frontmatter}
+            > 📌 A blockquote that should be preserved.
+            # Old Rule
+            Rule description.
+          `,
+        );
+        const newHeader = normalize(
+          outdent`
+            # New Rule
+            <!-- end auto-generated rule header -->
+          `,
+        );
+
+        expect(replaceOrCreateHeader(context, markdown, newHeader, false)).toBe(
+          `${frontmatter}${context.endOfLine}> 📌 A blockquote that should be preserved.${context.endOfLine}${newHeader}${context.endOfLine}Rule description.`,
+        );
+      });
+
+      it('should should preserve additional content above header when no frontmatter exists', function () {
+        const markdown = normalize(
+          outdent`
+            > 📌 A blockquote that should be preserved.
+            # Old Rule
+            Rule description.
+          `,
+        );
+        const newHeader = normalize(
+          outdent`
+            # New Rule
+            <!-- end auto-generated rule header -->
+          `,
+        );
+
+        expect(replaceOrCreateHeader(context, markdown, newHeader, false)).toBe(
+          `> 📌 A blockquote that should be preserved.${context.endOfLine}${newHeader}${context.endOfLine}Rule description.`,
+        );
+      });
     });
 
-    it('should replace an existing title header and preserve the original body', function () {
-      const markdown = normalize(
-        outdent`
-          # Old Rule
-          Rule description.
-        `,
-      );
-      const newHeader = normalize(
-        outdent`
-          # New Rule
-          <!-- marker -->
-        `,
-      );
+    describe('for mdx files', function () {
+      it('should create a new header when no existing header or marker exists', function () {
+        const markdown = normalize(
+          outdent`
+            This is the content of the rule doc.
+          `,
+        );
+        const newHeader = normalize(
+          outdent`
+            # New Rule
+            {/* end auto-generated rule header */}
+          `,
+        );
 
-      expect(
-        replaceOrCreateHeader(context, markdown, newHeader, '<!-- marker -->'),
-      ).toBe(`${newHeader}${context.endOfLine}Rule description.`);
-    });
+        expect(replaceOrCreateHeader(context, markdown, newHeader, true)).toBe(
+          `${newHeader}${context.endOfLine}${markdown}`,
+        );
+      });
 
-    it('should replace everything up to the marker and keep content after the marker', function () {
-      const markdown = normalize(
-        outdent`
-          # Old Rule
-          Intro sentence.
-          <!-- marker -->
-          Rule description.
-        `,
-      );
-      const newHeader = normalize(
-        outdent`
-          # New Rule
-          <!-- marker -->
-        `,
-      );
+      it('should replace an existing title header and preserve the original body', function () {
+        const markdown = normalize(
+          outdent`
+            # Old Rule
+            Rule description.
+          `,
+        );
+        const newHeader = normalize(
+          outdent`
+            # New Rule
+            {/* end auto-generated rule header */}
+          `,
+        );
 
-      expect(
-        replaceOrCreateHeader(context, markdown, newHeader, '<!-- marker -->'),
-      ).toBe(`${newHeader}${context.endOfLine}Rule description.`);
-    });
+        expect(replaceOrCreateHeader(context, markdown, newHeader, true)).toBe(
+          `${newHeader}${context.endOfLine}Rule description.`,
+        );
+      });
 
-    it('should preserve frontmatter and doc body when replacing header', function () {
-      const frontmatter = normalize(
-        outdent`
-          ---
-          title: Old Rule
-          ---
-        `,
-      );
-      const markdown = normalize(
-        outdent`
-          ${frontmatter}
-          # Old Rule
-          Rule description.
-        `,
-      );
-      const newHeader = normalize(
-        outdent`
-          # New Rule
-          <!-- marker -->
-        `,
-      );
+      it('should replace everything up to the marker and keep content after the marker', function () {
+        const markdown = normalize(
+          outdent`
+            # Old Rule
+            Intro sentence.
+            {/* end auto-generated rule header */}
+            Rule description.
+          `,
+        );
+        const newHeader = normalize(
+          outdent`
+            # New Rule
+            {/* end auto-generated rule header */}
+          `,
+        );
 
-      expect(
-        replaceOrCreateHeader(context, markdown, newHeader, '<!-- marker -->'),
-      ).toBe(
-        `${frontmatter}${context.endOfLine}${newHeader}${context.endOfLine}Rule description.`,
-      );
-    });
+        expect(replaceOrCreateHeader(context, markdown, newHeader, true)).toBe(
+          `${newHeader}${context.endOfLine}Rule description.`,
+        );
+      });
 
-    it('should should preserve additional content between frontmatter and header', function () {
-      const frontmatter = normalize(
-        outdent`
-          ---
-          title: Old Rule
-          ---
-        `,
-      );
-      const markdown = normalize(
-        outdent`
-          ${frontmatter}
-          > 📌 A blockquote that should be preserved.
-          # Old Rule
-          Rule description.
-        `,
-      );
-      const newHeader = normalize(
-        outdent`
-          # New Rule
-          <!-- marker -->
-        `,
-      );
+      it('should preserve frontmatter and doc body when replacing header', function () {
+        const frontmatter = normalize(
+          outdent`
+            ---
+            title: Old Rule
+            ---
+          `,
+        );
+        const markdown = normalize(
+          outdent`
+            ${frontmatter}
+            # Old Rule
+            Rule description.
+          `,
+        );
+        const newHeader = normalize(
+          outdent`
+            # New Rule
+            {/* end auto-generated rule header */}
+          `,
+        );
 
-      expect(
-        replaceOrCreateHeader(context, markdown, newHeader, '<!-- marker -->'),
-      ).toBe(
-        `${frontmatter}${context.endOfLine}> 📌 A blockquote that should be preserved.${context.endOfLine}${newHeader}${context.endOfLine}Rule description.`,
-      );
-    });
+        expect(replaceOrCreateHeader(context, markdown, newHeader, true)).toBe(
+          `${frontmatter}${context.endOfLine}${newHeader}${context.endOfLine}Rule description.`,
+        );
+      });
 
-    it('should should preserve additional content above header when no frontmatter exists', function () {
-      const markdown = normalize(
-        outdent`
-          > 📌 A blockquote that should be preserved.
-          # Old Rule
-          Rule description.
-        `,
-      );
-      const newHeader = normalize(
-        outdent`
-          # New Rule
-          <!-- marker -->
-        `,
-      );
+      it('should should preserve additional content between frontmatter and header', function () {
+        const frontmatter = normalize(
+          outdent`
+            ---
+            title: Old Rule
+            ---
+          `,
+        );
+        const markdown = normalize(
+          outdent`
+            ${frontmatter}
+            > 📌 A blockquote that should be preserved.
+            # Old Rule
+            Rule description.
+          `,
+        );
+        const newHeader = normalize(
+          outdent`
+            # New Rule
+            {/* end auto-generated rule header */}
+          `,
+        );
 
-      expect(
-        replaceOrCreateHeader(context, markdown, newHeader, '<!-- marker -->'),
-      ).toBe(
-        `> 📌 A blockquote that should be preserved.${context.endOfLine}${newHeader}${context.endOfLine}Rule description.`,
-      );
+        expect(replaceOrCreateHeader(context, markdown, newHeader, true)).toBe(
+          `${frontmatter}${context.endOfLine}> 📌 A blockquote that should be preserved.${context.endOfLine}${newHeader}${context.endOfLine}Rule description.`,
+        );
+      });
+
+      it('should should preserve additional content above header when no frontmatter exists', function () {
+        const markdown = normalize(
+          outdent`
+            > 📌 A blockquote that should be preserved.
+            # Old Rule
+            Rule description.
+          `,
+        );
+        const newHeader = normalize(
+          outdent`
+            # New Rule
+            {/* end auto-generated rule header */}
+          `,
+        );
+
+        expect(replaceOrCreateHeader(context, markdown, newHeader, true)).toBe(
+          `> 📌 A blockquote that should be preserved.${context.endOfLine}${newHeader}${context.endOfLine}Rule description.`,
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
This change adds support for `mdx` rule doc and rule list files.  You can now specific mdx files in options `--path-rule-doc` and `--path-rule-list`.  Additionally, if you have `md` specified for the rule doc pattern and it doesn't fine a rule doc at the expected location, it'll try `mdx` for the same location, and use that if it's there. (should we do the reverse fallback also?)

The main difference in `mdx` generation and `md` generation is the comment formatting.  `mdx` uses `{/* */}` instead of `<!-- -->`.

fixes #942
