### PR TITLE
 feat: add `description` option to `ruleListSplit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,10 +344,12 @@ const config = {
       {
         title: 'Foo',
         rules: rules.filter(([name, rule]) => rule.meta.someProp === 'foo'),
+        description: 'A set of Foo rules.',
       },
       {
         title: 'Bar',
         rules: rules.filter(([name, rule]) => rule.meta.someProp === 'bar'),
+        description: 'A set of Bar rules.',
       },
     ];
   },

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ const config = {
   ruleListSplit(rules) {
     return [
       {
-        // No header for this list.
+        // No title nor description for this list.
         rules: rules.filter(([name, rule]) => !rule.meta.someProp),
       },
       {

--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -396,7 +396,7 @@ export function updateRulesList(
             minItems: 1,
             uniqueItems: true,
           },
-          description: { type: 'string' },
+          description: { type: 'string', minLength: 1 },
         },
         required: ['rules'],
         additionalProperties: false,

--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -172,12 +172,16 @@ function generateRulesListMarkdown(
   );
 }
 
-type RulesAndHeaders = { title?: string; rules: RuleNamesAndRules }[];
-type RulesAndHeadersReadOnly = Readonly<RulesAndHeaders>;
+type RuleListSplitData = {
+  title?: string;
+  rules: RuleNamesAndRules;
+  description?: string;
+}[];
+type RuleListSplitDataReadOnly = Readonly<RuleListSplitData>;
 
 function generateRuleListMarkdownForRulesAndHeaders(
   context: Context,
-  rulesAndHeaders: RulesAndHeadersReadOnly,
+  rulesAndHeaders: RuleListSplitDataReadOnly,
   headerLevel: number,
   columns: Record<COLUMN_TYPE, boolean>,
   pathToFile: string,
@@ -185,9 +189,12 @@ function generateRuleListMarkdownForRulesAndHeaders(
   const { endOfLine } = context;
   const parts: string[] = [];
 
-  for (const { title, rules } of rulesAndHeaders) {
+  for (const { title, rules, description } of rulesAndHeaders) {
     if (title) {
       parts.push(`${'#'.repeat(headerLevel)} ${title}`);
+    }
+    if (description) {
+      parts.push(description);
     }
     parts.push(generateRulesListMarkdown(context, rules, columns, pathToFile));
   }
@@ -202,8 +209,8 @@ function getRulesAndHeadersForSplit(
   context: Context,
   ruleNamesAndRules: RuleNamesAndRules,
   ruleListSplit: readonly string[],
-): RulesAndHeadersReadOnly {
-  const rulesAndHeaders: RulesAndHeaders = [];
+): RuleListSplitDataReadOnly {
+  const rulesAndHeaders: RuleListSplitData = [];
 
   // Initially, all rules are unused.
   let unusedRules: RuleNamesAndRules = ruleNamesAndRules;
@@ -211,7 +218,7 @@ function getRulesAndHeadersForSplit(
   // Loop through each split property.
   for (const ruleListSplitItem of ruleListSplit) {
     // Store the rules and headers for this split property.
-    const rulesAndHeadersForThisSplit: RulesAndHeaders = [];
+    const rulesAndHeadersForThisSplit: RuleListSplitData = [];
 
     // Check what possible values this split property can have.
     const valuesForThisPropertyFromUnusedRules = [
@@ -363,7 +370,7 @@ export function updateRulesList(
   const legend = generateLegend(context, columns);
 
   // Determine the pairs of rules and headers based on any split property.
-  const rulesAndHeaders: RulesAndHeaders = [];
+  const ruleListSplitData: RuleListSplitData = [];
   if (typeof ruleListSplit === 'function') {
     const userDefinedLists = ruleListSplit(ruleNamesAndRules);
 
@@ -389,6 +396,7 @@ export function updateRulesList(
             minItems: 1,
             uniqueItems: true,
           },
+          description: { type: 'string' },
         },
         required: ['rules'],
         additionalProperties: false,
@@ -412,19 +420,19 @@ export function updateRulesList(
       );
     }
 
-    rulesAndHeaders.push(...userDefinedLists);
+    ruleListSplitData.push(...userDefinedLists);
   } else if (ruleListSplit.length > 0) {
-    rulesAndHeaders.push(
+    ruleListSplitData.push(
       ...getRulesAndHeadersForSplit(context, ruleNamesAndRules, ruleListSplit),
     );
   } else {
-    rulesAndHeaders.push({ rules: ruleNamesAndRules });
+    ruleListSplitData.push({ rules: ruleNamesAndRules });
   }
 
   // New rule list.
   const list = generateRuleListMarkdownForRulesAndHeaders(
     context,
-    rulesAndHeaders,
+    ruleListSplitData,
     ruleListSplitHeaderLevel,
     columns,
     pathToFile,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -161,7 +161,7 @@ export type OPTION_TYPE = (typeof OPTION_TYPE)[keyof typeof OPTION_TYPE];
 export type RuleListSplitFunction = (rules: RuleNamesAndRules) => readonly {
   title?: string;
   rules: RuleNamesAndRules;
-  /** Optional description for the section, which will be displayed below the header. */
+  /** Optional description for the section, which will be displayed below the title. */
   description?: string;
 }[];
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -161,6 +161,8 @@ export type OPTION_TYPE = (typeof OPTION_TYPE)[keyof typeof OPTION_TYPE];
 export type RuleListSplitFunction = (rules: RuleNamesAndRules) => readonly {
   title?: string;
   rules: RuleNamesAndRules;
+  /** Optional description for the section, which will be displayed below the header. */
+  description?: string;
 }[];
 
 /**

--- a/test/lib/generate/__snapshots__/option-rule-list-split-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-rule-list-split-test.ts.snap
@@ -34,6 +34,46 @@ exports[`generate (--rule-list-split) > as a function > generates the documentat
 "
 `;
 
+exports[`generate (--rule-list-split) > as a function with description > generates the documentation 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+❌ Deprecated.
+
+| Name                           | ❌  |
+| :----------------------------- | :- |
+| [no-biz](docs/rules/no-biz.md) |    |
+
+### Not Deprecated
+
+These rules are not deprecated.
+
+| Name                           | ❌  |
+| :----------------------------- | :- |
+| [no-bar](docs/rules/no-bar.md) |    |
+| [no-baz](docs/rules/no-baz.md) |    |
+| [no-biz](docs/rules/no-biz.md) |    |
+
+### Deprecated
+
+These rules are deprecated.
+
+| Name                           | ❌  |
+| :----------------------------- | :- |
+| [no-foo](docs/rules/no-foo.md) | ❌  |
+
+### Name = "no-baz"
+
+This is the "no-baz" rule.
+
+| Name                           | ❌  |
+| :----------------------------- | :- |
+| [no-baz](docs/rules/no-baz.md) |    |
+
+<!-- end auto-generated rules list -->
+"
+`;
+
 exports[`generate (--rule-list-split) > by nested property meta.docs.category > splits the list 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->

--- a/test/lib/generate/option-rule-list-split-test.ts
+++ b/test/lib/generate/option-rule-list-split-test.ts
@@ -634,6 +634,63 @@ describe('generate (--rule-list-split)', function () {
     });
   });
 
+  describe('as a function with description', function () {
+    let fixture: FixtureContext;
+
+    beforeAll(async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'index.js': `
+          export default {
+            rules: {
+              'no-foo': { meta: { deprecated: true, }, create(context) {} },
+              'no-bar': { meta: { deprecated: false, }, create(context) {} },
+              'no-baz': { meta: { deprecated: false, }, create(context) {} },
+              'no-biz': { meta: { type: 'suggestion' }, create(context) {} },
+            },
+          };`,
+          'README.md': '## Rules\n',
+          'docs/rules/no-foo.md': '',
+          'docs/rules/no-bar.md': '',
+          'docs/rules/no-baz.md': '',
+          'docs/rules/no-biz.md': '',
+        },
+      });
+    });
+
+    afterAll(async function () {
+      await fixture.cleanup();
+    });
+
+    it('generates the documentation', async function () {
+      await generate(fixture.path, {
+        ruleListSplit: (rules) => {
+          const list1 = {
+            rules: rules.filter(([, rule]) => rule.meta.type === 'suggestion'),
+          };
+          const list2 = {
+            title: 'Not Deprecated',
+            rules: rules.filter(([, rule]) => !rule.meta.deprecated),
+            description: 'These rules are not deprecated.',
+          };
+          const list3 = {
+            title: 'Deprecated',
+            rules: rules.filter(([, rule]) => rule.meta.deprecated),
+            description: 'These rules are deprecated.',
+          };
+          const list4 = {
+            title: 'Name = "no-baz"',
+            rules: rules.filter(([name]) => name === 'no-baz'),
+            description: 'This is the "no-baz" rule.',
+          };
+          return [list1, list2, list3, list4];
+        },
+      });
+      expect(await fixture.readFile('README.md')).toMatchSnapshot();
+    });
+  });
+
   describe('as a function but invalid return value', function () {
     let fixture: FixtureContext;
 


### PR DESCRIPTION
 This change adds an optional `description` property to the `ruleListSplit` configuration.  If present, the description will be output for that rule list section, under the section header.

fixes #952