### PR TITLE
refactor: replace sinon with vitest mocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
       "devDependencies": {
         "@eslint/js": "^10.0.0",
         "@types/node": "^25.0.3",
-        "@types/sinon": "^21.0.0",
         "@typescript/native-preview": "^7.0.0-dev.20260102.1",
         "@vitest/coverage-istanbul": "^4.0.16",
         "@vitest/eslint-plugin": "^1.6.9",
@@ -46,7 +45,6 @@
         "npm-run-all": "^4.1.5",
         "outdent": "^0.8.0",
         "prettier": "^3.4.2",
-        "sinon": "^21.0.0",
         "sort-package-json": "^3.0.0",
         "typescript": "^6.0.2",
         "typescript-eslint": "^8.55.1-alpha.4",
@@ -1453,47 +1451,6 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
-    "node_modules/@sinonjs/commons": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
-      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/fake-timers": {
-      "version": "15.3.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
-      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1"
-      }
-    },
-    "node_modules/@sinonjs/samsam": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-10.0.2.tgz",
-      "integrity": "sha512-8lVwD1Df1BmzoaOLhMcGGcz/Jyr5QY2KSB75/YK1QgKzoabTeLdIVyhXNZK9ojfSKSdirbXqdbsXXqP9/Ve8+A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1",
-        "type-detect": "^4.1.0"
-      }
-    },
-    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1592,23 +1549,6 @@
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/sinon": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-21.0.1.tgz",
-      "integrity": "sha512-5yoJSqLbjH8T9V2bksgRayuhpZy+723/z6wBOR+Soe4ZlXC0eW8Na71TeaZPUWDQvM7LYKa9UGFc6LRqxiR5fQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/sinonjs__fake-timers": "*"
-      }
-    },
-    "node_modules/@types/sinonjs__fake-timers": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
-      "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
       "dev": true,
       "license": "MIT"
     },
@@ -3222,16 +3162,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/dir-glob": {
@@ -8000,23 +7930,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/sinon": {
-      "version": "21.1.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-21.1.2.tgz",
-      "integrity": "sha512-FS6mN+/bx7e2ajpXkEmOcWB6xBzWiuNoAQT18/+a20SS4U7FSYl8Ms7N6VTUxN/1JAjkx7aXp+THMC8xdpp0gA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1",
-        "@sinonjs/fake-timers": "^15.3.2",
-        "@sinonjs/samsam": "^10.0.2",
-        "diff": "^8.0.4"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/sinon"
-      }
-    },
     "node_modules/skin-tone": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
@@ -8611,16 +8524,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
   "devDependencies": {
     "@eslint/js": "^10.0.0",
     "@types/node": "^25.0.3",
-    "@types/sinon": "^21.0.0",
     "@typescript/native-preview": "^7.0.0-dev.20260102.1",
     "@vitest/coverage-istanbul": "^4.0.16",
     "@vitest/eslint-plugin": "^1.6.9",
@@ -78,7 +77,6 @@
     "npm-run-all": "^4.1.5",
     "outdent": "^0.8.0",
     "prettier": "^3.4.2",
-    "sinon": "^21.0.0",
     "sort-package-json": "^3.0.0",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.55.1-alpha.4",

--- a/test/fixtures/cjs-config-extends/README.md
+++ b/test/fixtures/cjs-config-extends/README.md
@@ -7,8 +7,8 @@
 💼 Configurations enabled in.\
 ✅ Set in the `recommended` configuration.
 
-| Name                           | Description            | 💼  |
-| :----------------------------- | :--------------------- | :-- |
+| Name                           | Description            | 💼 |
+| :----------------------------- | :--------------------- | :- |
 | [no-bar](docs/rules/no-bar.md) | Description of no-bar. | ✅  |
 | [no-baz](docs/rules/no-baz.md) | Description of no-baz. | ✅  |
 | [no-biz](docs/rules/no-biz.md) | Description of no-biz. | ✅  |

--- a/test/fixtures/cjs-config-extends/README.md
+++ b/test/fixtures/cjs-config-extends/README.md
@@ -7,8 +7,8 @@
 💼 Configurations enabled in.\
 ✅ Set in the `recommended` configuration.
 
-| Name                           | Description            | 💼 |
-| :----------------------------- | :--------------------- | :- |
+| Name                           | Description            | 💼  |
+| :----------------------------- | :--------------------- | :-- |
 | [no-bar](docs/rules/no-bar.md) | Description of no-bar. | ✅  |
 | [no-baz](docs/rules/no-baz.md) | Description of no-baz. | ✅  |
 | [no-biz](docs/rules/no-biz.md) | Description of no-biz. | ✅  |

--- a/test/lib/cli-test.ts
+++ b/test/lib/cli-test.ts
@@ -1,4 +1,3 @@
-import * as sinon from 'sinon';
 import { run } from '../../lib/cli.js';
 import { OPTION_TYPE } from '../../lib/types.js';
 import { type FixtureContext, setupFixture } from '../helpers/fixture.js';
@@ -122,7 +121,7 @@ const cliOptionsAll: { [key in OPTION_TYPE]: readonly string[] } = {
 describe('cli', () => {
   describe('no options', () => {
     it('is called correctly', async () => {
-      const stub = sinon.stub().resolves();
+      const stub = vi.fn().mockResolvedValue(undefined);
       await run(
         [
           'node', // Path to node.
@@ -130,14 +129,14 @@ describe('cli', () => {
         ],
         stub,
       );
-      expect(stub.callCount).toBe(1);
-      expect(stub.firstCall.args).toMatchSnapshot();
+      expect(stub.mock.calls.length).toBe(1);
+      expect(stub.mock.calls[0]).toMatchSnapshot();
     });
   });
 
   describe('all CLI options, no config file options', () => {
     it('is called correctly', async () => {
-      const stub = sinon.stub().resolves();
+      const stub = vi.fn().mockResolvedValue(undefined);
       await run(
         [
           'node', // Path to node.
@@ -147,8 +146,8 @@ describe('cli', () => {
         ],
         stub,
       );
-      expect(stub.callCount).toBe(1);
-      expect(stub.firstCall.args).toMatchSnapshot();
+      expect(stub.mock.calls.length).toBe(1);
+      expect(stub.mock.calls[0]).toMatchSnapshot();
     });
   });
 
@@ -179,7 +178,7 @@ describe('cli', () => {
     });
 
     it('is called correctly', async () => {
-      const stub = sinon.stub().resolves();
+      const stub = vi.fn().mockResolvedValue(undefined);
       await run(
         [
           'node', // Path to node.
@@ -187,8 +186,8 @@ describe('cli', () => {
         ],
         stub,
       );
-      expect(stub.callCount).toBe(1);
-      expect(stub.firstCall.args).toMatchSnapshot();
+      expect(stub.mock.calls.length).toBe(1);
+      expect(stub.mock.calls[0]).toMatchSnapshot();
     });
   });
 
@@ -219,7 +218,7 @@ describe('cli', () => {
     });
 
     it('merges correctly, with CLI options taking precedence', async () => {
-      const stub = sinon.stub().resolves();
+      const stub = vi.fn().mockResolvedValue(undefined);
       await run(
         [
           'node', // Path to node.
@@ -229,8 +228,8 @@ describe('cli', () => {
         ],
         stub,
       );
-      expect(stub.callCount).toBe(1);
-      expect(stub.firstCall.args).toMatchSnapshot();
+      expect(stub.mock.calls.length).toBe(1);
+      expect(stub.mock.calls[0]).toMatchSnapshot();
     });
   });
 
@@ -263,7 +262,7 @@ describe('cli', () => {
     });
 
     it('merges correctly', async () => {
-      const stub = sinon.stub().resolves();
+      const stub = vi.fn().mockResolvedValue(undefined);
       await run(
         [
           'node', // Path to node.
@@ -276,14 +275,14 @@ describe('cli', () => {
         ],
         stub,
       );
-      expect(stub.callCount).toBe(1);
-      expect(stub.firstCall.args).toMatchSnapshot();
+      expect(stub.mock.calls.length).toBe(1);
+      expect(stub.mock.calls[0]).toMatchSnapshot();
     });
   });
 
   describe('boolean option - false (explicit)', () => {
     it('is called correctly', async () => {
-      const stub = sinon.stub().resolves();
+      const stub = vi.fn().mockResolvedValue(undefined);
       await run(
         [
           'node', // Path to node.
@@ -294,14 +293,14 @@ describe('cli', () => {
         ],
         stub,
       );
-      expect(stub.callCount).toBe(1);
-      expect(stub.firstCall.args).toMatchSnapshot();
+      expect(stub.mock.calls.length).toBe(1);
+      expect(stub.mock.calls[0]).toMatchSnapshot();
     });
   });
 
   describe('boolean option - true (explicit)', () => {
     it('is called correctly', async () => {
-      const stub = sinon.stub().resolves();
+      const stub = vi.fn().mockResolvedValue(undefined);
       await run(
         [
           'node', // Path to node.
@@ -312,14 +311,14 @@ describe('cli', () => {
         ],
         stub,
       );
-      expect(stub.callCount).toBe(1);
-      expect(stub.firstCall.args).toMatchSnapshot();
+      expect(stub.mock.calls.length).toBe(1);
+      expect(stub.mock.calls[0]).toMatchSnapshot();
     });
   });
 
   describe('boolean option - true (implicit)', () => {
     it('is called correctly', async () => {
-      const stub = sinon.stub().resolves();
+      const stub = vi.fn().mockResolvedValue(undefined);
       await run(
         [
           'node', // Path to node.
@@ -329,8 +328,8 @@ describe('cli', () => {
         ],
         stub,
       );
-      expect(stub.callCount).toBe(1);
-      expect(stub.firstCall.args).toMatchSnapshot();
+      expect(stub.mock.calls.length).toBe(1);
+      expect(stub.mock.calls[0]).toMatchSnapshot();
     });
   });
 
@@ -369,7 +368,7 @@ describe('cli', () => {
       });
 
       it('throws an error', async () => {
-        const stub = sinon.stub().resolves();
+        const stub = vi.fn().mockResolvedValue(undefined);
         await expect(
           run(
             [
@@ -412,7 +411,7 @@ describe('cli', () => {
       });
 
       it('requires that postprocess be a function', async () => {
-        const stub = sinon.stub().resolves();
+        const stub = vi.fn().mockResolvedValue(undefined);
         await expect(
           run(
             [
@@ -455,7 +454,7 @@ describe('cli', () => {
       });
 
       it('throws an error', async () => {
-        const stub = sinon.stub().resolves();
+        const stub = vi.fn().mockResolvedValue(undefined);
         await expect(
           run(
             [
@@ -500,7 +499,7 @@ describe('cli', () => {
       });
 
       it('throws an error', async () => {
-        const stub = sinon.stub().resolves();
+        const stub = vi.fn().mockResolvedValue(undefined);
         await expect(
           run(
             [
@@ -545,7 +544,7 @@ describe('cli', () => {
       });
 
       it('throws an error', async () => {
-        const stub = sinon.stub().resolves();
+        const stub = vi.fn().mockResolvedValue(undefined);
         await expect(
           run(
             [

--- a/test/lib/generate/option-check-test.ts
+++ b/test/lib/generate/option-check-test.ts
@@ -1,7 +1,6 @@
 import { generate } from '../../../lib/generator.js';
 import { join } from 'node:path';
 import { setupFixture, type FixtureContext } from '../../helpers/fixture.js';
-import * as sinon from 'sinon';
 
 describe('generate (--check)', function () {
   describe('basic', function () {
@@ -28,23 +27,25 @@ describe('generate (--check)', function () {
     });
 
     it('prints the issues, exits with failure, and does not write changes', async function () {
-      const consoleErrorStub = sinon.stub(console, 'error');
+      const consoleErrorStub = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
       await generate(fixture.path, { check: true });
-      expect(consoleErrorStub.callCount).toBe(4);
+      expect(consoleErrorStub.mock.calls.length).toBe(4);
       // Use join to handle both Windows and Unix paths.
-      expect(consoleErrorStub.firstCall.args).toStrictEqual([
+      expect(consoleErrorStub.mock.calls[0]).toStrictEqual([
         `Please run eslint-doc-generator. A rule doc is out-of-date: ${join(
           'docs',
           'rules',
           'no-foo.md',
         )}`,
       ]);
-      expect(consoleErrorStub.secondCall.args).toMatchSnapshot(); // Diff
-      expect(consoleErrorStub.thirdCall.args).toStrictEqual([
+      expect(consoleErrorStub.mock.calls[1]).toMatchSnapshot(); // Diff
+      expect(consoleErrorStub.mock.calls[2]).toStrictEqual([
         'Please run eslint-doc-generator. The rules table in README.md is out-of-date.',
       ]);
-      expect(consoleErrorStub.getCall(3).args).toMatchSnapshot(); // Diff
-      consoleErrorStub.restore();
+      expect(consoleErrorStub.mock.calls[3]).toMatchSnapshot(); // Diff
+      consoleErrorStub.mockRestore();
 
       expect(await fixture.readFile('README.md')).toMatchSnapshot();
       expect(await fixture.readFile('docs/rules/no-foo.md')).toMatchSnapshot();

--- a/test/lib/generate/option-rule-doc-section-test.ts
+++ b/test/lib/generate/option-rule-doc-section-test.ts
@@ -1,6 +1,5 @@
 import { generate } from '../../../lib/generator.js';
 import { setupFixture, type FixtureContext } from '../../helpers/fixture.js';
-import * as sinon from 'sinon';
 
 describe('generate (rule doc sections)', function () {
   describe('with `--rule-doc-section-include` and `--rule-doc-section-exclude` and no problems', function () {
@@ -60,19 +59,21 @@ describe('generate (rule doc sections)', function () {
     });
 
     it('prints errors', async function () {
-      const consoleErrorStub = sinon.stub(console, 'error');
+      const consoleErrorStub = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
       await generate(fixture.path, {
         ruleDocSectionInclude: ['Examples'],
         ruleDocSectionExclude: ['Unwanted Section'],
       });
-      expect(consoleErrorStub.callCount).toBe(2);
-      expect(consoleErrorStub.firstCall.args).toStrictEqual([
+      expect(consoleErrorStub.mock.calls.length).toBe(2);
+      expect(consoleErrorStub.mock.calls[0]).toStrictEqual([
         '`no-foo` rule doc should have included the header: Examples',
       ]);
-      expect(consoleErrorStub.secondCall.args).toStrictEqual([
+      expect(consoleErrorStub.mock.calls[1]).toStrictEqual([
         '`no-foo` rule doc should not have included the header: Unwanted Section',
       ]);
-      consoleErrorStub.restore();
+      consoleErrorStub.mockRestore();
     });
   });
 });

--- a/test/lib/generate/option-suggest-emojis-test.ts
+++ b/test/lib/generate/option-suggest-emojis-test.ts
@@ -79,8 +79,20 @@ function createTextFetchResponse(
   };
 }
 
-function stubFetch() {
-  return vi.spyOn(globalThis, 'fetch');
+interface FetchStub {
+  (...args: unknown[]): Promise<MockFetchResponse>;
+  mock: { calls: unknown[][] };
+  mockResolvedValue: (value: MockFetchResponse) => FetchStub;
+  mockResolvedValueOnce: (value: MockFetchResponse) => FetchStub;
+  mockRejectedValue: (value: unknown) => FetchStub;
+  mockRejectedValueOnce: (value: unknown) => FetchStub;
+  mockImplementation: (
+    fn: (...args: unknown[]) => Promise<MockFetchResponse>,
+  ) => FetchStub;
+}
+
+function stubFetch(): FetchStub {
+  return vi.spyOn(globalThis, 'fetch') as unknown as FetchStub;
 }
 
 async function withTempFixture(
@@ -174,7 +186,7 @@ describe('generate (--suggest-emojis)', function () {
 
     expect(fetchStub.mock.calls.length).toBe(0);
     expect(consoleLogStub.mock.calls.length).toBe(1);
-    const output = String(consoleLogStub.mock.calls[0][0]);
+    const output = String(consoleLogStub.mock.calls[0]![0]);
     expect(output).toContain('Config');
     expect(output).toContain('Emoji');
     const suggestions = parseSuggestionTable(output);
@@ -194,7 +206,7 @@ describe('generate (--suggest-emojis)', function () {
       configEmoji: [['recommended', '🧪']],
     });
 
-    const output = String(consoleLogStub.mock.calls[0][0]);
+    const output = String(consoleLogStub.mock.calls[0]![0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('recommended')).toBe('✅');
     expect(suggestions.get('recommended')).not.toBe('🧪');
@@ -228,10 +240,10 @@ describe('generate (--suggest-emojis)', function () {
     });
 
     expect(fetchStub.mock.calls.length).toBe(1);
-    expect(fetchStub.mock.calls[0][0]).toBe(
+    expect(fetchStub.mock.calls[0]![0]).toBe(
       'https://api.openai.com/v1/chat/completions',
     );
-    const requestInit = fetchStub.mock.calls[0][1];
+    const requestInit = fetchStub.mock.calls[0]![1];
     expect(requestInit).toBeTruthy();
     expect(requestInit).toBeTypeOf('object');
     if (
@@ -252,7 +264,7 @@ describe('generate (--suggest-emojis)', function () {
     expect(requestBody.model).toBe('gpt-5.2');
     expect(requestBody.response_format).toStrictEqual({ type: 'json_object' });
 
-    const output = String(consoleLogStub.mock.calls[0][0]);
+    const output = String(consoleLogStub.mock.calls[0]![0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).toBe('🧠');
   });
@@ -284,10 +296,10 @@ describe('generate (--suggest-emojis)', function () {
     });
 
     expect(fetchStub.mock.calls.length).toBe(1);
-    expect(fetchStub.mock.calls[0][0]).toBe(
+    expect(fetchStub.mock.calls[0]![0]).toBe(
       'https://api.groq.com/openai/v1/chat/completions',
     );
-    const requestInit = fetchStub.mock.calls[0][1];
+    const requestInit = fetchStub.mock.calls[0]![1];
     expect(requestInit).toBeTruthy();
     expect(requestInit).toBeTypeOf('object');
     if (
@@ -308,7 +320,7 @@ describe('generate (--suggest-emojis)', function () {
     expect(requestBody.model).toBe('llama-3.3-70b-versatile');
     expect(requestBody.response_format).toStrictEqual({ type: 'json_object' });
 
-    const output = String(consoleLogStub.mock.calls[0][0]);
+    const output = String(consoleLogStub.mock.calls[0]![0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).toBe('🛰️');
   });
@@ -340,10 +352,10 @@ describe('generate (--suggest-emojis)', function () {
     });
 
     expect(fetchStub.mock.calls.length).toBe(1);
-    expect(fetchStub.mock.calls[0][0]).toBe(
+    expect(fetchStub.mock.calls[0]![0]).toBe(
       'https://ai-gateway.vercel.sh/v1/chat/completions',
     );
-    const requestInit = fetchStub.mock.calls[0][1];
+    const requestInit = fetchStub.mock.calls[0]![1];
     expect(requestInit).toBeTruthy();
     expect(requestInit).toBeTypeOf('object');
     if (
@@ -364,7 +376,7 @@ describe('generate (--suggest-emojis)', function () {
     expect(requestBody.model).toBe('openai/gpt-5.2');
     expect(requestBody.response_format).toStrictEqual({ type: 'json' });
 
-    const output = String(consoleLogStub.mock.calls[0][0]);
+    const output = String(consoleLogStub.mock.calls[0]![0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).toBe('🌐');
   });
@@ -396,10 +408,10 @@ describe('generate (--suggest-emojis)', function () {
     });
 
     expect(fetchStub.mock.calls.length).toBe(1);
-    expect(fetchStub.mock.calls[0][0]).toBe(
+    expect(fetchStub.mock.calls[0]![0]).toBe(
       'https://openrouter.ai/api/v1/chat/completions',
     );
-    const requestInit = fetchStub.mock.calls[0][1];
+    const requestInit = fetchStub.mock.calls[0]![1];
     expect(requestInit).toBeTruthy();
     expect(requestInit).toBeTypeOf('object');
     if (
@@ -420,7 +432,7 @@ describe('generate (--suggest-emojis)', function () {
     expect(requestBody.model).toBe('openai/gpt-5.2');
     expect(requestBody.response_format).toStrictEqual({ type: 'json_object' });
 
-    const output = String(consoleLogStub.mock.calls[0][0]);
+    const output = String(consoleLogStub.mock.calls[0]![0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).toBe('🪐');
   });
@@ -452,10 +464,10 @@ describe('generate (--suggest-emojis)', function () {
     });
 
     expect(fetchStub.mock.calls.length).toBe(1);
-    expect(fetchStub.mock.calls[0][0]).toBe(
+    expect(fetchStub.mock.calls[0]![0]).toBe(
       'https://api.together.xyz/v1/chat/completions',
     );
-    const requestInit = fetchStub.mock.calls[0][1];
+    const requestInit = fetchStub.mock.calls[0]![1];
     expect(requestInit).toBeTruthy();
     expect(requestInit).toBeTypeOf('object');
     if (
@@ -476,7 +488,7 @@ describe('generate (--suggest-emojis)', function () {
     expect(requestBody.model).toBe('openai/gpt-oss-20b');
     expect(requestBody.response_format).toStrictEqual({ type: 'json_object' });
 
-    const output = String(consoleLogStub.mock.calls[0][0]);
+    const output = String(consoleLogStub.mock.calls[0]![0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).toBe('🧩');
   });
@@ -508,10 +520,10 @@ describe('generate (--suggest-emojis)', function () {
     });
 
     expect(fetchStub.mock.calls.length).toBe(1);
-    expect(fetchStub.mock.calls[0][0]).toBe(
+    expect(fetchStub.mock.calls[0]![0]).toBe(
       'https://api.x.ai/v1/chat/completions',
     );
-    const requestInit = fetchStub.mock.calls[0][1];
+    const requestInit = fetchStub.mock.calls[0]![1];
     expect(requestInit).toBeTruthy();
     expect(requestInit).toBeTypeOf('object');
     if (
@@ -532,7 +544,7 @@ describe('generate (--suggest-emojis)', function () {
     expect(requestBody.model).toBe('grok-4-1-fast-reasoning');
     expect(requestBody.response_format).toStrictEqual({ type: 'json_object' });
 
-    const output = String(consoleLogStub.mock.calls[0][0]);
+    const output = String(consoleLogStub.mock.calls[0]![0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).toBe('🛰️');
   });
@@ -563,10 +575,10 @@ describe('generate (--suggest-emojis)', function () {
     });
 
     expect(fetchStub.mock.calls.length).toBe(1);
-    expect(fetchStub.mock.calls[0][0]).toBe(
+    expect(fetchStub.mock.calls[0]![0]).toBe(
       'https://api.anthropic.com/v1/messages',
     );
-    const requestInit = fetchStub.mock.calls[0][1];
+    const requestInit = fetchStub.mock.calls[0]![1];
     expect(requestInit).toBeTruthy();
     expect(requestInit).toBeTypeOf('object');
     if (
@@ -583,7 +595,7 @@ describe('generate (--suggest-emojis)', function () {
     const requestBody = JSON.parse(requestInit.body) as { model?: string };
     expect(requestBody.model).toBe('claude-sonnet-4-6');
 
-    const output = String(consoleLogStub.mock.calls[0][0]);
+    const output = String(consoleLogStub.mock.calls[0]![0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).toBe('🦾');
   });
@@ -1029,7 +1041,7 @@ describe('generate (--suggest-emojis)', function () {
       aiProvider: 'openai',
     });
 
-    const output = String(consoleLogStub.mock.calls[0][0]);
+    const output = String(consoleLogStub.mock.calls[0]![0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).not.toBe('💼');
     expect(suggestions.get('zzzz-one')).toBeTruthy();
@@ -1065,7 +1077,7 @@ describe('generate (--suggest-emojis)', function () {
       aiProvider: 'openai',
     });
 
-    const output = String(consoleLogStub.mock.calls[0][0]);
+    const output = String(consoleLogStub.mock.calls[0]![0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).toBe('🚀');
     expect(suggestions.get('zzzz-one')).toBeTruthy();
@@ -1114,7 +1126,7 @@ describe('generate (--suggest-emojis)', function () {
 
         expect(fetchStub.mock.calls.length).toBe(1);
         expect(consoleLogStub.mock.calls.length).toBe(1);
-        const output = String(consoleLogStub.mock.calls[0][0]);
+        const output = String(consoleLogStub.mock.calls[0]![0]);
         const suggestions = parseSuggestionTable(output);
         expect(suggestions.get('recommended')).toBe('🧠');
       },
@@ -1165,7 +1177,7 @@ describe('generate (--suggest-emojis)', function () {
           configEmoji: [['recommended']],
         });
 
-        const output = String(consoleLogStub.mock.calls[0][0]);
+        const output = String(consoleLogStub.mock.calls[0]![0]);
         const suggestions = parseSuggestionTable(output);
         expect(suggestions.get('recommended')).toBe('✅');
         expect(suggestions.has('react-native')).toBe(true);
@@ -1204,7 +1216,7 @@ describe('generate (--suggest-emojis)', function () {
       aiProvider: 'openai',
     });
 
-    const output = String(consoleLogStub.mock.calls[0][0]);
+    const output = String(consoleLogStub.mock.calls[0]![0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).not.toBe('123');
     expect(suggestions.get('zzzz-one')).not.toBe('abc123');
@@ -1249,7 +1261,7 @@ describe('generate (--suggest-emojis)', function () {
           configEmoji: [['typescript']],
         });
 
-        const output = String(consoleLogStub.mock.calls[0][0]);
+        const output = String(consoleLogStub.mock.calls[0]![0]);
         const suggestions = parseSuggestionTable(output);
         expect(suggestions.get('typescript')).toBe('⌨️');
       },
@@ -1279,7 +1291,7 @@ describe('generate (--suggest-emojis)', function () {
           .mockImplementation(() => {});
         await generate(tempFixture.path, { suggestEmojis: true });
 
-        const output = String(consoleLogStub.mock.calls[0][0]);
+        const output = String(consoleLogStub.mock.calls[0]![0]);
         const suggestions = parseSuggestionTable(output);
         expect(suggestions.has('qzxqzx-1')).toBe(true);
         expect(suggestions.has('qzxqzx-22')).toBe(true);

--- a/test/lib/generate/option-suggest-emojis-test.ts
+++ b/test/lib/generate/option-suggest-emojis-test.ts
@@ -95,6 +95,17 @@ function stubFetch(): FetchStub {
   return vi.spyOn(globalThis, 'fetch') as unknown as FetchStub;
 }
 
+function getCallArgs(
+  stub: { mock: { calls: unknown[][] } },
+  callIndex = 0,
+): unknown[] {
+  const args = stub.mock.calls[callIndex];
+  if (!args) {
+    throw new Error(`Expected mock call at index ${String(callIndex)}`);
+  }
+  return args;
+}
+
 async function withTempFixture(
   indexContent: string,
   run: (fixture: FixtureContext) => Promise<void>,
@@ -186,7 +197,7 @@ describe('generate (--suggest-emojis)', function () {
 
     expect(fetchStub.mock.calls.length).toBe(0);
     expect(consoleLogStub.mock.calls.length).toBe(1);
-    const output = String(consoleLogStub.mock.calls[0]![0]);
+    const output = String(getCallArgs(consoleLogStub)[0]);
     expect(output).toContain('Config');
     expect(output).toContain('Emoji');
     const suggestions = parseSuggestionTable(output);
@@ -206,7 +217,7 @@ describe('generate (--suggest-emojis)', function () {
       configEmoji: [['recommended', '🧪']],
     });
 
-    const output = String(consoleLogStub.mock.calls[0]![0]);
+    const output = String(getCallArgs(consoleLogStub)[0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('recommended')).toBe('✅');
     expect(suggestions.get('recommended')).not.toBe('🧪');
@@ -240,10 +251,10 @@ describe('generate (--suggest-emojis)', function () {
     });
 
     expect(fetchStub.mock.calls.length).toBe(1);
-    expect(fetchStub.mock.calls[0]![0]).toBe(
+    expect(getCallArgs(fetchStub)[0]).toBe(
       'https://api.openai.com/v1/chat/completions',
     );
-    const requestInit = fetchStub.mock.calls[0]![1];
+    const requestInit = getCallArgs(fetchStub)[1];
     expect(requestInit).toBeTruthy();
     expect(requestInit).toBeTypeOf('object');
     if (
@@ -264,7 +275,7 @@ describe('generate (--suggest-emojis)', function () {
     expect(requestBody.model).toBe('gpt-5.2');
     expect(requestBody.response_format).toStrictEqual({ type: 'json_object' });
 
-    const output = String(consoleLogStub.mock.calls[0]![0]);
+    const output = String(getCallArgs(consoleLogStub)[0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).toBe('🧠');
   });
@@ -296,10 +307,10 @@ describe('generate (--suggest-emojis)', function () {
     });
 
     expect(fetchStub.mock.calls.length).toBe(1);
-    expect(fetchStub.mock.calls[0]![0]).toBe(
+    expect(getCallArgs(fetchStub)[0]).toBe(
       'https://api.groq.com/openai/v1/chat/completions',
     );
-    const requestInit = fetchStub.mock.calls[0]![1];
+    const requestInit = getCallArgs(fetchStub)[1];
     expect(requestInit).toBeTruthy();
     expect(requestInit).toBeTypeOf('object');
     if (
@@ -320,7 +331,7 @@ describe('generate (--suggest-emojis)', function () {
     expect(requestBody.model).toBe('llama-3.3-70b-versatile');
     expect(requestBody.response_format).toStrictEqual({ type: 'json_object' });
 
-    const output = String(consoleLogStub.mock.calls[0]![0]);
+    const output = String(getCallArgs(consoleLogStub)[0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).toBe('🛰️');
   });
@@ -352,10 +363,10 @@ describe('generate (--suggest-emojis)', function () {
     });
 
     expect(fetchStub.mock.calls.length).toBe(1);
-    expect(fetchStub.mock.calls[0]![0]).toBe(
+    expect(getCallArgs(fetchStub)[0]).toBe(
       'https://ai-gateway.vercel.sh/v1/chat/completions',
     );
-    const requestInit = fetchStub.mock.calls[0]![1];
+    const requestInit = getCallArgs(fetchStub)[1];
     expect(requestInit).toBeTruthy();
     expect(requestInit).toBeTypeOf('object');
     if (
@@ -376,7 +387,7 @@ describe('generate (--suggest-emojis)', function () {
     expect(requestBody.model).toBe('openai/gpt-5.2');
     expect(requestBody.response_format).toStrictEqual({ type: 'json' });
 
-    const output = String(consoleLogStub.mock.calls[0]![0]);
+    const output = String(getCallArgs(consoleLogStub)[0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).toBe('🌐');
   });
@@ -408,10 +419,10 @@ describe('generate (--suggest-emojis)', function () {
     });
 
     expect(fetchStub.mock.calls.length).toBe(1);
-    expect(fetchStub.mock.calls[0]![0]).toBe(
+    expect(getCallArgs(fetchStub)[0]).toBe(
       'https://openrouter.ai/api/v1/chat/completions',
     );
-    const requestInit = fetchStub.mock.calls[0]![1];
+    const requestInit = getCallArgs(fetchStub)[1];
     expect(requestInit).toBeTruthy();
     expect(requestInit).toBeTypeOf('object');
     if (
@@ -432,7 +443,7 @@ describe('generate (--suggest-emojis)', function () {
     expect(requestBody.model).toBe('openai/gpt-5.2');
     expect(requestBody.response_format).toStrictEqual({ type: 'json_object' });
 
-    const output = String(consoleLogStub.mock.calls[0]![0]);
+    const output = String(getCallArgs(consoleLogStub)[0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).toBe('🪐');
   });
@@ -464,10 +475,10 @@ describe('generate (--suggest-emojis)', function () {
     });
 
     expect(fetchStub.mock.calls.length).toBe(1);
-    expect(fetchStub.mock.calls[0]![0]).toBe(
+    expect(getCallArgs(fetchStub)[0]).toBe(
       'https://api.together.xyz/v1/chat/completions',
     );
-    const requestInit = fetchStub.mock.calls[0]![1];
+    const requestInit = getCallArgs(fetchStub)[1];
     expect(requestInit).toBeTruthy();
     expect(requestInit).toBeTypeOf('object');
     if (
@@ -488,7 +499,7 @@ describe('generate (--suggest-emojis)', function () {
     expect(requestBody.model).toBe('openai/gpt-oss-20b');
     expect(requestBody.response_format).toStrictEqual({ type: 'json_object' });
 
-    const output = String(consoleLogStub.mock.calls[0]![0]);
+    const output = String(getCallArgs(consoleLogStub)[0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).toBe('🧩');
   });
@@ -520,10 +531,10 @@ describe('generate (--suggest-emojis)', function () {
     });
 
     expect(fetchStub.mock.calls.length).toBe(1);
-    expect(fetchStub.mock.calls[0]![0]).toBe(
+    expect(getCallArgs(fetchStub)[0]).toBe(
       'https://api.x.ai/v1/chat/completions',
     );
-    const requestInit = fetchStub.mock.calls[0]![1];
+    const requestInit = getCallArgs(fetchStub)[1];
     expect(requestInit).toBeTruthy();
     expect(requestInit).toBeTypeOf('object');
     if (
@@ -544,7 +555,7 @@ describe('generate (--suggest-emojis)', function () {
     expect(requestBody.model).toBe('grok-4-1-fast-reasoning');
     expect(requestBody.response_format).toStrictEqual({ type: 'json_object' });
 
-    const output = String(consoleLogStub.mock.calls[0]![0]);
+    const output = String(getCallArgs(consoleLogStub)[0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).toBe('🛰️');
   });
@@ -575,10 +586,10 @@ describe('generate (--suggest-emojis)', function () {
     });
 
     expect(fetchStub.mock.calls.length).toBe(1);
-    expect(fetchStub.mock.calls[0]![0]).toBe(
+    expect(getCallArgs(fetchStub)[0]).toBe(
       'https://api.anthropic.com/v1/messages',
     );
-    const requestInit = fetchStub.mock.calls[0]![1];
+    const requestInit = getCallArgs(fetchStub)[1];
     expect(requestInit).toBeTruthy();
     expect(requestInit).toBeTypeOf('object');
     if (
@@ -595,7 +606,7 @@ describe('generate (--suggest-emojis)', function () {
     const requestBody = JSON.parse(requestInit.body) as { model?: string };
     expect(requestBody.model).toBe('claude-sonnet-4-6');
 
-    const output = String(consoleLogStub.mock.calls[0]![0]);
+    const output = String(getCallArgs(consoleLogStub)[0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).toBe('🦾');
   });
@@ -1041,7 +1052,7 @@ describe('generate (--suggest-emojis)', function () {
       aiProvider: 'openai',
     });
 
-    const output = String(consoleLogStub.mock.calls[0]![0]);
+    const output = String(getCallArgs(consoleLogStub)[0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).not.toBe('💼');
     expect(suggestions.get('zzzz-one')).toBeTruthy();
@@ -1077,7 +1088,7 @@ describe('generate (--suggest-emojis)', function () {
       aiProvider: 'openai',
     });
 
-    const output = String(consoleLogStub.mock.calls[0]![0]);
+    const output = String(getCallArgs(consoleLogStub)[0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).toBe('🚀');
     expect(suggestions.get('zzzz-one')).toBeTruthy();
@@ -1126,7 +1137,7 @@ describe('generate (--suggest-emojis)', function () {
 
         expect(fetchStub.mock.calls.length).toBe(1);
         expect(consoleLogStub.mock.calls.length).toBe(1);
-        const output = String(consoleLogStub.mock.calls[0]![0]);
+        const output = String(getCallArgs(consoleLogStub)[0]);
         const suggestions = parseSuggestionTable(output);
         expect(suggestions.get('recommended')).toBe('🧠');
       },
@@ -1177,7 +1188,7 @@ describe('generate (--suggest-emojis)', function () {
           configEmoji: [['recommended']],
         });
 
-        const output = String(consoleLogStub.mock.calls[0]![0]);
+        const output = String(getCallArgs(consoleLogStub)[0]);
         const suggestions = parseSuggestionTable(output);
         expect(suggestions.get('recommended')).toBe('✅');
         expect(suggestions.has('react-native')).toBe(true);
@@ -1216,7 +1227,7 @@ describe('generate (--suggest-emojis)', function () {
       aiProvider: 'openai',
     });
 
-    const output = String(consoleLogStub.mock.calls[0]![0]);
+    const output = String(getCallArgs(consoleLogStub)[0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).not.toBe('123');
     expect(suggestions.get('zzzz-one')).not.toBe('abc123');
@@ -1261,7 +1272,7 @@ describe('generate (--suggest-emojis)', function () {
           configEmoji: [['typescript']],
         });
 
-        const output = String(consoleLogStub.mock.calls[0]![0]);
+        const output = String(getCallArgs(consoleLogStub)[0]);
         const suggestions = parseSuggestionTable(output);
         expect(suggestions.get('typescript')).toBe('⌨️');
       },
@@ -1291,7 +1302,7 @@ describe('generate (--suggest-emojis)', function () {
           .mockImplementation(() => {});
         await generate(tempFixture.path, { suggestEmojis: true });
 
-        const output = String(consoleLogStub.mock.calls[0]![0]);
+        const output = String(getCallArgs(consoleLogStub)[0]);
         const suggestions = parseSuggestionTable(output);
         expect(suggestions.has('qzxqzx-1')).toBe(true);
         expect(suggestions.has('qzxqzx-22')).toBe(true);

--- a/test/lib/generate/option-suggest-emojis-test.ts
+++ b/test/lib/generate/option-suggest-emojis-test.ts
@@ -1,4 +1,3 @@
-import * as sinon from 'sinon';
 import { generate } from '../../../lib/generator.js';
 import { setupFixture, type FixtureContext } from '../../helpers/fixture.js';
 
@@ -80,12 +79,8 @@ function createTextFetchResponse(
   };
 }
 
-interface FetchStubTarget {
-  fetch: (...args: unknown[]) => Promise<MockFetchResponse>;
-}
-
 function stubFetch() {
-  return sinon.stub(globalThis as unknown as FetchStubTarget, 'fetch');
+  return vi.spyOn(globalThis, 'fetch');
 }
 
 async function withTempFixture(
@@ -155,7 +150,7 @@ describe('generate (--suggest-emojis)', function () {
   });
 
   afterEach(function () {
-    sinon.restore();
+    vi.restoreAllMocks();
     restoreProviderApiKeys();
   });
 
@@ -165,7 +160,9 @@ describe('generate (--suggest-emojis)', function () {
 
   it('prints a table of suggestions and does not write files in builtin mode', async function () {
     const readmeBefore = await fixture.readFile('README.md');
-    const consoleLogStub = sinon.stub(console, 'log');
+    const consoleLogStub = vi
+      .spyOn(console, 'log')
+      .mockImplementation(() => {});
     const fetchStub = stubFetch();
 
     restoreEnvVar('OPENAI_API_KEY', undefined);
@@ -175,9 +172,9 @@ describe('generate (--suggest-emojis)', function () {
     const readmeAfter = await fixture.readFile('README.md');
     expect(readmeAfter).toBe(readmeBefore);
 
-    expect(fetchStub.callCount).toBe(0);
-    expect(consoleLogStub.callCount).toBe(1);
-    const output = String(consoleLogStub.firstCall.args[0]);
+    expect(fetchStub.mock.calls.length).toBe(0);
+    expect(consoleLogStub.mock.calls.length).toBe(1);
+    const output = String(consoleLogStub.mock.calls[0][0]);
     expect(output).toContain('Config');
     expect(output).toContain('Emoji');
     const suggestions = parseSuggestionTable(output);
@@ -188,22 +185,26 @@ describe('generate (--suggest-emojis)', function () {
   });
 
   it('regenerates suggestions even when configEmoji already includes a config', async function () {
-    const consoleLogStub = sinon.stub(console, 'log');
+    const consoleLogStub = vi
+      .spyOn(console, 'log')
+      .mockImplementation(() => {});
 
     await generate(fixture.path, {
       suggestEmojis: true,
       configEmoji: [['recommended', '🧪']],
     });
 
-    const output = String(consoleLogStub.firstCall.args[0]);
+    const output = String(consoleLogStub.mock.calls[0][0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('recommended')).toBe('✅');
     expect(suggestions.get('recommended')).not.toBe('🧪');
   });
 
   it('uses OpenAI in ai mode with provider defaults and applies suggestions', async function () {
-    const consoleLogStub = sinon.stub(console, 'log');
-    const fetchStub = stubFetch().resolves(
+    const consoleLogStub = vi
+      .spyOn(console, 'log')
+      .mockImplementation(() => {});
+    const fetchStub = stubFetch().mockResolvedValue(
       createJsonFetchResponse({
         choices: [
           {
@@ -226,11 +227,11 @@ describe('generate (--suggest-emojis)', function () {
       aiProvider: 'openai',
     });
 
-    expect(fetchStub.callCount).toBe(1);
-    expect(fetchStub.firstCall.args[0]).toBe(
+    expect(fetchStub.mock.calls.length).toBe(1);
+    expect(fetchStub.mock.calls[0][0]).toBe(
       'https://api.openai.com/v1/chat/completions',
     );
-    const requestInit = fetchStub.firstCall.args[1];
+    const requestInit = fetchStub.mock.calls[0][1];
     expect(requestInit).toBeTruthy();
     expect(requestInit).toBeTypeOf('object');
     if (
@@ -251,14 +252,16 @@ describe('generate (--suggest-emojis)', function () {
     expect(requestBody.model).toBe('gpt-5.2');
     expect(requestBody.response_format).toStrictEqual({ type: 'json_object' });
 
-    const output = String(consoleLogStub.firstCall.args[0]);
+    const output = String(consoleLogStub.mock.calls[0][0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).toBe('🧠');
   });
 
   it('uses Groq in ai mode with provider defaults and applies suggestions', async function () {
-    const consoleLogStub = sinon.stub(console, 'log');
-    const fetchStub = stubFetch().resolves(
+    const consoleLogStub = vi
+      .spyOn(console, 'log')
+      .mockImplementation(() => {});
+    const fetchStub = stubFetch().mockResolvedValue(
       createJsonFetchResponse({
         choices: [
           {
@@ -280,11 +283,11 @@ describe('generate (--suggest-emojis)', function () {
       aiProvider: 'groq',
     });
 
-    expect(fetchStub.callCount).toBe(1);
-    expect(fetchStub.firstCall.args[0]).toBe(
+    expect(fetchStub.mock.calls.length).toBe(1);
+    expect(fetchStub.mock.calls[0][0]).toBe(
       'https://api.groq.com/openai/v1/chat/completions',
     );
-    const requestInit = fetchStub.firstCall.args[1];
+    const requestInit = fetchStub.mock.calls[0][1];
     expect(requestInit).toBeTruthy();
     expect(requestInit).toBeTypeOf('object');
     if (
@@ -305,14 +308,16 @@ describe('generate (--suggest-emojis)', function () {
     expect(requestBody.model).toBe('llama-3.3-70b-versatile');
     expect(requestBody.response_format).toStrictEqual({ type: 'json_object' });
 
-    const output = String(consoleLogStub.firstCall.args[0]);
+    const output = String(consoleLogStub.mock.calls[0][0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).toBe('🛰️');
   });
 
   it('uses Vercel AI Gateway in ai mode with provider defaults and applies suggestions', async function () {
-    const consoleLogStub = sinon.stub(console, 'log');
-    const fetchStub = stubFetch().resolves(
+    const consoleLogStub = vi
+      .spyOn(console, 'log')
+      .mockImplementation(() => {});
+    const fetchStub = stubFetch().mockResolvedValue(
       createJsonFetchResponse({
         choices: [
           {
@@ -334,11 +339,11 @@ describe('generate (--suggest-emojis)', function () {
       aiProvider: 'vercelaigateway',
     });
 
-    expect(fetchStub.callCount).toBe(1);
-    expect(fetchStub.firstCall.args[0]).toBe(
+    expect(fetchStub.mock.calls.length).toBe(1);
+    expect(fetchStub.mock.calls[0][0]).toBe(
       'https://ai-gateway.vercel.sh/v1/chat/completions',
     );
-    const requestInit = fetchStub.firstCall.args[1];
+    const requestInit = fetchStub.mock.calls[0][1];
     expect(requestInit).toBeTruthy();
     expect(requestInit).toBeTypeOf('object');
     if (
@@ -359,14 +364,16 @@ describe('generate (--suggest-emojis)', function () {
     expect(requestBody.model).toBe('openai/gpt-5.2');
     expect(requestBody.response_format).toStrictEqual({ type: 'json' });
 
-    const output = String(consoleLogStub.firstCall.args[0]);
+    const output = String(consoleLogStub.mock.calls[0][0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).toBe('🌐');
   });
 
   it('uses OpenRouter in ai mode with provider defaults and applies suggestions', async function () {
-    const consoleLogStub = sinon.stub(console, 'log');
-    const fetchStub = stubFetch().resolves(
+    const consoleLogStub = vi
+      .spyOn(console, 'log')
+      .mockImplementation(() => {});
+    const fetchStub = stubFetch().mockResolvedValue(
       createJsonFetchResponse({
         choices: [
           {
@@ -388,11 +395,11 @@ describe('generate (--suggest-emojis)', function () {
       aiProvider: 'openrouter',
     });
 
-    expect(fetchStub.callCount).toBe(1);
-    expect(fetchStub.firstCall.args[0]).toBe(
+    expect(fetchStub.mock.calls.length).toBe(1);
+    expect(fetchStub.mock.calls[0][0]).toBe(
       'https://openrouter.ai/api/v1/chat/completions',
     );
-    const requestInit = fetchStub.firstCall.args[1];
+    const requestInit = fetchStub.mock.calls[0][1];
     expect(requestInit).toBeTruthy();
     expect(requestInit).toBeTypeOf('object');
     if (
@@ -413,14 +420,16 @@ describe('generate (--suggest-emojis)', function () {
     expect(requestBody.model).toBe('openai/gpt-5.2');
     expect(requestBody.response_format).toStrictEqual({ type: 'json_object' });
 
-    const output = String(consoleLogStub.firstCall.args[0]);
+    const output = String(consoleLogStub.mock.calls[0][0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).toBe('🪐');
   });
 
   it('uses Together in ai mode with provider defaults and applies suggestions', async function () {
-    const consoleLogStub = sinon.stub(console, 'log');
-    const fetchStub = stubFetch().resolves(
+    const consoleLogStub = vi
+      .spyOn(console, 'log')
+      .mockImplementation(() => {});
+    const fetchStub = stubFetch().mockResolvedValue(
       createJsonFetchResponse({
         choices: [
           {
@@ -442,11 +451,11 @@ describe('generate (--suggest-emojis)', function () {
       aiProvider: 'together',
     });
 
-    expect(fetchStub.callCount).toBe(1);
-    expect(fetchStub.firstCall.args[0]).toBe(
+    expect(fetchStub.mock.calls.length).toBe(1);
+    expect(fetchStub.mock.calls[0][0]).toBe(
       'https://api.together.xyz/v1/chat/completions',
     );
-    const requestInit = fetchStub.firstCall.args[1];
+    const requestInit = fetchStub.mock.calls[0][1];
     expect(requestInit).toBeTruthy();
     expect(requestInit).toBeTypeOf('object');
     if (
@@ -467,14 +476,16 @@ describe('generate (--suggest-emojis)', function () {
     expect(requestBody.model).toBe('openai/gpt-oss-20b');
     expect(requestBody.response_format).toStrictEqual({ type: 'json_object' });
 
-    const output = String(consoleLogStub.firstCall.args[0]);
+    const output = String(consoleLogStub.mock.calls[0][0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).toBe('🧩');
   });
 
   it('uses xAI in ai mode with provider defaults and applies suggestions', async function () {
-    const consoleLogStub = sinon.stub(console, 'log');
-    const fetchStub = stubFetch().resolves(
+    const consoleLogStub = vi
+      .spyOn(console, 'log')
+      .mockImplementation(() => {});
+    const fetchStub = stubFetch().mockResolvedValue(
       createJsonFetchResponse({
         choices: [
           {
@@ -496,11 +507,11 @@ describe('generate (--suggest-emojis)', function () {
       aiProvider: 'xai',
     });
 
-    expect(fetchStub.callCount).toBe(1);
-    expect(fetchStub.firstCall.args[0]).toBe(
+    expect(fetchStub.mock.calls.length).toBe(1);
+    expect(fetchStub.mock.calls[0][0]).toBe(
       'https://api.x.ai/v1/chat/completions',
     );
-    const requestInit = fetchStub.firstCall.args[1];
+    const requestInit = fetchStub.mock.calls[0][1];
     expect(requestInit).toBeTruthy();
     expect(requestInit).toBeTypeOf('object');
     if (
@@ -521,14 +532,16 @@ describe('generate (--suggest-emojis)', function () {
     expect(requestBody.model).toBe('grok-4-1-fast-reasoning');
     expect(requestBody.response_format).toStrictEqual({ type: 'json_object' });
 
-    const output = String(consoleLogStub.firstCall.args[0]);
+    const output = String(consoleLogStub.mock.calls[0][0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).toBe('🛰️');
   });
 
   it('uses Anthropic automatically when exactly one provider API key is set', async function () {
-    const consoleLogStub = sinon.stub(console, 'log');
-    const fetchStub = stubFetch().resolves(
+    const consoleLogStub = vi
+      .spyOn(console, 'log')
+      .mockImplementation(() => {});
+    const fetchStub = stubFetch().mockResolvedValue(
       createJsonFetchResponse({
         content: [
           {
@@ -549,11 +562,11 @@ describe('generate (--suggest-emojis)', function () {
       ai: true,
     });
 
-    expect(fetchStub.callCount).toBe(1);
-    expect(fetchStub.firstCall.args[0]).toBe(
+    expect(fetchStub.mock.calls.length).toBe(1);
+    expect(fetchStub.mock.calls[0][0]).toBe(
       'https://api.anthropic.com/v1/messages',
     );
-    const requestInit = fetchStub.firstCall.args[1];
+    const requestInit = fetchStub.mock.calls[0][1];
     expect(requestInit).toBeTruthy();
     expect(requestInit).toBeTypeOf('object');
     if (
@@ -570,7 +583,7 @@ describe('generate (--suggest-emojis)', function () {
     const requestBody = JSON.parse(requestInit.body) as { model?: string };
     expect(requestBody.model).toBe('claude-sonnet-4-6');
 
-    const output = String(consoleLogStub.firstCall.args[0]);
+    const output = String(consoleLogStub.mock.calls[0][0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).toBe('🦾');
   });
@@ -587,7 +600,7 @@ describe('generate (--suggest-emojis)', function () {
       }),
     ).rejects.toThrow('Multiple AI provider API keys found');
 
-    expect(fetchStub.callCount).toBe(0);
+    expect(fetchStub.mock.calls.length).toBe(0);
   });
 
   it('throws when no provider API key is set for ai mode', async function () {
@@ -621,7 +634,7 @@ describe('generate (--suggest-emojis)', function () {
   it('throws when ai request fails', async function () {
     process.env['OPENAI_API_KEY'] = 'test-openai-key';
     restoreEnvVar('ANTHROPIC_API_KEY', undefined);
-    stubFetch().rejects(new Error('request failed while connecting'));
+    stubFetch().mockRejectedValue(new Error('request failed while connecting'));
 
     await expect(
       generate(fixture.path, {
@@ -635,13 +648,13 @@ describe('generate (--suggest-emojis)', function () {
   it('throws when ai request times out', async function () {
     process.env['OPENAI_API_KEY'] = 'test-openai-key';
     restoreEnvVar('ANTHROPIC_API_KEY', undefined);
-    sinon.stub(globalThis, 'setTimeout').callsFake((handler) => {
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation((handler) => {
       if (typeof handler === 'function') {
         handler();
       }
       return 1 as unknown as ReturnType<typeof setTimeout>;
     });
-    stubFetch().callsFake((_input, init) => {
+    stubFetch().mockImplementation((_input, init) => {
       const signal = (
         init as {
           signal?: {
@@ -673,7 +686,7 @@ describe('generate (--suggest-emojis)', function () {
   it('throws when ai response content is malformed JSON', async function () {
     process.env['OPENAI_API_KEY'] = 'test-openai-key';
     restoreEnvVar('ANTHROPIC_API_KEY', undefined);
-    stubFetch().resolves(
+    stubFetch().mockResolvedValue(
       createJsonFetchResponse({
         choices: [
           {
@@ -697,7 +710,7 @@ describe('generate (--suggest-emojis)', function () {
   it('throws when OpenAI returns a non-OK HTTP status', async function () {
     process.env['OPENAI_API_KEY'] = 'test-openai-key';
     restoreEnvVar('ANTHROPIC_API_KEY', undefined);
-    stubFetch().resolves(
+    stubFetch().mockResolvedValue(
       createJsonFetchResponse(
         {},
         {
@@ -719,7 +732,7 @@ describe('generate (--suggest-emojis)', function () {
   it('throws generic HTTP status when non-OK OpenAI error payload is not JSON', async function () {
     process.env['OPENAI_API_KEY'] = 'test-openai-key';
     restoreEnvVar('ANTHROPIC_API_KEY', undefined);
-    stubFetch().resolves(
+    stubFetch().mockResolvedValue(
       createTextFetchResponse('invalid-json', {
         status: 502,
         statusText: 'Bad Gateway',
@@ -739,7 +752,7 @@ describe('generate (--suggest-emojis)', function () {
     process.env['VERCEL_AI_GATEWAY_API_KEY'] = 'test-ai-gateway-key';
     restoreEnvVar('OPENAI_API_KEY', undefined);
     restoreEnvVar('ANTHROPIC_API_KEY', undefined);
-    stubFetch().resolves(
+    stubFetch().mockResolvedValue(
       createJsonFetchResponse(
         {
           error: {
@@ -779,7 +792,7 @@ describe('generate (--suggest-emojis)', function () {
     process.env['VERCEL_AI_GATEWAY_API_KEY'] = 'test-ai-gateway-key';
     restoreEnvVar('OPENAI_API_KEY', undefined);
     restoreEnvVar('ANTHROPIC_API_KEY', undefined);
-    stubFetch().resolves(
+    stubFetch().mockResolvedValue(
       createJsonFetchResponse(
         {
           error: {
@@ -818,27 +831,27 @@ describe('generate (--suggest-emojis)', function () {
     process.env['OPENAI_API_KEY'] = 'test-openai-key';
     restoreEnvVar('ANTHROPIC_API_KEY', undefined);
     const fetchStub = stubFetch();
-    fetchStub.onCall(0).resolves(createJsonFetchResponse([]));
-    fetchStub.onCall(1).resolves(createJsonFetchResponse({ choices: [] }));
-    fetchStub
-      .onCall(2)
-      .resolves(createJsonFetchResponse({ choices: [undefined] }));
-    fetchStub.onCall(3).resolves(
+    fetchStub.mockResolvedValueOnce(createJsonFetchResponse([]));
+    fetchStub.mockResolvedValueOnce(createJsonFetchResponse({ choices: [] }));
+    fetchStub.mockResolvedValueOnce(
+      createJsonFetchResponse({ choices: [undefined] }),
+    );
+    fetchStub.mockResolvedValueOnce(
       createJsonFetchResponse({
         choices: [{ message: undefined }],
       }),
     );
-    fetchStub.onCall(4).resolves(
+    fetchStub.mockResolvedValueOnce(
       createJsonFetchResponse({
         choices: [{ message: { content: {} } }],
       }),
     );
-    fetchStub.onCall(5).resolves(
+    fetchStub.mockResolvedValueOnce(
       createJsonFetchResponse({
         choices: [{ message: { content: [undefined] } }],
       }),
     );
-    fetchStub.onCall(6).resolves(
+    fetchStub.mockResolvedValueOnce(
       createJsonFetchResponse({
         choices: [{ message: { content: [{}] } }],
       }),
@@ -861,12 +874,12 @@ describe('generate (--suggest-emojis)', function () {
     process.env['OPENAI_API_KEY'] = 'test-openai-key';
     restoreEnvVar('ANTHROPIC_API_KEY', undefined);
     const fetchStub = stubFetch();
-    fetchStub.onCall(0).resolves(
+    fetchStub.mockResolvedValueOnce(
       createJsonFetchResponse({
         choices: [{ message: { content: '' } }],
       }),
     );
-    fetchStub.onCall(1).resolves(
+    fetchStub.mockResolvedValueOnce(
       createJsonFetchResponse({
         choices: [{ message: { content: '[]' } }],
       }),
@@ -892,8 +905,8 @@ describe('generate (--suggest-emojis)', function () {
     restoreEnvVar('OPENAI_API_KEY', undefined);
     process.env['ANTHROPIC_API_KEY'] = 'test-anthropic-key';
     const fetchStub = stubFetch();
-    fetchStub.onCall(0).rejects(new Error('anthropic-network-failure'));
-    fetchStub.onCall(1).resolves(
+    fetchStub.mockRejectedValueOnce(new Error('anthropic-network-failure'));
+    fetchStub.mockResolvedValueOnce(
       createJsonFetchResponse(
         {},
         {
@@ -902,23 +915,23 @@ describe('generate (--suggest-emojis)', function () {
         },
       ),
     );
-    fetchStub.onCall(2).resolves(createJsonFetchResponse([]));
-    fetchStub.onCall(3).resolves(
+    fetchStub.mockResolvedValueOnce(createJsonFetchResponse([]));
+    fetchStub.mockResolvedValueOnce(
       createJsonFetchResponse({
         content: {},
       }),
     );
-    fetchStub.onCall(4).resolves(
+    fetchStub.mockResolvedValueOnce(
       createJsonFetchResponse({
         content: [undefined],
       }),
     );
-    fetchStub.onCall(5).resolves(
+    fetchStub.mockResolvedValueOnce(
       createJsonFetchResponse({
         content: [{ type: 'image' }],
       }),
     );
-    fetchStub.onCall(6).resolves(
+    fetchStub.mockResolvedValueOnce(
       createJsonFetchResponse({
         content: [{ type: 'text' }],
       }),
@@ -954,7 +967,7 @@ describe('generate (--suggest-emojis)', function () {
   it('includes parsed Anthropic non-OK payload details', async function () {
     restoreEnvVar('OPENAI_API_KEY', undefined);
     process.env['ANTHROPIC_API_KEY'] = 'test-anthropic-key';
-    stubFetch().resolves(
+    stubFetch().mockResolvedValue(
       createJsonFetchResponse(
         {
           error: {
@@ -989,10 +1002,12 @@ describe('generate (--suggest-emojis)', function () {
   });
 
   it('rejects reserved emojis and keeps uniqueness when ai suggestions duplicate', async function () {
-    const consoleLogStub = sinon.stub(console, 'log');
+    const consoleLogStub = vi
+      .spyOn(console, 'log')
+      .mockImplementation(() => {});
     process.env['OPENAI_API_KEY'] = 'test-openai-key';
     restoreEnvVar('ANTHROPIC_API_KEY', undefined);
-    stubFetch().resolves(
+    stubFetch().mockResolvedValue(
       createJsonFetchResponse({
         choices: [
           {
@@ -1014,7 +1029,7 @@ describe('generate (--suggest-emojis)', function () {
       aiProvider: 'openai',
     });
 
-    const output = String(consoleLogStub.firstCall.args[0]);
+    const output = String(consoleLogStub.mock.calls[0][0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).not.toBe('💼');
     expect(suggestions.get('zzzz-one')).toBeTruthy();
@@ -1023,10 +1038,12 @@ describe('generate (--suggest-emojis)', function () {
   });
 
   it('parses array-based OpenAI message content and normalizes alias suggestions', async function () {
-    const consoleLogStub = sinon.stub(console, 'log');
+    const consoleLogStub = vi
+      .spyOn(console, 'log')
+      .mockImplementation(() => {});
     process.env['OPENAI_API_KEY'] = 'test-openai-key';
     restoreEnvVar('ANTHROPIC_API_KEY', undefined);
-    stubFetch().resolves(
+    stubFetch().mockResolvedValue(
       createJsonFetchResponse({
         choices: [
           {
@@ -1048,7 +1065,7 @@ describe('generate (--suggest-emojis)', function () {
       aiProvider: 'openai',
     });
 
-    const output = String(consoleLogStub.firstCall.args[0]);
+    const output = String(consoleLogStub.mock.calls[0][0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).toBe('🚀');
     expect(suggestions.get('zzzz-one')).toBeTruthy();
@@ -1070,8 +1087,10 @@ describe('generate (--suggest-emojis)', function () {
       };
       `,
       async (tempFixture) => {
-        const consoleLogStub = sinon.stub(console, 'log');
-        const fetchStub = stubFetch().resolves(
+        const consoleLogStub = vi
+          .spyOn(console, 'log')
+          .mockImplementation(() => {});
+        const fetchStub = stubFetch().mockResolvedValue(
           createJsonFetchResponse({
             choices: [
               {
@@ -1093,9 +1112,9 @@ describe('generate (--suggest-emojis)', function () {
           aiProvider: 'openai',
         });
 
-        expect(fetchStub.callCount).toBe(1);
-        expect(consoleLogStub.callCount).toBe(1);
-        const output = String(consoleLogStub.firstCall.args[0]);
+        expect(fetchStub.mock.calls.length).toBe(1);
+        expect(consoleLogStub.mock.calls.length).toBe(1);
+        const output = String(consoleLogStub.mock.calls[0][0]);
         const suggestions = parseSuggestionTable(output);
         expect(suggestions.get('recommended')).toBe('🧠');
       },
@@ -1138,13 +1157,15 @@ describe('generate (--suggest-emojis)', function () {
       };
       `,
       async (tempFixture) => {
-        const consoleLogStub = sinon.stub(console, 'log');
+        const consoleLogStub = vi
+          .spyOn(console, 'log')
+          .mockImplementation(() => {});
         await generate(tempFixture.path, {
           suggestEmojis: true,
           configEmoji: [['recommended']],
         });
 
-        const output = String(consoleLogStub.firstCall.args[0]);
+        const output = String(consoleLogStub.mock.calls[0][0]);
         const suggestions = parseSuggestionTable(output);
         expect(suggestions.get('recommended')).toBe('✅');
         expect(suggestions.has('react-native')).toBe(true);
@@ -1156,10 +1177,12 @@ describe('generate (--suggest-emojis)', function () {
   });
 
   it('ignores non-string and non-emoji ai suggestions', async function () {
-    const consoleLogStub = sinon.stub(console, 'log');
+    const consoleLogStub = vi
+      .spyOn(console, 'log')
+      .mockImplementation(() => {});
     process.env['OPENAI_API_KEY'] = 'test-openai-key';
     restoreEnvVar('ANTHROPIC_API_KEY', undefined);
-    stubFetch().resolves(
+    stubFetch().mockResolvedValue(
       createJsonFetchResponse({
         choices: [
           {
@@ -1181,7 +1204,7 @@ describe('generate (--suggest-emojis)', function () {
       aiProvider: 'openai',
     });
 
-    const output = String(consoleLogStub.firstCall.args[0]);
+    const output = String(consoleLogStub.mock.calls[0][0]);
     const suggestions = parseSuggestionTable(output);
     expect(suggestions.get('xyzabc')).not.toBe('123');
     expect(suggestions.get('zzzz-one')).not.toBe('abc123');
@@ -1200,10 +1223,12 @@ describe('generate (--suggest-emojis)', function () {
       };
       `,
       async (tempFixture) => {
-        const consoleLogStub = sinon.stub(console, 'log');
+        const consoleLogStub = vi
+          .spyOn(console, 'log')
+          .mockImplementation(() => {});
         process.env['OPENAI_API_KEY'] = 'test-openai-key';
         restoreEnvVar('ANTHROPIC_API_KEY', undefined);
-        stubFetch().resolves(
+        stubFetch().mockResolvedValue(
           createJsonFetchResponse({
             choices: [
               {
@@ -1224,7 +1249,7 @@ describe('generate (--suggest-emojis)', function () {
           configEmoji: [['typescript']],
         });
 
-        const output = String(consoleLogStub.firstCall.args[0]);
+        const output = String(consoleLogStub.mock.calls[0][0]);
         const suggestions = parseSuggestionTable(output);
         expect(suggestions.get('typescript')).toBe('⌨️');
       },
@@ -1249,10 +1274,12 @@ describe('generate (--suggest-emojis)', function () {
       };
       `,
       async (tempFixture) => {
-        const consoleLogStub = sinon.stub(console, 'log');
+        const consoleLogStub = vi
+          .spyOn(console, 'log')
+          .mockImplementation(() => {});
         await generate(tempFixture.path, { suggestEmojis: true });
 
-        const output = String(consoleLogStub.firstCall.args[0]);
+        const output = String(consoleLogStub.mock.calls[0][0]);
         const suggestions = parseSuggestionTable(output);
         expect(suggestions.has('qzxqzx-1')).toBe(true);
         expect(suggestions.has('qzxqzx-22')).toBe(true);

--- a/test/lib/generate/rule-options-list-test.ts
+++ b/test/lib/generate/rule-options-list-test.ts
@@ -1,6 +1,5 @@
 import { generate } from '../../../lib/generator.js';
 import { setupFixture, type FixtureContext } from '../../helpers/fixture.js';
-import * as sinon from 'sinon';
 
 describe('generate (rule options list)', function () {
   describe('for md files', () => {
@@ -90,10 +89,12 @@ describe('generate (rule options list)', function () {
       });
 
       it('generates the documentation', async function () {
-        const consoleErrorStub = sinon.stub(console, 'error');
+        const consoleErrorStub = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {});
         await generate(fixture.path);
-        expect(consoleErrorStub.callCount).toBe(0);
-        consoleErrorStub.restore();
+        expect(consoleErrorStub.mock.calls.length).toBe(0);
+        consoleErrorStub.mockRestore();
         expect(
           await fixture.readFile('docs/rules/no-foo.md'),
         ).toMatchSnapshot();
@@ -140,10 +141,12 @@ describe('generate (rule options list)', function () {
       });
 
       it('generates the documentation', async function () {
-        const consoleErrorStub = sinon.stub(console, 'error');
+        const consoleErrorStub = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {});
         await generate(fixture.path);
-        expect(consoleErrorStub.callCount).toBe(0);
-        consoleErrorStub.restore();
+        expect(consoleErrorStub.mock.calls.length).toBe(0);
+        consoleErrorStub.mockRestore();
         expect(
           await fixture.readFile('docs/rules/no-foo.md'),
         ).toMatchSnapshot();
@@ -182,10 +185,12 @@ describe('generate (rule options list)', function () {
       });
 
       it('generates the documentation', async function () {
-        const consoleErrorStub = sinon.stub(console, 'error');
+        const consoleErrorStub = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {});
         await generate(fixture.path);
-        expect(consoleErrorStub.callCount).toBe(0);
-        consoleErrorStub.restore();
+        expect(consoleErrorStub.mock.calls.length).toBe(0);
+        consoleErrorStub.mockRestore();
         expect(
           await fixture.readFile('docs/rules/no-foo.md'),
         ).toMatchSnapshot();
@@ -234,10 +239,12 @@ describe('generate (rule options list)', function () {
       });
 
       it('generates the documentation with defaults from meta.defaultOptions', async function () {
-        const consoleErrorStub = sinon.stub(console, 'error');
+        const consoleErrorStub = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {});
         await generate(fixture.path);
-        expect(consoleErrorStub.callCount).toBe(0);
-        consoleErrorStub.restore();
+        expect(consoleErrorStub.mock.calls.length).toBe(0);
+        consoleErrorStub.mockRestore();
         expect(await fixture.readFile('docs/rules/no-foo.md')).toContain(
           '`true`',
         );
@@ -276,10 +283,12 @@ describe('generate (rule options list)', function () {
       });
 
       it('generates the documentation', async function () {
-        const consoleErrorStub = sinon.stub(console, 'error');
+        const consoleErrorStub = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {});
         await generate(fixture.path);
-        expect(consoleErrorStub.callCount).toBe(0);
-        consoleErrorStub.restore();
+        expect(consoleErrorStub.mock.calls.length).toBe(0);
+        consoleErrorStub.mockRestore();
         expect(
           await fixture.readFile('docs/rules/no-foo.md'),
         ).toMatchSnapshot();
@@ -318,10 +327,12 @@ describe('generate (rule options list)', function () {
       });
 
       it('generates the documentation', async function () {
-        const consoleErrorStub = sinon.stub(console, 'error');
+        const consoleErrorStub = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {});
         await generate(fixture.path);
-        expect(consoleErrorStub.callCount).toBe(0);
-        consoleErrorStub.restore();
+        expect(consoleErrorStub.mock.calls.length).toBe(0);
+        consoleErrorStub.mockRestore();
         expect(
           await fixture.readFile('docs/rules/no-foo.md'),
         ).toMatchSnapshot();
@@ -416,10 +427,12 @@ describe('generate (rule options list)', function () {
       });
 
       it('generates the documentation', async function () {
-        const consoleErrorStub = sinon.stub(console, 'error');
+        const consoleErrorStub = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {});
         await generate(fixture.path);
-        expect(consoleErrorStub.callCount).toBe(0);
-        consoleErrorStub.restore();
+        expect(consoleErrorStub.mock.calls.length).toBe(0);
+        consoleErrorStub.mockRestore();
         expect(
           await fixture.readFile('docs/rules/no-foo.mdx'),
         ).toMatchSnapshot();
@@ -466,10 +479,12 @@ describe('generate (rule options list)', function () {
       });
 
       it('generates the documentation', async function () {
-        const consoleErrorStub = sinon.stub(console, 'error');
+        const consoleErrorStub = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {});
         await generate(fixture.path);
-        expect(consoleErrorStub.callCount).toBe(0);
-        consoleErrorStub.restore();
+        expect(consoleErrorStub.mock.calls.length).toBe(0);
+        consoleErrorStub.mockRestore();
         expect(
           await fixture.readFile('docs/rules/no-foo.mdx'),
         ).toMatchSnapshot();
@@ -508,10 +523,12 @@ describe('generate (rule options list)', function () {
       });
 
       it('generates the documentation', async function () {
-        const consoleErrorStub = sinon.stub(console, 'error');
+        const consoleErrorStub = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {});
         await generate(fixture.path);
-        expect(consoleErrorStub.callCount).toBe(0);
-        consoleErrorStub.restore();
+        expect(consoleErrorStub.mock.calls.length).toBe(0);
+        consoleErrorStub.mockRestore();
         expect(
           await fixture.readFile('docs/rules/no-foo.mdx'),
         ).toMatchSnapshot();
@@ -560,10 +577,12 @@ describe('generate (rule options list)', function () {
       });
 
       it('generates the documentation with defaults from meta.defaultOptions', async function () {
-        const consoleErrorStub = sinon.stub(console, 'error');
+        const consoleErrorStub = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {});
         await generate(fixture.path);
-        expect(consoleErrorStub.callCount).toBe(0);
-        consoleErrorStub.restore();
+        expect(consoleErrorStub.mock.calls.length).toBe(0);
+        consoleErrorStub.mockRestore();
         expect(await fixture.readFile('docs/rules/no-foo.mdx')).toContain(
           '`true`',
         );
@@ -602,10 +621,12 @@ describe('generate (rule options list)', function () {
       });
 
       it('generates the documentation', async function () {
-        const consoleErrorStub = sinon.stub(console, 'error');
+        const consoleErrorStub = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {});
         await generate(fixture.path);
-        expect(consoleErrorStub.callCount).toBe(0);
-        consoleErrorStub.restore();
+        expect(consoleErrorStub.mock.calls.length).toBe(0);
+        consoleErrorStub.mockRestore();
         expect(
           await fixture.readFile('docs/rules/no-foo.mdx'),
         ).toMatchSnapshot();
@@ -644,10 +665,12 @@ describe('generate (rule options list)', function () {
       });
 
       it('generates the documentation', async function () {
-        const consoleErrorStub = sinon.stub(console, 'error');
+        const consoleErrorStub = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {});
         await generate(fixture.path);
-        expect(consoleErrorStub.callCount).toBe(0);
-        consoleErrorStub.restore();
+        expect(consoleErrorStub.mock.calls.length).toBe(0);
+        consoleErrorStub.mockRestore();
         expect(
           await fixture.readFile('docs/rules/no-foo.mdx'),
         ).toMatchSnapshot();

--- a/test/lib/generate/rule-options-test.ts
+++ b/test/lib/generate/rule-options-test.ts
@@ -1,6 +1,5 @@
 import { generate } from '../../../lib/generator.js';
 import { setupFixture, type FixtureContext } from '../../helpers/fixture.js';
-import * as sinon from 'sinon';
 import { COLUMN_TYPE, NOTICE_TYPE } from '../../../lib/types.js';
 
 describe('generate (rule options)', function () {
@@ -39,13 +38,15 @@ describe('generate (rule options)', function () {
     });
 
     it('prints an error', async function () {
-      const consoleErrorStub = sinon.stub(console, 'error');
+      const consoleErrorStub = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
       await generate(fixture.path);
-      expect(consoleErrorStub.callCount).toBe(1);
-      expect(consoleErrorStub.firstCall.args).toStrictEqual([
+      expect(consoleErrorStub.mock.calls.length).toBe(1);
+      expect(consoleErrorStub.mock.calls[0]).toStrictEqual([
         '`no-foo` rule doc should not have included any of these headers: Options, Config',
       ]);
-      consoleErrorStub.restore();
+      consoleErrorStub.mockRestore();
     });
   });
 
@@ -80,13 +81,15 @@ describe('generate (rule options)', function () {
     });
 
     it('prints an error', async function () {
-      const consoleErrorStub = sinon.stub(console, 'error');
+      const consoleErrorStub = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
       await generate(fixture.path);
-      expect(consoleErrorStub.callCount).toBe(1);
-      expect(consoleErrorStub.firstCall.args).toStrictEqual([
+      expect(consoleErrorStub.mock.calls.length).toBe(1);
+      expect(consoleErrorStub.mock.calls[0]).toStrictEqual([
         '`no-foo` rule doc should have included one of these headers: Options, Config',
       ]);
-      consoleErrorStub.restore();
+      consoleErrorStub.mockRestore();
     });
   });
 
@@ -121,13 +124,15 @@ describe('generate (rule options)', function () {
     });
 
     it('prints an error', async function () {
-      const consoleErrorStub = sinon.stub(console, 'error');
+      const consoleErrorStub = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
       await generate(fixture.path, { ruleDocSectionOptions: true });
-      expect(consoleErrorStub.callCount).toBe(1);
-      expect(consoleErrorStub.firstCall.args).toStrictEqual([
+      expect(consoleErrorStub.mock.calls.length).toBe(1);
+      expect(consoleErrorStub.mock.calls[0]).toStrictEqual([
         '`no-foo` rule doc should have included one of these headers: Options, Config',
       ]);
-      consoleErrorStub.restore();
+      consoleErrorStub.mockRestore();
     });
   });
 
@@ -162,10 +167,12 @@ describe('generate (rule options)', function () {
     });
 
     it('has no error', async function () {
-      const consoleErrorStub = sinon.stub(console, 'error');
+      const consoleErrorStub = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
       await generate(fixture.path, { ruleDocSectionOptions: false });
-      expect(consoleErrorStub.callCount).toBe(0);
-      consoleErrorStub.restore();
+      expect(consoleErrorStub.mock.calls.length).toBe(0);
+      consoleErrorStub.mockRestore();
     });
   });
 
@@ -216,10 +223,12 @@ describe('generate (rule options)', function () {
     });
 
     it('successfully finds the options mentioned in the rule doc despite quote escaping', async function () {
-      const consoleErrorStub = sinon.stub(console, 'error');
+      const consoleErrorStub = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
       await generate(fixture.path);
-      expect(consoleErrorStub.callCount).toBe(0);
-      consoleErrorStub.restore();
+      expect(consoleErrorStub.mock.calls.length).toBe(0);
+      consoleErrorStub.mockRestore();
     });
   });
 
@@ -272,13 +281,15 @@ describe('generate (rule options)', function () {
     });
 
     it('prints an error', async function () {
-      const consoleErrorStub = sinon.stub(console, 'error');
+      const consoleErrorStub = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
       await generate(fixture.path);
-      expect(consoleErrorStub.callCount).toBe(1);
-      expect(consoleErrorStub.firstCall.args).toStrictEqual([
+      expect(consoleErrorStub.mock.calls.length).toBe(1);
+      expect(consoleErrorStub.mock.calls[0]).toStrictEqual([
         '`no-foo` rule doc should have included rule option: optionToDoSomething',
       ]);
-      consoleErrorStub.restore();
+      consoleErrorStub.mockRestore();
     });
   });
 


### PR DESCRIPTION
## Summary

- Replace `sinon` stubs/spies with Vitest `vi.fn` / `vi.spyOn` / `vi.restoreAllMocks`
- Remove `sinon` and `@types/sinon` so tests use one mocking API

## Test plan

- [x] Full suite: 350 tests passed
- [ ] CI green

Made with [Cursor](https://cursor.com)