### PR TITLE
refactor: replace custom fixture copyDir with fs.cp

### DIFF
--- a/test/helpers/fixture.ts
+++ b/test/helpers/fixture.ts
@@ -1,34 +1,10 @@
-import {
-  copyFile,
-  mkdir,
-  mkdtemp,
-  readdir,
-  readFile,
-  rm,
-  stat,
-  writeFile,
-} from 'node:fs/promises';
+import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURES_DIR = join(__dirname, '..', 'fixtures');
-
-// TODO: Replace with `cp` from 'node:fs/promises' when minimum Node.js version is 22.3.0+
-/** Recursively copy a directory (using stable Node.js APIs) */
-async function copyDir(src: string, dest: string): Promise<void> {
-  await mkdir(dest, { recursive: true });
-  const entries = await readdir(src);
-  for (const entry of entries) {
-    const srcPath = join(src, entry);
-    const destPath = join(dest, entry);
-    const stats = await stat(srcPath);
-    await (stats.isDirectory()
-      ? copyDir(srcPath, destPath)
-      : copyFile(srcPath, destPath));
-  }
-}
 
 export interface SetupFixtureOptions {
   /** Name of the fixture directory in test/fixtures/ (e.g., 'esm-base') */
@@ -60,7 +36,7 @@ export async function setupFixture(
   const tempDir = await mkdtemp(join(tmpdir(), 'eslint-doc-generator-test-'));
 
   // Copy the fixture to temp directory
-  await copyDir(sourceDir, tempDir);
+  await cp(sourceDir, tempDir, { recursive: true });
 
   // Apply any overrides
   if (overrides) {


### PR DESCRIPTION
## Summary

- Replace the hand-rolled recursive `copyDir` helper in test fixtures with Node's built-in `fs.promises.cp`
- Engines already require Node `^20.19.0 || ^22.13.0 || >=24.0.0`, so the stale TODO targeting Node 22.3+ no longer applies

## Test plan

- [x] Sample fixture-using tests pass (`general-test`, `package-json-test`, `cli-test` — 27 tests)
- [ ] CI green on Node 20/22/24

Made with [Cursor](https://cursor.com)