### PR TITLE
refactor: type RuleModule docs generic for requiresTypeChecking

### DIFF
--- a/lib/rule-doc-notices.ts
+++ b/lib/rule-doc-notices.ts
@@ -366,8 +366,7 @@ function getNoticesForRule(
 
     [NOTICE_TYPE.OPTIONS]: hasOptions(rule.meta?.schema),
     [NOTICE_TYPE.REQUIRES_TYPE_CHECKING]:
-      // @ts-expect-error -- TODO: requiresTypeChecking type not present
-      (rule.meta?.docs?.requiresTypeChecking as boolean | undefined) || false,
+      rule.meta?.docs?.requiresTypeChecking ?? false,
     [NOTICE_TYPE.TYPE]: Boolean(rule.meta?.type),
   };
 

--- a/lib/rule-list-columns.ts
+++ b/lib/rule-list-columns.ts
@@ -105,7 +105,6 @@ export function getColumns(
       hasOptions(rule.meta?.schema),
     ),
     [COLUMN_TYPE.REQUIRES_TYPE_CHECKING]: ruleNamesAndRules.some(
-      // @ts-expect-error -- TODO: requiresTypeChecking type not present
       ([, rule]) => rule.meta?.docs?.requiresTypeChecking,
     ),
     // Show type column only if we found at least one rule with a standard type.

--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -119,7 +119,6 @@ function buildRuleRow(
       return getLinkToRule(context, ruleName, pathToFile, false, false);
     },
     [COLUMN_TYPE.OPTIONS]: hasOptions(rule.meta?.schema) ? EMOJI_OPTIONS : '',
-    // @ts-expect-error -- TODO: requiresTypeChecking type not present
     [COLUMN_TYPE.REQUIRES_TYPE_CHECKING]: rule.meta?.docs?.requiresTypeChecking
       ? EMOJI_REQUIRES_TYPE_CHECKING
       : '',

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,7 +4,13 @@ import type { ConfigFormat } from './config-format.js';
 
 // Standard ESLint types.
 
-export type RuleModule = TSESLint.RuleModule<string, readonly unknown[]>;
+export type RuleModule = TSESLint.RuleModule<
+  string,
+  readonly unknown[],
+  // `requiresTypeChecking` is a common convention in the ESLint ecosystem but
+  // isn't part of the standard `RuleMetaDataDocs` type, so we augment it here.
+  { requiresTypeChecking?: boolean }
+>;
 
 export type Rules = TSESLint.Linter.RulesRecord;
 


### PR DESCRIPTION
## Summary

`meta.docs.requiresTypeChecking` is a common ESLint-ecosystem convention but isn't part of `@typescript-eslint/utils`' standard `RuleMetaDataDocs` type. We were working around that with three identical `@ts-expect-error` suppressions.

This passes `{ requiresTypeChecking?: boolean }` as the `Docs` generic to `TSESLint.RuleModule` (its third type parameter, which flows into `meta.docs`), so the property is properly typed in one place — removing all three suppressions.

### Changes
- `lib/types.ts` — augment the `RuleModule` `Docs` generic.
- `lib/rule-list.ts`, `lib/rule-list-columns.ts`, `lib/rule-doc-notices.ts` — drop the now-unnecessary `@ts-expect-error` comments (and a redundant `as boolean | undefined` cast).

## Test plan
- `npm run lint:types` passes.
- `eslint` passes on changed files.
- Full test suite green (350 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)