### PR TITLE
fix: preserve existing line endings when updating docs

### DIFF
--- a/lib/config-list.ts
+++ b/lib/config-list.ts
@@ -4,6 +4,7 @@ import {
   formatComment,
 } from './comment-markers.js';
 import { markdownTable } from 'markdown-table';
+import { normalizeEndOfLine } from './eol.js';
 import type { Config } from './types.js';
 import { configNameToDisplay } from './config-format.js';
 import { sanitizeMarkdownTable } from './string.js';
@@ -59,9 +60,13 @@ function generateConfigListMarkdown(context: Context): string {
       }),
   ];
 
-  return markdownTable(
-    sanitizeMarkdownTable(context, rows),
-    { align: 'l' }, // Left-align headers.
+  // `markdownTable` uses LF line endings, so convert to the desired end of line.
+  return normalizeEndOfLine(
+    markdownTable(
+      sanitizeMarkdownTable(context, rows),
+      { align: 'l' }, // Left-align headers.
+    ),
+    context.endOfLine,
   );
 }
 

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -1,5 +1,5 @@
 import { mockPlugin } from './mock-plugin.js';
-import { getEndOfLine } from './eol.js';
+import { detectEndOfLine, getEndOfLine } from './eol.js';
 import { getResolvedOptions } from './options.js';
 import type { ResolvedGenerateOptions } from './options.js';
 import { getPluginName, loadPlugin } from './package-json.js';
@@ -41,5 +41,23 @@ export async function getContext(
     path,
     plugin,
     pluginPrefix,
+  };
+}
+
+/**
+ * Create a copy of the context that uses the end of line already predominant
+ * in the given file contents, if any. This way, updating an existing file
+ * preserves the file's current line endings even when they differ from the
+ * configured end of line (such as when another tool like Prettier rewrote the
+ * file with different line endings). The configured end of line still applies
+ * to files without any line breaks.
+ */
+export function getContextForFileContents(
+  context: Context,
+  contents: string,
+): Context {
+  return {
+    ...context,
+    endOfLine: detectEndOfLine(contents) ?? context.endOfLine,
   };
 }

--- a/lib/eol.ts
+++ b/lib/eol.ts
@@ -60,6 +60,31 @@ async function getEndOfLineFromPrettierConfig(): Promise<
   return '\n';
 }
 
+/**
+ * Detect the predominant end of line in the given file contents.
+ * Returns undefined if the contents have no line breaks.
+ */
+export function detectEndOfLine(contents: string): '\n' | '\r\n' | undefined {
+  const crlfCount = contents.match(/\r\n/gu)?.length ?? 0;
+  const lfCount = contents.match(/(?<!\r)\n/gu)?.length ?? 0;
+
+  if (crlfCount === 0 && lfCount === 0) {
+    return undefined;
+  }
+
+  return crlfCount > lfCount ? '\r\n' : '\n';
+}
+
+/**
+ * Convert all line endings in the given contents to the given end of line.
+ */
+export function normalizeEndOfLine(
+  contents: string,
+  endOfLine: string,
+): string {
+  return contents.replaceAll(/\r\n|\n/gu, endOfLine);
+}
+
 /* istanbul ignore next */
 /** `EOL` is typed as `string`, so we perform run-time validation to be safe. */
 function getNodeEOL(): '\n' | '\r\n' {

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -25,7 +25,8 @@ import type { GenerateOptions, RuleModule } from './types.js';
 import { replaceRulePlaceholder } from './rule-link.js';
 import { updateRuleOptionsList } from './rule-options-list.js';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { getContext } from './context.js';
+import { getContext, getContextForFileContents } from './context.js';
+import { normalizeEndOfLine } from './eol.js';
 import { generateSuggestedEmojis } from './suggest-emojis.js';
 import { generateFrontmatterLines } from './frontmatter.js';
 
@@ -166,17 +167,31 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     const isRuleDocMdx = isMdx(pathToDoc);
     const contentsOldBuffer = await readFile(pathToDoc);
     const contentsOld = contentsOldBuffer.toString();
-    const frontmatterOld = extractFrontmatter(context, contentsOld);
+
+    // Preserve the line endings already used in the doc, which may differ from
+    // the configured end of line (such as when another tool like Prettier
+    // rewrote the doc with different line endings). Unify any mixed line
+    // endings so that line-based processing of the doc works reliably.
+    const contextForDoc = getContextForFileContents(context, contentsOld);
+    const contentsOldNormalized = normalizeEndOfLine(
+      contentsOld,
+      contextForDoc.endOfLine,
+    );
+
+    const frontmatterOld = extractFrontmatter(
+      contextForDoc,
+      contentsOldNormalized,
+    );
 
     // Regenerate the header (title/notices) and frontmatter of each rule doc.
     const newHeaderLines = generateRuleHeaderLines(
-      context,
+      contextForDoc,
       description,
       name,
       isRuleDocMdx,
     );
     const newFrontmatterLines = generateFrontmatterLines(
-      context,
+      contextForDoc,
       name,
       description,
       frontmatterOld,
@@ -184,18 +199,18 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
 
     // Generate the new content for the rule doc by replacing the header and frontmatter, and updating the rule options list if necessary.
     let contentsNew = replaceOrCreateFrontmatter(
-      context,
-      contentsOld,
+      contextForDoc,
+      contentsOldNormalized,
       newFrontmatterLines,
     );
     contentsNew = replaceOrCreateHeader(
-      context,
+      contextForDoc,
       contentsNew,
       newHeaderLines,
       isRuleDocMdx,
     );
     contentsNew = updateRuleOptionsList(
-      context,
+      contextForDoc,
       contentsNew,
       rule,
       isRuleDocMdx,
@@ -223,7 +238,7 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     // Check for required sections.
     for (const section of ruleDocSectionInclude) {
       expectSectionHeaderOrFail(
-        context,
+        contextForDoc,
         `\`${name}\` rule doc`,
         contentsNew,
         [section],
@@ -234,7 +249,7 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     // Check for disallowed sections.
     for (const section of ruleDocSectionExclude) {
       expectSectionHeaderOrFail(
-        context,
+        contextForDoc,
         `\`${name}\` rule doc`,
         contentsNew,
         [section],
@@ -245,7 +260,7 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     if (ruleDocSectionOptions) {
       // Options section.
       expectSectionHeaderOrFail(
-        context,
+        contextForDoc,
         `\`${name}\` rule doc`,
         contentsNew,
         ['Options', 'Config'],
@@ -287,14 +302,25 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
 
     // Update the rules list in this file.
     const fileContents = await readFile(pathToFile, 'utf8');
-    const rulesList = updateRulesList(
-      context,
-      ruleNamesAndRules,
+
+    // Preserve the line endings already used in the file, which may differ
+    // from the configured end of line (such as when the file was written with
+    // different line endings by another tool). Unify any mixed line endings so
+    // that line-based processing of the file works reliably.
+    const contextForFile = getContextForFileContents(context, fileContents);
+    const fileContentsNormalized = normalizeEndOfLine(
       fileContents,
+      contextForFile.endOfLine,
+    );
+
+    const rulesList = updateRulesList(
+      contextForFile,
+      ruleNamesAndRules,
+      fileContentsNormalized,
       pathToFile,
     );
     const fileContentsNew = await postprocess(
-      updateConfigsList(context, rulesList, isRuleListMdx),
+      updateConfigsList(contextForFile, rulesList, isRuleListMdx),
       resolve(pathToFile),
     );
 

--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -19,6 +19,7 @@ import { relative } from 'node:path';
 import { COLUMN_TYPE, SEVERITY_TYPE } from './types.js';
 import type { RuleModule, RuleNamesAndRules } from './types.js';
 import { markdownTable } from 'markdown-table';
+import { normalizeEndOfLine } from './eol.js';
 import { EMOJIS_TYPE } from './rule-type.js';
 import { hasOptions } from './rule-options.js';
 import { getLinkToRule } from './rule-link.js';
@@ -161,14 +162,18 @@ function generateRulesListMarkdown(
     ];
   });
 
-  return markdownTable(
-    sanitizeMarkdownTable(context, [
-      listHeaderRow,
-      ...ruleNamesAndRules.map(([name, rule]) =>
-        buildRuleRow(context, name, rule, columns, pathToFile),
-      ),
-    ]),
-    { align: 'l' }, // Left-align headers.
+  // `markdownTable` uses LF line endings, so convert to the desired end of line.
+  return normalizeEndOfLine(
+    markdownTable(
+      sanitizeMarkdownTable(context, [
+        listHeaderRow,
+        ...ruleNamesAndRules.map(([name, rule]) =>
+          buildRuleRow(context, name, rule, columns, pathToFile),
+        ),
+      ]),
+      { align: 'l' }, // Left-align headers.
+    ),
+    context.endOfLine,
   );
 }
 

--- a/lib/rule-options-list.ts
+++ b/lib/rule-options-list.ts
@@ -4,6 +4,7 @@ import {
   formatComment,
 } from './comment-markers.js';
 import { markdownTable } from 'markdown-table';
+import { normalizeEndOfLine } from './eol.js';
 import type { RuleModule } from './types.js';
 import { getAllNamedOptions } from './rule-options.js';
 import type { RuleOption } from './rule-options.js';
@@ -144,9 +145,13 @@ function generateRuleOptionsListMarkdown(
         .map((type) => ruleOptionColumnValues[type as COLUMN_TYPE] || '');
     });
 
-  return markdownTable(
-    sanitizeMarkdownTable(context, [listHeaderRow, ...rows]),
-    { align: 'l' }, // Left-align headers.
+  // `markdownTable` uses LF line endings, so convert to the desired end of line.
+  return normalizeEndOfLine(
+    markdownTable(
+      sanitizeMarkdownTable(context, [listHeaderRow, ...rows]),
+      { align: 'l' }, // Left-align headers.
+    ),
+    context.endOfLine,
   );
 }
 

--- a/test/lib/generate/eol-test.ts
+++ b/test/lib/generate/eol-test.ts
@@ -1,7 +1,42 @@
 import { generate } from '../../../lib/generator.js';
-import { getEndOfLine } from '../../../lib/eol.js';
+import {
+  detectEndOfLine,
+  getEndOfLine,
+  normalizeEndOfLine,
+} from '../../../lib/eol.js';
 import { EOL } from 'node:os';
 import { setupFixture, type FixtureContext } from '../../helpers/fixture.js';
+
+describe('detectEndOfLine', function () {
+  it('returns undefined for contents without line breaks', function () {
+    expect(detectEndOfLine('')).toBeUndefined();
+    expect(detectEndOfLine('no line breaks')).toBeUndefined();
+  });
+
+  it('detects lf', function () {
+    expect(detectEndOfLine('a\nb\nc\n')).toStrictEqual('\n');
+  });
+
+  it('detects crlf', function () {
+    expect(detectEndOfLine('a\r\nb\r\nc\r\n')).toStrictEqual('\r\n');
+  });
+
+  it('detects the predominant end of line in contents with mixed line endings', function () {
+    expect(detectEndOfLine('a\r\nb\r\nc\n')).toStrictEqual('\r\n');
+    expect(detectEndOfLine('a\nb\nc\r\n')).toStrictEqual('\n');
+  });
+});
+
+describe('normalizeEndOfLine', function () {
+  it('converts mixed line endings to the given end of line', function () {
+    expect(normalizeEndOfLine('a\r\nb\nc\r\n', '\n')).toStrictEqual(
+      'a\nb\nc\n',
+    );
+    expect(normalizeEndOfLine('a\r\nb\nc\r\n', '\r\n')).toStrictEqual(
+      'a\r\nb\r\nc\r\n',
+    );
+  });
+});
 
 describe('getEndOfLine', function () {
   describe('with a ".editorconfig" file', function () {
@@ -72,8 +107,14 @@ describe('getEndOfLine', function () {
 
     describe('generates using the correct end of line when ".editorconfig" exists', function () {
       let fixture: FixtureContext;
+      let originalCwd: string;
+
+      beforeEach(function () {
+        originalCwd = process.cwd();
+      });
 
       afterEach(async function () {
+        process.chdir(originalCwd);
         await fixture.cleanup();
       });
 
@@ -106,6 +147,7 @@ describe('getEndOfLine', function () {
                   end_of_line = lf`,
           },
         });
+        process.chdir(fixture.path);
 
         await generate(fixture.path, {
           configEmoji: [
@@ -114,6 +156,10 @@ describe('getEndOfLine', function () {
             ['c', '🌊'],
           ],
         });
+        // Explicit line ending assertions since snapshots normalize CRLF to LF.
+        expect(await fixture.readFile('README.md')).not.toContain('\r');
+        expect(await fixture.readFile('docs/rules/a.md')).not.toContain('\r');
+
         expect(await fixture.readFile('README.md')).toMatchSnapshot();
         expect(await fixture.readFile('docs/rules/a.md')).toMatchSnapshot();
         expect(await fixture.readFile('docs/rules/B.md')).toMatchSnapshot();
@@ -149,6 +195,7 @@ describe('getEndOfLine', function () {
                   end_of_line = crlf`,
           },
         });
+        process.chdir(fixture.path);
 
         await generate(fixture.path, {
           configEmoji: [
@@ -157,6 +204,15 @@ describe('getEndOfLine', function () {
             ['c', '🌊'],
           ],
         });
+        // Explicit line ending assertions since snapshots normalize CRLF to LF.
+        // The README already used CRLF, and the empty rule docs use CRLF from the config.
+        const readme = await fixture.readFile('README.md');
+        expect(readme).toContain('\r\n');
+        expect(readme.replaceAll('\r\n', '')).not.toContain('\n');
+        const docA = await fixture.readFile('docs/rules/a.md');
+        expect(docA).toContain('\r\n');
+        expect(docA.replaceAll('\r\n', '')).not.toContain('\n');
+
         expect(await fixture.readFile('README.md')).toMatchSnapshot();
         expect(await fixture.readFile('docs/rules/a.md')).toMatchSnapshot();
         expect(await fixture.readFile('docs/rules/B.md')).toMatchSnapshot();
@@ -195,6 +251,7 @@ describe('getEndOfLine', function () {
                   end_of_line = crlf`,
           },
         });
+        process.chdir(fixture.path);
 
         await generate(fixture.path, {
           configEmoji: [
@@ -203,6 +260,15 @@ describe('getEndOfLine', function () {
             ['c', '🌊'],
           ],
         });
+        // Explicit line ending assertions since snapshots normalize CRLF to LF.
+        // The README already used CRLF, and the empty rule docs use CRLF from the `*.md` config.
+        const readme = await fixture.readFile('README.md');
+        expect(readme).toContain('\r\n');
+        expect(readme.replaceAll('\r\n', '')).not.toContain('\n');
+        const docA = await fixture.readFile('docs/rules/a.md');
+        expect(docA).toContain('\r\n');
+        expect(docA.replaceAll('\r\n', '')).not.toContain('\n');
+
         expect(await fixture.readFile('README.md')).toMatchSnapshot();
         expect(await fixture.readFile('docs/rules/a.md')).toMatchSnapshot();
         expect(await fixture.readFile('docs/rules/B.md')).toMatchSnapshot();
@@ -269,6 +335,123 @@ describe('getEndOfLine', function () {
       process.chdir(fixture.path);
 
       expect(await getEndOfLine()).toStrictEqual('\n');
+    });
+  });
+
+  describe('end-of-line detection from existing files', function () {
+    let fixture: FixtureContext;
+    let originalCwd: string;
+
+    beforeEach(function () {
+      originalCwd = process.cwd();
+    });
+
+    afterEach(async function () {
+      process.chdir(originalCwd);
+      await fixture.cleanup();
+    });
+
+    it('preserves content after the rule header marker when the rule doc uses different line endings than the configured end of line (#725)', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          // Rule doc uses LF line endings.
+          'docs/rules/no-foo.md':
+            '# Description of no-foo (`test/no-foo`)\n\n<!-- end auto-generated rule header -->\n\nSome description.\n\n## Further Reading\n\n- [link](https://example.com/)\n',
+          'README.md':
+            '## Rules\n\n<!-- begin auto-generated rules list -->\n<!-- end auto-generated rules list -->\n',
+          // But the configured end of line is CRLF (same situation as the `os.EOL` fallback on Windows).
+          '.editorconfig': `
+                root = true
+
+                [*]
+                end_of_line = crlf`,
+        },
+      });
+      process.chdir(fixture.path);
+
+      await generate(fixture.path);
+
+      const ruleDoc = await fixture.readFile('docs/rules/no-foo.md');
+      expect(ruleDoc).toContain('## Further Reading');
+      expect(ruleDoc).not.toContain('\r'); // Keeps its existing LF line endings.
+    });
+
+    it('inserts the rules list using the line endings of the existing file (#726)', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'docs/rules/no-foo.md': '',
+          // README uses CRLF line endings but the configured end of line is LF.
+          'README.md':
+            '## Rules\r\n\r\n<!-- begin auto-generated rules list -->\r\n<!-- end auto-generated rules list -->\r\n',
+          '.editorconfig': `
+                root = true
+
+                [*]
+                end_of_line = lf`,
+        },
+      });
+      process.chdir(fixture.path);
+
+      await generate(fixture.path);
+
+      const readme = await fixture.readFile('README.md');
+      expect(readme).toContain('\r\n');
+      // No mixed line endings: every LF should be part of a CRLF.
+      expect(readme.replaceAll('\r\n', '')).not.toContain('\n');
+    });
+
+    it('unifies mixed line endings to the predominant one in the file', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'docs/rules/no-foo.md': '',
+          // README has mostly-CRLF but mixed line endings (as could be produced by older versions of this tool).
+          'README.md':
+            '# eslint-plugin-test\n\r\n## Rules\r\n\r\n<!-- begin auto-generated rules list -->\r\n<!-- end auto-generated rules list -->\r\n',
+          '.editorconfig': `
+                root = true
+
+                [*]
+                end_of_line = lf`,
+        },
+      });
+      process.chdir(fixture.path);
+
+      await generate(fixture.path);
+
+      const readme = await fixture.readFile('README.md');
+      expect(readme).toContain('\r\n');
+      // No mixed line endings: every LF should be part of a CRLF.
+      expect(readme.replaceAll('\r\n', '')).not.toContain('\n');
+    });
+
+    it('passes in --check mode when up-to-date files use different line endings than the configured end of line', async function () {
+      const ruleDocCrlf =
+        '# Description of no-foo (`test/no-foo`)\r\n\r\n<!-- end auto-generated rule header -->\r\n\r\nSome description.\r\n';
+      const readmeCrlf =
+        '## Rules\r\n\r\n<!-- begin auto-generated rules list -->\r\n<!-- end auto-generated rules list -->\r\n';
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'docs/rules/no-foo.md': ruleDocCrlf,
+          'README.md': readmeCrlf,
+          '.editorconfig': `
+                root = true
+
+                [*]
+                end_of_line = lf`,
+        },
+      });
+      process.chdir(fixture.path);
+
+      // First, bring the CRLF docs up-to-date.
+      await generate(fixture.path);
+
+      // Then, --check should pass since nothing needs to change.
+      await generate(fixture.path, { check: true });
+      expect(process.exitCode).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
Fixes #725
Fixes #726

## Investigation

Both issues turned out to share one root cause, plus one additional bug:

1. **A single end of line is detected per run** (EditorConfig → Prettier config → `os.EOL`) and is used both for **parsing** existing files and for **serializing** generated content. When a file on disk uses different line endings than the detected end of line (e.g. after Prettier rewrote a doc with LF on Windows, where the fallback is CRLF):
   - `replaceOrCreateHeader` splits the doc on the wrong end of line, so the whole file collapses into a single "line" starting with `# `. Everything after the title is then sliced away — the content deletion reported in #725.
   - Generated lists are spliced in with the wrong end of line (markers are found via `indexOf`, which is EOL-agnostic), producing the mixed line endings reported in #726.
2. **`markdown-table` hard-codes LF** between table rows, so even a fully-CRLF run produced tables with LF internals — also #726 ("inserted tables have mixed LF/CRLF").

## Fix

- `lib/eol.ts`: add `detectEndOfLine()` (predominant end of line in a file) and `normalizeEndOfLine()`.
- `lib/context.ts`: add `getContextForFileContents()` to derive a per-file context using the file's detected end of line, falling back to the configured one for files without line breaks.
- `lib/generator.ts`: process each rule doc and rule list file with its per-file context, normalizing any mixed line endings to the file's predominant one first so line-based processing is reliable.
- `lib/rule-list.ts`, `lib/config-list.ts`, `lib/rule-options-list.ts`: convert `markdownTable()` output from its hard-coded LF to the target end of line.

Net behavior:

- Existing files keep their current line endings, even when they differ from the configured end of line (the expectation stated in #726).
- Doc content is never deleted due to line ending mismatches (#725).
- Generated content never introduces mixed line endings; files that already have mixed endings (e.g. from prior runs of this bug) are unified to their predominant end of line on the next run — a one-time diff.
- `--check` passes on up-to-date files regardless of their line endings.
- The configured end of line still applies to newly created docs (`--init-rule-docs`) and empty files.

## Tests

- Direct regression tests for #725 and #726, a mixed-endings unification test, a `--check`-mode test, and unit tests for the new helpers.
- Fixed a pre-existing gap: the `generates using crlf end of line from ".editorconfig"` tests never `chdir`'d into their fixture (so this repo's own `.prettierrc.json` determined the end of line) and snapshot comparison normalizes CRLF→LF anyway, so they could not fail on line endings. Added the missing `chdir`s and explicit `\r\n` assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)