### PR TITLE
refactor: consolidate first-letter capitalization in string.ts

### DIFF
--- a/lib/string.ts
+++ b/lib/string.ts
@@ -1,9 +1,13 @@
 import type { Context } from './context.js';
 
+/** Uppercase the first character of a string, leaving the rest unchanged. */
+function upperFirst(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
 export function toSentenceCase(str: string) {
-  return str.replace(/^\w/u, function (txt) {
-    return txt.charAt(0).toUpperCase() + txt.slice(1).toLowerCase();
-  });
+  // Only uppercase a leading word character, leaving the rest of the string as-is.
+  return str.replace(/^\w/u, (char) => char.toUpperCase());
 }
 
 export function addTrailingPeriod(str: string) {
@@ -18,7 +22,7 @@ export function removeTrailingPeriod(str: string) {
  * Example: FOO => Foo, foo => Foo
  */
 export function capitalizeOnlyFirstLetter(str: string) {
-  return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
+  return upperFirst(str.toLowerCase());
 }
 
 function sanitizeMarkdownTableCell(context: Context, text: string): string {


### PR DESCRIPTION
## Summary

`toSentenceCase` and `capitalizeOnlyFirstLetter` both reimplemented the `str.charAt(0).toUpperCase() + str.slice(1)…` pattern. This extracts a shared private `upperFirst` helper and:

- **`capitalizeOnlyFirstLetter`** → `upperFirst(str.toLowerCase())` (uppercase first, lowercase the rest — unchanged).
- **`toSentenceCase`** → drops the dead `.slice(1).toLowerCase()`. Its `/^\w/u` regex only ever matches a single character, so `slice(1)` was always `''`; the function still uppercases just the leading word character and preserves the rest of the string.

Note: the two functions intentionally keep their differing semantics (`toSentenceCase` preserves tail casing and only touches a leading ASCII word char; `capitalizeOnlyFirstLetter` lowercases the tail). No behavior change.

## Test plan
- `npm run lint:types` passes.
- `eslint` passes on the changed file.
- Existing `string-test.ts` cases for `toSentenceCase` still pass; full suite green (350 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)