### PR TITLE
refactor: use string replaceAll for EOL instead of dynamic RegExp

### DIFF
--- a/lib/string.ts
+++ b/lib/string.ts
@@ -24,9 +24,7 @@ export function capitalizeOnlyFirstLetter(str: string) {
 function sanitizeMarkdownTableCell(context: Context, text: string): string {
   const { endOfLine } = context;
 
-  return text
-    .replaceAll('|', String.raw`\|`)
-    .replaceAll(new RegExp(endOfLine, 'gu'), '<br/>');
+  return text.replaceAll('|', String.raw`\|`).replaceAll(endOfLine, '<br/>');
 }
 
 export function sanitizeMarkdownTable(


### PR DESCRIPTION
## Summary

In `sanitizeMarkdownTableCell`, `endOfLine` is always the literal `'\n'` or `'\r\n'`. Building a global `RegExp` from it (`new RegExp(endOfLine, 'gu')`) is unnecessary — `String.prototype.replaceAll` with a string argument already replaces every occurrence (and avoids treating the string as a pattern).

## Test plan
- `npm run lint:types` passes.
- `eslint` passes on the changed file.
- Full test suite green (350 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)