### PR TITLE
refactor: drop redundant .values() on Set spread

### DIFF
--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -226,14 +226,14 @@ function getRulesAndHeadersForSplit(
         unusedRules.map(([name]) =>
           getPropertyFromRule(context, name, ruleListSplitItem),
         ),
-      ).values(),
+      ),
     ];
     const valuesForThisPropertyFromAllRules = [
       ...new Set(
         ruleNamesAndRules.map(([name]) =>
           getPropertyFromRule(context, name, ruleListSplitItem),
         ),
-      ).values(),
+      ),
     ];
 
     // Throw an exception if there are no possible rules with this split property.


### PR DESCRIPTION
## Summary

A `Set` is directly iterable, so spreading it (`[...new Set(...)]`) already yields its values. The trailing `.values()` in two spots in `lib/rule-list.ts` is redundant.

## Test plan
- `npm run lint:types` passes.
- `eslint` passes on the changed file.
- Full test suite green (350 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)