### PR TITLE
fix: process markdown using LF internally, applying each file's end of line only when writing

### DIFF
--- a/lib/config-list.ts
+++ b/lib/config-list.ts
@@ -60,7 +60,7 @@ function generateConfigListMarkdown(context: Context): string {
   ];
 
   return markdownTable(
-    sanitizeMarkdownTable(context, rows),
+    sanitizeMarkdownTable(rows),
     { align: 'l' }, // Left-align headers.
   );
 }
@@ -70,7 +70,7 @@ export function updateConfigsList(
   markdown: string,
   isMdx: boolean,
 ): string {
-  const { configsToRules, endOfLine, options } = context;
+  const { configsToRules, options } = context;
   const { ignoreConfig } = options;
 
   const formattedConfigListMarkerBegin = formatComment(
@@ -108,5 +108,5 @@ export function updateConfigsList(
   // New config list.
   const list = generateConfigListMarkdown(context);
 
-  return `${preList}${formattedConfigListMarkerBegin}${endOfLine}${endOfLine}${list}${endOfLine}${endOfLine}${formattedConfigListMarkerEnd}${postList}`;
+  return `${preList}${formattedConfigListMarkerBegin}\n\n${list}\n\n${formattedConfigListMarkerEnd}${postList}`;
 }

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -1,5 +1,4 @@
 import { mockPlugin } from './mock-plugin.js';
-import { getEndOfLine } from './eol.js';
 import { getResolvedOptions } from './options.js';
 import type { ResolvedGenerateOptions } from './options.js';
 import { getPluginName, loadPlugin } from './package-json.js';
@@ -8,12 +7,14 @@ import { getPluginPrefix } from './plugin-prefix.js';
 import { resolveConfigsToRules } from './plugin-config-resolution.js';
 
 /**
- * Context about the current invocation of the program, like what end-of-line
- * character to use.
+ * Context about the current invocation of the program.
+ *
+ * Note: all markdown content is processed using LF (`\n`) line endings
+ * internally. The desired end of line for each file is only applied when
+ * writing the file in the generator.
  */
 export interface Context {
   configsToRules: ConfigsToRules;
-  endOfLine: string;
   options: ResolvedGenerateOptions;
   path: string;
   plugin: Plugin;
@@ -25,7 +26,6 @@ export async function getContext(
   userOptions?: GenerateOptions,
   useMockPlugin = false,
 ): Promise<Context> {
-  const endOfLine = await getEndOfLine();
   const plugin = useMockPlugin ? mockPlugin : await loadPlugin(path);
   const pluginPrefix = getPluginPrefix(
     plugin.meta?.name ?? (await getPluginName(path)),
@@ -36,7 +36,6 @@ export async function getContext(
 
   return {
     configsToRules,
-    endOfLine,
     options,
     path,
     plugin,

--- a/lib/eol.ts
+++ b/lib/eol.ts
@@ -60,6 +60,31 @@ async function getEndOfLineFromPrettierConfig(): Promise<
   return '\n';
 }
 
+/**
+ * Detect the predominant end of line in the given file contents.
+ * Returns undefined if the contents have no line breaks.
+ */
+export function detectEndOfLine(contents: string): '\n' | '\r\n' | undefined {
+  const crlfCount = contents.match(/\r\n/gu)?.length ?? 0;
+  const lfCount = contents.match(/(?<!\r)\n/gu)?.length ?? 0;
+
+  if (crlfCount === 0 && lfCount === 0) {
+    return undefined;
+  }
+
+  return crlfCount > lfCount ? '\r\n' : '\n';
+}
+
+/**
+ * Convert all line endings in the given contents to the given end of line.
+ */
+export function normalizeEndOfLine(
+  contents: string,
+  endOfLine: string,
+): string {
+  return contents.replaceAll(/\r\n|\n/gu, endOfLine);
+}
+
 /* istanbul ignore next */
 /** `EOL` is typed as `string`, so we perform run-time validation to be safe. */
 function getNodeEOL(): '\n' | '\r\n' {

--- a/lib/frontmatter.ts
+++ b/lib/frontmatter.ts
@@ -19,19 +19,16 @@ export function generateFrontmatterLines(
   frontmatterOld: string | undefined,
 ): string {
   const {
-    endOfLine,
     options: { framework },
   } = context;
   const title = makeRuleDocTitle(context, name, description);
 
-  const oldFrontmatterLines = frontmatterOld
-    ? frontmatterOld.split(endOfLine)
-    : [];
+  const oldFrontmatterLines = frontmatterOld ? frontmatterOld.split('\n') : [];
 
   // If the framework is 'none', then just bail out and return the old frontmatter.
   // We don't want to change anything.
   if (framework === 'none') {
-    return oldFrontmatterLines.join(endOfLine);
+    return oldFrontmatterLines.join('\n');
   }
 
   // If there is currently no frontmatter, then create a new one with the title and description.
@@ -43,7 +40,7 @@ export function generateFrontmatterLines(
       );
     }
     newFrontmatter.push('---');
-    return newFrontmatter.join(endOfLine);
+    return newFrontmatter.join('\n');
   }
 
   const newFrontmatter = [];
@@ -78,5 +75,5 @@ export function generateFrontmatterLines(
       formatFrontmatterProperty('description', description),
     );
   }
-  return newFrontmatter.join(endOfLine);
+  return newFrontmatter.join('\n');
 }

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -26,6 +26,7 @@ import { replaceRulePlaceholder } from './rule-link.js';
 import { updateRuleOptionsList } from './rule-options-list.js';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { getContext } from './context.js';
+import { detectEndOfLine, getEndOfLine, normalizeEndOfLine } from './eol.js';
 import { generateSuggestedEmojis } from './suggest-emojis.js';
 import { generateFrontmatterLines } from './frontmatter.js';
 
@@ -61,7 +62,13 @@ function resolveDocPath(configuredPath: string): string | undefined {
 // eslint-disable-next-line complexity
 export async function generate(path: string, userOptions?: GenerateOptions) {
   const context = await getContext(path, userOptions);
-  const { endOfLine, options, plugin } = context;
+  const { options, plugin } = context;
+
+  // All markdown content is processed using LF (`\n`) line endings internally.
+  // Each file is written using the end of line already predominant in that
+  // file, falling back to the configured end of line (EditorConfig, then
+  // Prettier, then `os.EOL`) for new files and files without line breaks.
+  const configuredEndOfLine = await getEndOfLine();
 
   // Destructure options that are only used in this function. Other options are passed around using
   // the "context" object.
@@ -142,31 +149,40 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
       const isRuleDocMdx = isMdx(pathToDoc);
       let newRuleDocContents = [
         ruleDocSectionInclude.length > 0
-          ? ruleDocSectionInclude
-              .map((title) => `## ${title}`)
-              .join(`${endOfLine}${endOfLine}`)
+          ? ruleDocSectionInclude.map((title) => `## ${title}`).join('\n\n')
           : undefined,
         /* istanbul ignore next -- both branches tested but coverage has instrumentation issue with ternary in array */
         ruleHasOptions
-          ? `## Options${endOfLine}${endOfLine}${formatComment(BEGIN_RULE_OPTIONS_LIST_MARKER, isRuleDocMdx)}${endOfLine}${formatComment(END_RULE_OPTIONS_LIST_MARKER, isRuleDocMdx)}`
+          ? `## Options\n\n${formatComment(BEGIN_RULE_OPTIONS_LIST_MARKER, isRuleDocMdx)}\n${formatComment(END_RULE_OPTIONS_LIST_MARKER, isRuleDocMdx)}`
           : undefined,
       ]
         .filter((section) => section !== undefined)
-        .join(`${endOfLine}${endOfLine}`);
+        .join('\n\n');
       /* istanbul ignore next -- V8 branch coverage doesn't detect this branch is tested */
       if (newRuleDocContents !== '') {
-        newRuleDocContents = `${endOfLine}${newRuleDocContents}${endOfLine}`;
+        newRuleDocContents = `\n${newRuleDocContents}\n`;
       }
 
       await mkdir(dirname(pathToDoc), { recursive: true });
-      await writeFile(pathToDoc, newRuleDocContents);
+      await writeFile(
+        pathToDoc,
+        normalizeEndOfLine(newRuleDocContents, configuredEndOfLine),
+      );
       initializedRuleDoc = true;
     }
 
     const isRuleDocMdx = isMdx(pathToDoc);
     const contentsOldBuffer = await readFile(pathToDoc);
     const contentsOld = contentsOldBuffer.toString();
-    const frontmatterOld = extractFrontmatter(context, contentsOld);
+
+    // Process the doc using LF line endings. When writing, use the end of
+    // line already predominant in the doc so that its line endings are
+    // preserved even when they differ from the configured end of line (such
+    // as when another tool like Prettier rewrote the doc).
+    const endOfLine = detectEndOfLine(contentsOld) ?? configuredEndOfLine;
+    const contentsOldNormalized = normalizeEndOfLine(contentsOld, '\n');
+
+    const frontmatterOld = extractFrontmatter(contentsOldNormalized);
 
     // Regenerate the header (title/notices) and frontmatter of each rule doc.
     const newHeaderLines = generateRuleHeaderLines(
@@ -184,23 +200,22 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
 
     // Generate the new content for the rule doc by replacing the header and frontmatter, and updating the rule options list if necessary.
     let contentsNew = replaceOrCreateFrontmatter(
-      context,
-      contentsOld,
+      contentsOldNormalized,
       newFrontmatterLines,
     );
     contentsNew = replaceOrCreateHeader(
-      context,
       contentsNew,
       newHeaderLines,
       isRuleDocMdx,
     );
-    contentsNew = updateRuleOptionsList(
-      context,
-      contentsNew,
-      rule,
-      isRuleDocMdx,
-    );
+    contentsNew = updateRuleOptionsList(contentsNew, rule, isRuleDocMdx);
+
+    // Convert to the doc's end of line before postprocessing and writing.
+    contentsNew = normalizeEndOfLine(contentsNew, endOfLine);
     contentsNew = await postprocess(contentsNew, resolve(pathToDoc));
+
+    // LF-normalized copy of the final contents for the content checks below.
+    const contentsNewNormalized = normalizeEndOfLine(contentsNew, '\n');
 
     if (check) {
       /* istanbul ignore next -- V8 branch coverage doesn't detect this branch is tested */
@@ -223,9 +238,8 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     // Check for required sections.
     for (const section of ruleDocSectionInclude) {
       expectSectionHeaderOrFail(
-        context,
         `\`${name}\` rule doc`,
-        contentsNew,
+        contentsNewNormalized,
         [section],
         true,
       );
@@ -234,9 +248,8 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     // Check for disallowed sections.
     for (const section of ruleDocSectionExclude) {
       expectSectionHeaderOrFail(
-        context,
         `\`${name}\` rule doc`,
-        contentsNew,
+        contentsNewNormalized,
         [section],
         false,
       );
@@ -245,9 +258,8 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     if (ruleDocSectionOptions) {
       // Options section.
       expectSectionHeaderOrFail(
-        context,
         `\`${name}\` rule doc`,
-        contentsNew,
+        contentsNewNormalized,
         ['Options', 'Config'],
         ruleHasOptions,
       );
@@ -258,7 +270,7 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
         expectContentOrFail(
           `\`${name}\` rule doc`,
           'rule option',
-          contentsNew,
+          contentsNewNormalized,
           namedOption,
           true,
         ); // Each rule option is mentioned.
@@ -287,14 +299,24 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
 
     // Update the rules list in this file.
     const fileContents = await readFile(pathToFile, 'utf8');
+
+    // Process the file using LF line endings. When writing, use the end of
+    // line already predominant in the file so that its line endings are
+    // preserved even when they differ from the configured end of line.
+    const endOfLine = detectEndOfLine(fileContents) ?? configuredEndOfLine;
+    const fileContentsNormalized = normalizeEndOfLine(fileContents, '\n');
+
     const rulesList = updateRulesList(
       context,
       ruleNamesAndRules,
-      fileContents,
+      fileContentsNormalized,
       pathToFile,
     );
     const fileContentsNew = await postprocess(
-      updateConfigsList(context, rulesList, isRuleListMdx),
+      normalizeEndOfLine(
+        updateConfigsList(context, rulesList, isRuleListMdx),
+        endOfLine,
+      ),
       resolve(pathToFile),
     );
 

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -1,11 +1,12 @@
 // General helpers for dealing with markdown files / content.
+// All markdown content is processed using LF (`\n`) line endings. The desired
+// end of line for each file is only applied when writing the file.
 
 import { END_RULE_HEADER_MARKER, formatComment } from './comment-markers.js';
 import type { Context } from './context.js';
 
-export function extractFrontmatter(context: Context, markdown: string) {
-  const { endOfLine } = context;
-  const lines = markdown.split(endOfLine);
+export function extractFrontmatter(markdown: string) {
+  const lines = markdown.split('\n');
   const frontMatterStart = lines.indexOf('---');
 
   // Frontmatter must start at the beginning of the file to be considered valid, so if we don't find '---' at the beginning, we want to ignore it.
@@ -14,19 +15,17 @@ export function extractFrontmatter(context: Context, markdown: string) {
   }
   const frontMatterEnd = lines.indexOf('---', frontMatterStart + 1);
   if (frontMatterEnd !== -1) {
-    return lines.slice(frontMatterStart, frontMatterEnd + 1).join(endOfLine);
+    return lines.slice(frontMatterStart, frontMatterEnd + 1).join('\n');
   }
   return undefined;
 }
 
 /**
  * Replace the frontmatter, if present.  If not and we have newFrontmatter to add, then add it at the beginning.
- * @param context - execution context
  * @param markdown - doc content
  * @param newFrontmatter - new frontmatter
  */
 export function replaceOrCreateFrontmatter(
-  context: Context,
   markdown: string,
   newFrontmatter: string | undefined,
 ): string {
@@ -35,39 +34,33 @@ export function replaceOrCreateFrontmatter(
     return markdown;
   }
 
-  const { endOfLine } = context;
-
-  const lines = markdown.split(endOfLine);
+  const lines = markdown.split('\n');
 
   const frontmatterStartIndex = lines.indexOf('---');
 
   // If there's no existing frontmatter, just add it to the top.
   if (frontmatterStartIndex !== 0) {
-    return [newFrontmatter, markdown].join(endOfLine);
+    return [newFrontmatter, markdown].join('\n');
   }
 
   const frontmatterEndIndex = lines.indexOf('---', frontmatterStartIndex + 1);
-  const postFrontmatter = lines.slice(frontmatterEndIndex + 1).join(endOfLine);
-  return [newFrontmatter, postFrontmatter].join(endOfLine);
+  const postFrontmatter = lines.slice(frontmatterEndIndex + 1).join('\n');
+  return [newFrontmatter, postFrontmatter].join('\n');
 }
 
 /**
  * Replace the header of a doc up to and including the specified marker.
  * Insert at beginning if header doesn't exist.
- * @param context - execution context
  * @param markdown - doc content
  * @param newHeader - new header including marker
  * @param isMdx - is the file we're working on mdx or just regular md
  */
 export function replaceOrCreateHeader(
-  context: Context,
   markdown: string,
   newHeader: string,
   isMdx: boolean,
 ) {
-  const { endOfLine } = context;
-
-  const lines = markdown.split(endOfLine);
+  const lines = markdown.split('\n');
 
   const titleLineIndex = lines.findIndex((line) => line.startsWith('# '));
   const markerLineIndex = lines.indexOf(
@@ -79,32 +72,27 @@ export function replaceOrCreateHeader(
   // Any YAML front matter or anything else above the title should be kept as-is ahead of the new header.
   const preHeader = lines
     .slice(0, Math.max(titleLineIndex, dashesLineIndex2 + 1))
-    .join(endOfLine);
+    .join('\n');
 
   // Anything after the marker comment, title, or YAML front matter should be kept as-is after the new header.
   const postHeader = lines
     .slice(
       Math.max(markerLineIndex + 1, titleLineIndex + 1, dashesLineIndex2 + 1),
     )
-    .join(endOfLine);
+    .join('\n');
 
-  return `${
-    preHeader ? `${preHeader}${endOfLine}` : ''
-  }${newHeader}${endOfLine}${postHeader}`;
+  return `${preHeader ? `${preHeader}\n` : ''}${newHeader}\n${postHeader}`;
 }
 
 /**
  * Find the section most likely to be the top-level section for a given string.
  */
 export function findSectionHeader(
-  context: Context,
   markdown: string,
   str: string,
 ): string | undefined {
-  const { endOfLine } = context;
-
   // Get all the matching strings.
-  const regexp = new RegExp(`## .*${str}.*${endOfLine}`, 'giu');
+  const regexp = new RegExp(`## .*${str}.*\n`, 'giu');
   const sectionPotentialMatches = [...markdown.matchAll(regexp)].map(
     (match) => match[0],
   );
@@ -130,11 +118,10 @@ export function findFinalHeaderLevel(
   str: string,
 ): number | undefined {
   const {
-    endOfLine,
     options: { framework },
   } = context;
 
-  const lines = str.split(endOfLine);
+  const lines = str.split('\n');
   const finalHeader = lines
     .toReversed()
     .find((line) => line.match('^(#+) .+$'));
@@ -143,7 +130,7 @@ export function findFinalHeaderLevel(
     return finalHeader.indexOf(' ');
   }
   // If the framework is `starlight` and there's frontmatter at the top, treat that as an H1
-  else if (framework === 'starlight' && extractFrontmatter(context, str)) {
+  else if (framework === 'starlight' && extractFrontmatter(str)) {
     return 1;
   }
 
@@ -184,14 +171,13 @@ export function expectContentOrFail(
 }
 
 export function expectSectionHeaderOrFail(
-  context: Context,
   contentName: string,
   contents: string,
   possibleHeaders: readonly string[],
   expected: boolean,
 ) {
   const found = possibleHeaders.some((header) =>
-    findSectionHeader(context, contents, header),
+    findSectionHeader(contents, header),
   );
   if (found !== expected) {
     if (possibleHeaders.length > 1) {

--- a/lib/rule-doc-notices.ts
+++ b/lib/rule-doc-notices.ts
@@ -481,7 +481,6 @@ export function generateRuleHeaderLines(
   isMdx: boolean,
 ): string {
   const {
-    endOfLine,
     options: { framework },
   } = context;
 
@@ -492,5 +491,5 @@ export function generateRuleHeaderLines(
     ...getRuleNoticeLines(context, name),
     '',
     formatComment(END_RULE_HEADER_MARKER, isMdx),
-  ].join(endOfLine);
+  ].join('\n');
 }

--- a/lib/rule-list-legend.ts
+++ b/lib/rule-list-legend.ts
@@ -169,8 +169,6 @@ export function generateLegend(
   context: Context,
   columns: Record<COLUMN_TYPE, boolean>,
 ) {
-  const { endOfLine } = context;
-
   const legends = (
     Object.entries(columns) as readonly [COLUMN_TYPE, boolean][]
   ).flatMap(([columnType, enabled]) => {
@@ -208,5 +206,5 @@ export function generateLegend(
   }
 
   // The backslashes ensure that they end up displayed on separate lines.
-  return legends.join(`\\${endOfLine}`);
+  return legends.join('\\\n');
 }

--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -162,7 +162,7 @@ function generateRulesListMarkdown(
   });
 
   return markdownTable(
-    sanitizeMarkdownTable(context, [
+    sanitizeMarkdownTable([
       listHeaderRow,
       ...ruleNamesAndRules.map(([name, rule]) =>
         buildRuleRow(context, name, rule, columns, pathToFile),
@@ -186,7 +186,6 @@ function generateRuleListMarkdownForRulesAndHeaders(
   columns: Record<COLUMN_TYPE, boolean>,
   pathToFile: string,
 ): string {
-  const { endOfLine } = context;
   const parts: string[] = [];
 
   for (const { title, rules, description } of rulesAndHeaders) {
@@ -199,7 +198,7 @@ function generateRuleListMarkdownForRulesAndHeaders(
     parts.push(generateRulesListMarkdown(context, rules, columns, pathToFile));
   }
 
-  return parts.join(`${endOfLine}${endOfLine}`);
+  return parts.join('\n\n');
 }
 
 /**
@@ -312,7 +311,7 @@ export function updateRulesList(
   markdown: string,
   pathToFile: string,
 ): string {
-  const { endOfLine, path, options } = context;
+  const { path, options } = context;
   const { ruleListSplit } = options;
 
   const isMdx = pathToFile.endsWith('.mdx');
@@ -326,7 +325,7 @@ export function updateRulesList(
   let listEndIndex = markdown.indexOf(formattedRuleListMarkerEnd);
 
   // Find the best possible section to insert the rules list into if the markers are missing.
-  const rulesSectionHeader = findSectionHeader(context, markdown, 'rules');
+  const rulesSectionHeader = findSectionHeader(markdown, 'rules');
   const rulesSectionIndex = rulesSectionHeader
     ? markdown.indexOf(rulesSectionHeader)
     : -1;
@@ -438,7 +437,7 @@ export function updateRulesList(
     pathToFile,
   );
 
-  const newContent = `${legend ? `${legend}${endOfLine}${endOfLine}` : ''}${list}`;
+  const newContent = `${legend ? `${legend}\n\n` : ''}${list}`;
 
-  return `${preList}${formattedRuleListMarkerBegin}${endOfLine}${endOfLine}${newContent}${endOfLine}${endOfLine}${formattedRuleListMarkerEnd}${postList}`;
+  return `${preList}${formattedRuleListMarkerBegin}\n\n${newContent}\n\n${formattedRuleListMarkerEnd}${postList}`;
 }

--- a/lib/rule-options-list.ts
+++ b/lib/rule-options-list.ts
@@ -8,7 +8,6 @@ import type { RuleModule } from './types.js';
 import { getAllNamedOptions } from './rule-options.js';
 import type { RuleOption } from './rule-options.js';
 import { sanitizeMarkdownTable } from './string.js';
-import type { Context } from './context.js';
 
 const COLUMN_TYPE = {
   // Alphabetical order.
@@ -113,10 +112,7 @@ function ruleOptionsToColumnsToDisplay(ruleOptions: readonly RuleOption[]): {
   return columnsToDisplay;
 }
 
-function generateRuleOptionsListMarkdown(
-  context: Context,
-  rule: RuleModule,
-): string {
+function generateRuleOptionsListMarkdown(rule: RuleModule): string {
   const ruleOptions = getAllNamedOptions(
     rule.meta?.schema,
     rule.meta?.defaultOptions,
@@ -145,19 +141,16 @@ function generateRuleOptionsListMarkdown(
     });
 
   return markdownTable(
-    sanitizeMarkdownTable(context, [listHeaderRow, ...rows]),
+    sanitizeMarkdownTable([listHeaderRow, ...rows]),
     { align: 'l' }, // Left-align headers.
   );
 }
 
 export function updateRuleOptionsList(
-  context: Context,
   markdown: string,
   rule: RuleModule,
   isMdx: boolean,
 ): string {
-  const { endOfLine } = context;
-
   const formattedRuleOptionsListMarkerBegin = formatComment(
     BEGIN_RULE_OPTIONS_LIST_MARKER,
     isMdx,
@@ -182,7 +175,7 @@ export function updateRuleOptionsList(
   const postList = markdown.slice(Math.max(0, listEndIndex));
 
   // New rule options list.
-  const list = generateRuleOptionsListMarkdown(context, rule);
+  const list = generateRuleOptionsListMarkdown(rule);
 
-  return `${preList}${formattedRuleOptionsListMarkerBegin}${endOfLine}${endOfLine}${list}${endOfLine}${endOfLine}${formattedRuleOptionsListMarkerEnd}${postList}`;
+  return `${preList}${formattedRuleOptionsListMarkerBegin}\n\n${list}\n\n${formattedRuleOptionsListMarkerEnd}${postList}`;
 }

--- a/lib/string.ts
+++ b/lib/string.ts
@@ -1,5 +1,3 @@
-import type { Context } from './context.js';
-
 export function toSentenceCase(str: string) {
   return str.replace(/^\w/u, function (txt) {
     return txt.charAt(0).toUpperCase() + txt.slice(1).toLowerCase();
@@ -21,19 +19,13 @@ export function capitalizeOnlyFirstLetter(str: string) {
   return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 }
 
-function sanitizeMarkdownTableCell(context: Context, text: string): string {
-  const { endOfLine } = context;
-
-  return text
-    .replaceAll('|', String.raw`\|`)
-    .replaceAll(new RegExp(endOfLine, 'gu'), '<br/>');
+function sanitizeMarkdownTableCell(text: string): string {
+  // Handle CRLF line endings too since cell text can come from rule metadata.
+  return text.replaceAll('|', String.raw`\|`).replaceAll(/\r?\n/gu, '<br/>');
 }
 
 export function sanitizeMarkdownTable(
-  context: Context,
   text: readonly (readonly string[])[],
 ): readonly (readonly string[])[] {
-  return text.map((row) =>
-    row.map((col) => sanitizeMarkdownTableCell(context, col)),
-  );
+  return text.map((row) => row.map((col) => sanitizeMarkdownTableCell(col)));
 }

--- a/test/lib/frontmatter-test.ts
+++ b/test/lib/frontmatter-test.ts
@@ -4,10 +4,6 @@ import { getContext, type Context } from '../../lib/context.js';
 
 const cwd = process.cwd();
 
-function normalize(context: Context, markdown: string) {
-  return markdown.split('\n').join(context.endOfLine);
-}
-
 const name = 'no-foo';
 const description = 'Description for no-foo.';
 
@@ -27,15 +23,12 @@ describe('frontmatter', function () {
       });
 
       it('should return old frontmatter if it exists', function () {
-        const frontmatter = normalize(
-          context,
-          outdent`
-            ---
-            title: no-foo
-            description: Description for no-foo.
-            ---
-          `,
-        );
+        const frontmatter = outdent`
+          ---
+          title: no-foo
+          description: Description for no-foo.
+          ---
+        `;
         expect(
           generateFrontmatterLines(context, name, description, frontmatter),
         ).toBe(frontmatter);
@@ -48,135 +41,108 @@ describe('frontmatter', function () {
       });
 
       it('should create new frontmatter if no old frontmatter existed', function () {
-        const expected = normalize(
-          context,
-          outdent`
-            ---
-            title: "eslint-doc-generator/no-foo"
-            description: "Description for no-foo."
-            ---
-          `,
-        );
+        const expected = outdent`
+          ---
+          title: "eslint-doc-generator/no-foo"
+          description: "Description for no-foo."
+          ---
+        `;
         expect(
           generateFrontmatterLines(context, name, description, undefined),
         ).toBe(expected);
       });
 
       it('should add title and description to old frontmatter', function () {
-        const oldFrontmatter = normalize(
-          context,
-          outdent`
-            ---
-            tableOfContents:
-              minHeadingLevel: 2
-              maxHeadingLevel: 2
-            ---
-          `,
-        );
+        const oldFrontmatter = outdent`
+          ---
+          tableOfContents:
+            minHeadingLevel: 2
+            maxHeadingLevel: 2
+          ---
+        `;
 
-        const expected = normalize(
-          context,
-          outdent`
-            ---
-            title: "eslint-doc-generator/no-foo"
-            description: "Description for no-foo."
-            tableOfContents:
-              minHeadingLevel: 2
-              maxHeadingLevel: 2
-            ---
-          `,
-        );
+        const expected = outdent`
+          ---
+          title: "eslint-doc-generator/no-foo"
+          description: "Description for no-foo."
+          tableOfContents:
+            minHeadingLevel: 2
+            maxHeadingLevel: 2
+          ---
+        `;
         expect(
           generateFrontmatterLines(context, name, description, oldFrontmatter),
         ).toBe(expected);
       });
 
       it('should add title to old frontmatter and replace description', function () {
-        const oldFrontmatter = normalize(
-          context,
-          outdent`
-            ---
-            tableOfContents:
-              minHeadingLevel: 2
-              maxHeadingLevel: 2
-            description: "Description for no-bar."
-            ---
-          `,
-        );
+        const oldFrontmatter = outdent`
+          ---
+          tableOfContents:
+            minHeadingLevel: 2
+            maxHeadingLevel: 2
+          description: "Description for no-bar."
+          ---
+        `;
 
-        const expected = normalize(
-          context,
-          outdent`
-            ---
-            title: "eslint-doc-generator/no-foo"
-            tableOfContents:
-              minHeadingLevel: 2
-              maxHeadingLevel: 2
-            description: "Description for no-foo."
-            ---
-          `,
-        );
+        const expected = outdent`
+          ---
+          title: "eslint-doc-generator/no-foo"
+          tableOfContents:
+            minHeadingLevel: 2
+            maxHeadingLevel: 2
+          description: "Description for no-foo."
+          ---
+        `;
         expect(
           generateFrontmatterLines(context, name, description, oldFrontmatter),
         ).toBe(expected);
       });
 
       it('should add description to old frontmatter and replace title', function () {
-        const oldFrontmatter = normalize(
-          context,
-          outdent`
-            ---
-            tableOfContents:
-              minHeadingLevel: 2
-              maxHeadingLevel: 2
-            title: "eslint-doc-generator/no-bar"
-            ---
-          `,
-        );
+        const oldFrontmatter = outdent`
+          ---
+          tableOfContents:
+            minHeadingLevel: 2
+            maxHeadingLevel: 2
+          title: "eslint-doc-generator/no-bar"
+          ---
+        `;
 
-        const expected = normalize(
-          context,
-          outdent`
-            ---
-            tableOfContents:
-              minHeadingLevel: 2
-              maxHeadingLevel: 2
-            title: "eslint-doc-generator/no-foo"
-            description: "Description for no-foo."
-            ---
-          `,
-        );
+        const expected = outdent`
+          ---
+          tableOfContents:
+            minHeadingLevel: 2
+            maxHeadingLevel: 2
+          title: "eslint-doc-generator/no-foo"
+          description: "Description for no-foo."
+          ---
+        `;
         expect(
           generateFrontmatterLines(context, name, description, oldFrontmatter),
         ).toBe(expected);
       });
 
       it('should should replace title and description in old frontmatter', function () {
-        const oldFrontmatter = normalize(
-          context,
-          outdent`
-            ---
-            tableOfContents:
-              minHeadingLevel: 2
-              maxHeadingLevel: 2
-            title: "eslint-doc-generator/no-bar"
-            description: "Description for no-bar."
-            ---
-          `,
-        );
+        const oldFrontmatter = outdent`
+          ---
+          tableOfContents:
+            minHeadingLevel: 2
+            maxHeadingLevel: 2
+          title: "eslint-doc-generator/no-bar"
+          description: "Description for no-bar."
+          ---
+        `;
 
-        const expected = normalize(
-          context,
-          outdent`
-            ---
-            tableOfContents:
-              minHeadingLevel: 2
-              maxHeadingLevel: 2
-            title: "eslint-doc-generator/no-foo"
-            description: "Description for no-foo."
-            ---
-          `,
-        );
+        const expected = outdent`
+          ---
+          tableOfContents:
+            minHeadingLevel: 2
+            maxHeadingLevel: 2
+          title: "eslint-doc-generator/no-foo"
+          description: "Description for no-foo."
+          ---
+        `;
         expect(
           generateFrontmatterLines(context, name, description, oldFrontmatter),
         ).toBe(expected);
@@ -185,31 +151,25 @@ describe('frontmatter', function () {
       it('should properly escape values', function () {
         const descriptionSpecial = 'Description of my "special" rule.';
 
-        const oldFrontmatter = normalize(
-          context,
-          outdent`
-            ---
-            tableOfContents:
-              minHeadingLevel: 2
-              maxHeadingLevel: 2
-            title: "eslint-doc-generator/no-bar"
-            description: "Description for no-bar."
-            ---
-          `,
-        );
+        const oldFrontmatter = outdent`
+          ---
+          tableOfContents:
+            minHeadingLevel: 2
+            maxHeadingLevel: 2
+          title: "eslint-doc-generator/no-bar"
+          description: "Description for no-bar."
+          ---
+        `;
 
-        const expected = normalize(
-          context,
-          outdent`
-            ---
-            tableOfContents:
-              minHeadingLevel: 2
-              maxHeadingLevel: 2
-            title: "eslint-doc-generator/no-foo"
-            description: "Description of my \\"special\\" rule."
-            ---
-          `,
-        );
+        const expected = outdent`
+          ---
+          tableOfContents:
+            minHeadingLevel: 2
+            maxHeadingLevel: 2
+          title: "eslint-doc-generator/no-foo"
+          description: "Description of my \\"special\\" rule."
+          ---
+        `;
         expect(
           generateFrontmatterLines(
             context,

--- a/test/lib/generate/eol-test.ts
+++ b/test/lib/generate/eol-test.ts
@@ -1,7 +1,42 @@
 import { generate } from '../../../lib/generator.js';
-import { getEndOfLine } from '../../../lib/eol.js';
+import {
+  detectEndOfLine,
+  getEndOfLine,
+  normalizeEndOfLine,
+} from '../../../lib/eol.js';
 import { EOL } from 'node:os';
 import { setupFixture, type FixtureContext } from '../../helpers/fixture.js';
+
+describe('detectEndOfLine', function () {
+  it('returns undefined for contents without line breaks', function () {
+    expect(detectEndOfLine('')).toBeUndefined();
+    expect(detectEndOfLine('no line breaks')).toBeUndefined();
+  });
+
+  it('detects lf', function () {
+    expect(detectEndOfLine('a\nb\nc\n')).toStrictEqual('\n');
+  });
+
+  it('detects crlf', function () {
+    expect(detectEndOfLine('a\r\nb\r\nc\r\n')).toStrictEqual('\r\n');
+  });
+
+  it('detects the predominant end of line in contents with mixed line endings', function () {
+    expect(detectEndOfLine('a\r\nb\r\nc\n')).toStrictEqual('\r\n');
+    expect(detectEndOfLine('a\nb\nc\r\n')).toStrictEqual('\n');
+  });
+});
+
+describe('normalizeEndOfLine', function () {
+  it('converts mixed line endings to the given end of line', function () {
+    expect(normalizeEndOfLine('a\r\nb\nc\r\n', '\n')).toStrictEqual(
+      'a\nb\nc\n',
+    );
+    expect(normalizeEndOfLine('a\r\nb\nc\r\n', '\r\n')).toStrictEqual(
+      'a\r\nb\r\nc\r\n',
+    );
+  });
+});
 
 describe('getEndOfLine', function () {
   describe('with a ".editorconfig" file', function () {
@@ -72,8 +107,14 @@ describe('getEndOfLine', function () {
 
     describe('generates using the correct end of line when ".editorconfig" exists', function () {
       let fixture: FixtureContext;
+      let originalCwd: string;
+
+      beforeEach(function () {
+        originalCwd = process.cwd();
+      });
 
       afterEach(async function () {
+        process.chdir(originalCwd);
         await fixture.cleanup();
       });
 
@@ -106,6 +147,7 @@ describe('getEndOfLine', function () {
                   end_of_line = lf`,
           },
         });
+        process.chdir(fixture.path);
 
         await generate(fixture.path, {
           configEmoji: [
@@ -114,6 +156,10 @@ describe('getEndOfLine', function () {
             ['c', '🌊'],
           ],
         });
+        // Explicit line ending assertions since snapshots normalize CRLF to LF.
+        expect(await fixture.readFile('README.md')).not.toContain('\r');
+        expect(await fixture.readFile('docs/rules/a.md')).not.toContain('\r');
+
         expect(await fixture.readFile('README.md')).toMatchSnapshot();
         expect(await fixture.readFile('docs/rules/a.md')).toMatchSnapshot();
         expect(await fixture.readFile('docs/rules/B.md')).toMatchSnapshot();
@@ -149,6 +195,7 @@ describe('getEndOfLine', function () {
                   end_of_line = crlf`,
           },
         });
+        process.chdir(fixture.path);
 
         await generate(fixture.path, {
           configEmoji: [
@@ -157,6 +204,15 @@ describe('getEndOfLine', function () {
             ['c', '🌊'],
           ],
         });
+        // Explicit line ending assertions since snapshots normalize CRLF to LF.
+        // The README already used CRLF, and the empty rule docs use CRLF from the config.
+        const readme = await fixture.readFile('README.md');
+        expect(readme).toContain('\r\n');
+        expect(readme.replaceAll('\r\n', '')).not.toContain('\n');
+        const docA = await fixture.readFile('docs/rules/a.md');
+        expect(docA).toContain('\r\n');
+        expect(docA.replaceAll('\r\n', '')).not.toContain('\n');
+
         expect(await fixture.readFile('README.md')).toMatchSnapshot();
         expect(await fixture.readFile('docs/rules/a.md')).toMatchSnapshot();
         expect(await fixture.readFile('docs/rules/B.md')).toMatchSnapshot();
@@ -195,6 +251,7 @@ describe('getEndOfLine', function () {
                   end_of_line = crlf`,
           },
         });
+        process.chdir(fixture.path);
 
         await generate(fixture.path, {
           configEmoji: [
@@ -203,6 +260,15 @@ describe('getEndOfLine', function () {
             ['c', '🌊'],
           ],
         });
+        // Explicit line ending assertions since snapshots normalize CRLF to LF.
+        // The README already used CRLF, and the empty rule docs use CRLF from the `*.md` config.
+        const readme = await fixture.readFile('README.md');
+        expect(readme).toContain('\r\n');
+        expect(readme.replaceAll('\r\n', '')).not.toContain('\n');
+        const docA = await fixture.readFile('docs/rules/a.md');
+        expect(docA).toContain('\r\n');
+        expect(docA.replaceAll('\r\n', '')).not.toContain('\n');
+
         expect(await fixture.readFile('README.md')).toMatchSnapshot();
         expect(await fixture.readFile('docs/rules/a.md')).toMatchSnapshot();
         expect(await fixture.readFile('docs/rules/B.md')).toMatchSnapshot();
@@ -269,6 +335,123 @@ describe('getEndOfLine', function () {
       process.chdir(fixture.path);
 
       expect(await getEndOfLine()).toStrictEqual('\n');
+    });
+  });
+
+  describe('end-of-line detection from existing files', function () {
+    let fixture: FixtureContext;
+    let originalCwd: string;
+
+    beforeEach(function () {
+      originalCwd = process.cwd();
+    });
+
+    afterEach(async function () {
+      process.chdir(originalCwd);
+      await fixture.cleanup();
+    });
+
+    it('preserves content after the rule header marker when the rule doc uses different line endings than the configured end of line (#725)', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          // Rule doc uses LF line endings.
+          'docs/rules/no-foo.md':
+            '# Description of no-foo (`test/no-foo`)\n\n<!-- end auto-generated rule header -->\n\nSome description.\n\n## Further Reading\n\n- [link](https://example.com/)\n',
+          'README.md':
+            '## Rules\n\n<!-- begin auto-generated rules list -->\n<!-- end auto-generated rules list -->\n',
+          // But the configured end of line is CRLF (same situation as the `os.EOL` fallback on Windows).
+          '.editorconfig': `
+                root = true
+
+                [*]
+                end_of_line = crlf`,
+        },
+      });
+      process.chdir(fixture.path);
+
+      await generate(fixture.path);
+
+      const ruleDoc = await fixture.readFile('docs/rules/no-foo.md');
+      expect(ruleDoc).toContain('## Further Reading');
+      expect(ruleDoc).not.toContain('\r'); // Keeps its existing LF line endings.
+    });
+
+    it('inserts the rules list using the line endings of the existing file (#726)', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'docs/rules/no-foo.md': '',
+          // README uses CRLF line endings but the configured end of line is LF.
+          'README.md':
+            '## Rules\r\n\r\n<!-- begin auto-generated rules list -->\r\n<!-- end auto-generated rules list -->\r\n',
+          '.editorconfig': `
+                root = true
+
+                [*]
+                end_of_line = lf`,
+        },
+      });
+      process.chdir(fixture.path);
+
+      await generate(fixture.path);
+
+      const readme = await fixture.readFile('README.md');
+      expect(readme).toContain('\r\n');
+      // No mixed line endings: every LF should be part of a CRLF.
+      expect(readme.replaceAll('\r\n', '')).not.toContain('\n');
+    });
+
+    it('unifies mixed line endings to the predominant one in the file', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'docs/rules/no-foo.md': '',
+          // README has mostly-CRLF but mixed line endings (as could be produced by older versions of this tool).
+          'README.md':
+            '# eslint-plugin-test\n\r\n## Rules\r\n\r\n<!-- begin auto-generated rules list -->\r\n<!-- end auto-generated rules list -->\r\n',
+          '.editorconfig': `
+                root = true
+
+                [*]
+                end_of_line = lf`,
+        },
+      });
+      process.chdir(fixture.path);
+
+      await generate(fixture.path);
+
+      const readme = await fixture.readFile('README.md');
+      expect(readme).toContain('\r\n');
+      // No mixed line endings: every LF should be part of a CRLF.
+      expect(readme.replaceAll('\r\n', '')).not.toContain('\n');
+    });
+
+    it('passes in --check mode when up-to-date files use different line endings than the configured end of line', async function () {
+      const ruleDocCrlf =
+        '# Description of no-foo (`test/no-foo`)\r\n\r\n<!-- end auto-generated rule header -->\r\n\r\nSome description.\r\n';
+      const readmeCrlf =
+        '## Rules\r\n\r\n<!-- begin auto-generated rules list -->\r\n<!-- end auto-generated rules list -->\r\n';
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'docs/rules/no-foo.md': ruleDocCrlf,
+          'README.md': readmeCrlf,
+          '.editorconfig': `
+                root = true
+
+                [*]
+                end_of_line = lf`,
+        },
+      });
+      process.chdir(fixture.path);
+
+      // First, bring the CRLF docs up-to-date.
+      await generate(fixture.path);
+
+      // Then, --check should pass since nothing needs to change.
+      await generate(fixture.path, { check: true });
+      expect(process.exitCode).toBeUndefined();
     });
   });
 

--- a/test/lib/markdown-test.ts
+++ b/test/lib/markdown-test.ts
@@ -10,10 +10,6 @@ import { getContext, type Context } from '../../lib/context.js';
 
 const cwd = process.cwd();
 
-function normalize(markdown: string, context: Context) {
-  return markdown.split('\n').join(context.endOfLine);
-}
-
 describe('markdown', function () {
   let context: Context;
 
@@ -33,7 +29,7 @@ describe('markdown', function () {
       `;
 
       expect(context).toBeDefined();
-      expect(extractFrontmatter(context, markdown)).toBe(outdent`
+      expect(extractFrontmatter(markdown)).toBe(outdent`
         ---
         title: Test Rule
         description: This is a test rule.
@@ -48,7 +44,7 @@ describe('markdown', function () {
       `;
 
       expect(context).toBeDefined();
-      expect(extractFrontmatter(context, markdown)).toBeUndefined();
+      expect(extractFrontmatter(markdown)).toBeUndefined();
     });
 
     it('should return undefined if there is only one frontmatter delimiter', function () {
@@ -59,7 +55,7 @@ describe('markdown', function () {
       `;
 
       expect(context).toBeDefined();
-      expect(extractFrontmatter(context, markdown)).toBeUndefined();
+      expect(extractFrontmatter(markdown)).toBeUndefined();
     });
 
     it('should return undefined if there is a frontmatter-like section that does not start at the beginning of the file', function () {
@@ -73,20 +69,17 @@ describe('markdown', function () {
       `;
 
       expect(context).toBeDefined();
-      expect(extractFrontmatter(context, markdown)).toBeUndefined();
+      expect(extractFrontmatter(markdown)).toBeUndefined();
     });
   });
 
   describe('findFinalHeaderLevel', function () {
     describe("framework='none'", () => {
       it('should detect top header', function () {
-        const markdown = normalize(
-          outdent`
-            # Header
-            Some description
-          `,
-          context,
-        );
+        const markdown = outdent`
+          # Header
+          Some description
+        `;
         expect(findFinalHeaderLevel(context, markdown)).toBe(1);
       });
 
@@ -103,19 +96,16 @@ describe('markdown', function () {
         expect(
           findFinalHeaderLevel(
             context,
-            normalize(
-              outdent`
-                # eslint-plugin-test
-                Description.
-                ## Configs
-                Configs
-                ### Some config
-                Description
-                ## Rules
-                Rules
-              `,
-              context,
-            ),
+            outdent`
+              # eslint-plugin-test
+              Description.
+              ## Configs
+              Configs
+              ### Some config
+              Description
+              ## Rules
+              Rules
+            `,
           ),
         ).toBe(2);
       });
@@ -128,16 +118,13 @@ describe('markdown', function () {
         expect(
           findFinalHeaderLevel(
             context,
-            normalize(
-              outdent`
-                ---
-                title: Test Rule
-                description: This is a test rule.
-                ---
-                Rules
-              `,
-              context,
-            ),
+            outdent`
+              ---
+              title: Test Rule
+              description: This is a test rule.
+              ---
+              Rules
+            `,
           ),
         ).toBeUndefined();
       });
@@ -149,25 +136,19 @@ describe('markdown', function () {
       });
 
       it('should detect top header', function () {
-        const markdown = normalize(
-          outdent`
-            # Header
-            Some description
-          `,
-          context,
-        );
+        const markdown = outdent`
+          # Header
+          Some description
+        `;
         expect(findFinalHeaderLevel(context, markdown)).toBe(1);
       });
 
       it('should detect sub-header', function () {
-        const markdown = normalize(
-          outdent`
-            # Header
-            Some description
-            ## Rules
-          `,
-          context,
-        );
+        const markdown = outdent`
+          # Header
+          Some description
+          ## Rules
+        `;
         expect(findFinalHeaderLevel(context, markdown)).toBe(2);
       });
 
@@ -175,19 +156,16 @@ describe('markdown', function () {
         expect(
           findFinalHeaderLevel(
             context,
-            normalize(
-              outdent`
-                # eslint-plugin-test
-                Description.
-                ## Configs
-                Configs
-                ### Some config
-                Description
-                ## Rules
-                Rules
-              `,
-              context,
-            ),
+            outdent`
+              # eslint-plugin-test
+              Description.
+              ## Configs
+              Configs
+              ### Some config
+              Description
+              ## Rules
+              Rules
+            `,
           ),
         ).toBe(2);
       });
@@ -200,16 +178,13 @@ describe('markdown', function () {
         expect(
           findFinalHeaderLevel(
             context,
-            normalize(
-              outdent`
-                ---
-                title: Test Rule
-                description: This is a test rule.
-                ---
-                Rules
-              `,
-              context,
-            ),
+            outdent`
+              ---
+              title: Test Rule
+              description: This is a test rule.
+              ---
+              Rules
+            `,
           ),
         ).toBe(1);
       });
@@ -218,16 +193,13 @@ describe('markdown', function () {
         expect(
           findFinalHeaderLevel(
             context,
-            normalize(
-              outdent`
-                ---
-                title: Test Rule
-                description: This is a test rule.
-                ---
-                ## Rules
-              `,
-              context,
-            ),
+            outdent`
+              ---
+              title: Test Rule
+              description: This is a test rule.
+              ---
+              ## Rules
+            `,
           ),
         ).toBe(2);
       });
@@ -237,28 +209,27 @@ describe('markdown', function () {
   describe('findSectionHeader', function () {
     it('handles standard section title', function () {
       const title = '## Rules\n';
-      expect(findSectionHeader(context, title, 'rules')).toBe(title);
+      expect(findSectionHeader(title, 'rules')).toBe(title);
     });
 
     it('handles section title with leading emoji', function () {
       const title = '## 🍟 Rules\n';
-      expect(findSectionHeader(context, title, 'rules')).toBe(title);
+      expect(findSectionHeader(title, 'rules')).toBe(title);
     });
 
     it('handles section title with html', function () {
       const title = "## <a name='Rules'></a>Rules\n";
-      expect(findSectionHeader(context, title, 'rules')).toBe(title);
+      expect(findSectionHeader(title, 'rules')).toBe(title);
     });
 
     it('handles sentential section title', function () {
       const title = '## List of supported rules\n';
-      expect(findSectionHeader(context, title, 'rules')).toBe(title);
+      expect(findSectionHeader(title, 'rules')).toBe(title);
     });
 
     it('handles doc with multiple sections', function () {
       expect(
         findSectionHeader(
-          context,
           outdent`
             # eslint-plugin-test
             Description.
@@ -275,7 +246,6 @@ describe('markdown', function () {
     it('handles doc with multiple rules-related sections', function () {
       expect(
         findSectionHeader(
-          context,
           outdent`
             # eslint-plugin-test
             Description.
@@ -294,382 +264,276 @@ describe('markdown', function () {
 
   describe('replaceOrCreateFrontmatter', function () {
     it('should leave everything as it was when no frontmatter was passed in (none existing)', function () {
-      const markdown = normalize(
-        outdent`
-          # Rule
-          Intro sentence.
-          <!-- end auto-generated rule header -->
-          Rule description.
-        `,
-        context,
-      );
+      const markdown = outdent`
+        # Rule
+        Intro sentence.
+        <!-- end auto-generated rule header -->
+        Rule description.
+      `;
 
-      expect(replaceOrCreateFrontmatter(context, markdown, undefined)).toBe(
-        markdown,
-      );
+      expect(replaceOrCreateFrontmatter(markdown, undefined)).toBe(markdown);
     });
 
     it('should leave everything as it was when no frontmatter was passed in (existing frontmatter)', function () {
-      const markdown = normalize(
-        outdent`
-          ---
-          name: no-foo
-          description: Some description
-          ---
-          # Rule
-          Intro sentence.
-          <!-- end auto-generated rule header -->
-          Rule description.
-        `,
-        context,
-      );
+      const markdown = outdent`
+        ---
+        name: no-foo
+        description: Some description
+        ---
+        # Rule
+        Intro sentence.
+        <!-- end auto-generated rule header -->
+        Rule description.
+      `;
 
-      expect(replaceOrCreateFrontmatter(context, markdown, undefined)).toBe(
-        markdown,
-      );
+      expect(replaceOrCreateFrontmatter(markdown, undefined)).toBe(markdown);
     });
 
     it('should create new frontmatter when no existing frontmatter exists', function () {
-      const markdown = normalize(
-        outdent`
-          Rule description.
-        `,
-        context,
-      );
-      const newFrontmatter = normalize(
-        outdent`
-          ---
-          title: New Rule
-          ---
-        `,
-        context,
-      );
+      const markdown = outdent`
+        Rule description.
+      `;
+      const newFrontmatter = outdent`
+        ---
+        title: New Rule
+        ---
+      `;
 
-      expect(
-        replaceOrCreateFrontmatter(context, markdown, newFrontmatter),
-      ).toBe(`${newFrontmatter}${context.endOfLine}${markdown}`);
+      expect(replaceOrCreateFrontmatter(markdown, newFrontmatter)).toBe(
+        `${newFrontmatter}\n${markdown}`,
+      );
     });
 
     it('should replace existing frontmatter with the specified new frontmatter', function () {
-      const markdown = normalize(
-        outdent`
-          ---
-          title: Old Rule
-          ---
-          Rule description.
-        `,
-        context,
-      );
-      const newFrontmatter = normalize(
-        outdent`
-          ---
-          title: New Rule
-          ---
-        `,
-        context,
-      );
+      const markdown = outdent`
+        ---
+        title: Old Rule
+        ---
+        Rule description.
+      `;
+      const newFrontmatter = outdent`
+        ---
+        title: New Rule
+        ---
+      `;
 
-      expect(
-        replaceOrCreateFrontmatter(context, markdown, newFrontmatter),
-      ).toBe(`${newFrontmatter}${context.endOfLine}Rule description.`);
+      expect(replaceOrCreateFrontmatter(markdown, newFrontmatter)).toBe(
+        `${newFrontmatter}\nRule description.`,
+      );
     });
   });
 
   describe('replaceOrCreateHeader', function () {
     describe('for md files', function () {
       it('should create a new header when no existing header or marker exists', function () {
-        const markdown = normalize(
-          outdent`
-            This is the content of the rule doc.
-          `,
-          context,
-        );
-        const newHeader = normalize(
-          outdent`
-            # New Rule
-            <!-- end auto-generated rule header -->
-          `,
-          context,
-        );
+        const markdown = outdent`
+          This is the content of the rule doc.
+        `;
+        const newHeader = outdent`
+          # New Rule
+          <!-- end auto-generated rule header -->
+        `;
 
-        expect(replaceOrCreateHeader(context, markdown, newHeader, false)).toBe(
-          `${newHeader}${context.endOfLine}${markdown}`,
+        expect(replaceOrCreateHeader(markdown, newHeader, false)).toBe(
+          `${newHeader}\n${markdown}`,
         );
       });
 
       it('should replace an existing title header and preserve the original body', function () {
-        const markdown = normalize(
-          outdent`
-            # Old Rule
-            Rule description.
-          `,
-          context,
-        );
-        const newHeader = normalize(
-          outdent`
-            # New Rule
-            <!-- end auto-generated rule header -->
-          `,
-          context,
-        );
+        const markdown = outdent`
+          # Old Rule
+          Rule description.
+        `;
+        const newHeader = outdent`
+          # New Rule
+          <!-- end auto-generated rule header -->
+        `;
 
-        expect(replaceOrCreateHeader(context, markdown, newHeader, false)).toBe(
-          `${newHeader}${context.endOfLine}Rule description.`,
+        expect(replaceOrCreateHeader(markdown, newHeader, false)).toBe(
+          `${newHeader}\nRule description.`,
         );
       });
 
       it('should replace everything up to the marker and keep content after the marker', function () {
-        const markdown = normalize(
-          outdent`
-            # Old Rule
-            Intro sentence.
-            <!-- end auto-generated rule header -->
-            Rule description.
-          `,
-          context,
-        );
-        const newHeader = normalize(
-          outdent`
-            # New Rule
-            <!-- end auto-generated rule header -->
-          `,
-          context,
-        );
+        const markdown = outdent`
+          # Old Rule
+          Intro sentence.
+          <!-- end auto-generated rule header -->
+          Rule description.
+        `;
+        const newHeader = outdent`
+          # New Rule
+          <!-- end auto-generated rule header -->
+        `;
 
-        expect(replaceOrCreateHeader(context, markdown, newHeader, false)).toBe(
-          `${newHeader}${context.endOfLine}Rule description.`,
+        expect(replaceOrCreateHeader(markdown, newHeader, false)).toBe(
+          `${newHeader}\nRule description.`,
         );
       });
 
       it('should preserve frontmatter and doc body when replacing header', function () {
-        const frontmatter = normalize(
-          outdent`
-            ---
-            title: Old Rule
-            ---
-          `,
-          context,
-        );
-        const markdown = normalize(
-          outdent`
-            ${frontmatter}
-            # Old Rule
-            Rule description.
-          `,
-          context,
-        );
-        const newHeader = normalize(
-          outdent`
-            # New Rule
-            <!-- end auto-generated rule header -->
-          `,
-          context,
-        );
+        const frontmatter = outdent`
+          ---
+          title: Old Rule
+          ---
+        `;
+        const markdown = outdent`
+          ${frontmatter}
+          # Old Rule
+          Rule description.
+        `;
+        const newHeader = outdent`
+          # New Rule
+          <!-- end auto-generated rule header -->
+        `;
 
-        expect(replaceOrCreateHeader(context, markdown, newHeader, false)).toBe(
-          `${frontmatter}${context.endOfLine}${newHeader}${context.endOfLine}Rule description.`,
+        expect(replaceOrCreateHeader(markdown, newHeader, false)).toBe(
+          `${frontmatter}\n${newHeader}\nRule description.`,
         );
       });
 
       it('should should preserve additional content between frontmatter and header', function () {
-        const frontmatter = normalize(
-          outdent`
-            ---
-            title: Old Rule
-            ---
-          `,
-          context,
-        );
-        const markdown = normalize(
-          outdent`
-            ${frontmatter}
-            > 📌 A blockquote that should be preserved.
-            # Old Rule
-            Rule description.
-          `,
-          context,
-        );
-        const newHeader = normalize(
-          outdent`
-            # New Rule
-            <!-- end auto-generated rule header -->
-          `,
-          context,
-        );
+        const frontmatter = outdent`
+          ---
+          title: Old Rule
+          ---
+        `;
+        const markdown = outdent`
+          ${frontmatter}
+          > 📌 A blockquote that should be preserved.
+          # Old Rule
+          Rule description.
+        `;
+        const newHeader = outdent`
+          # New Rule
+          <!-- end auto-generated rule header -->
+        `;
 
-        expect(replaceOrCreateHeader(context, markdown, newHeader, false)).toBe(
-          `${frontmatter}${context.endOfLine}> 📌 A blockquote that should be preserved.${context.endOfLine}${newHeader}${context.endOfLine}Rule description.`,
+        expect(replaceOrCreateHeader(markdown, newHeader, false)).toBe(
+          `${frontmatter}\n> 📌 A blockquote that should be preserved.\n${newHeader}\nRule description.`,
         );
       });
 
       it('should should preserve additional content above header when no frontmatter exists', function () {
-        const markdown = normalize(
-          outdent`
-            > 📌 A blockquote that should be preserved.
-            # Old Rule
-            Rule description.
-          `,
-          context,
-        );
-        const newHeader = normalize(
-          outdent`
-            # New Rule
-            <!-- end auto-generated rule header -->
-          `,
-          context,
-        );
+        const markdown = outdent`
+          > 📌 A blockquote that should be preserved.
+          # Old Rule
+          Rule description.
+        `;
+        const newHeader = outdent`
+          # New Rule
+          <!-- end auto-generated rule header -->
+        `;
 
-        expect(replaceOrCreateHeader(context, markdown, newHeader, false)).toBe(
-          `> 📌 A blockquote that should be preserved.${context.endOfLine}${newHeader}${context.endOfLine}Rule description.`,
+        expect(replaceOrCreateHeader(markdown, newHeader, false)).toBe(
+          `> 📌 A blockquote that should be preserved.\n${newHeader}\nRule description.`,
         );
       });
     });
 
     describe('for mdx files', function () {
       it('should create a new header when no existing header or marker exists', function () {
-        const markdown = normalize(
-          outdent`
-            This is the content of the rule doc.
-          `,
-          context,
-        );
-        const newHeader = normalize(
-          outdent`
-            # New Rule
-            {/* end auto-generated rule header */}
-          `,
-          context,
-        );
+        const markdown = outdent`
+          This is the content of the rule doc.
+        `;
+        const newHeader = outdent`
+          # New Rule
+          {/* end auto-generated rule header */}
+        `;
 
-        expect(replaceOrCreateHeader(context, markdown, newHeader, true)).toBe(
-          `${newHeader}${context.endOfLine}${markdown}`,
+        expect(replaceOrCreateHeader(markdown, newHeader, true)).toBe(
+          `${newHeader}\n${markdown}`,
         );
       });
 
       it('should replace an existing title header and preserve the original body', function () {
-        const markdown = normalize(
-          outdent`
-            # Old Rule
-            Rule description.
-          `,
-          context,
-        );
-        const newHeader = normalize(
-          outdent`
-            # New Rule
-            {/* end auto-generated rule header */}
-          `,
-          context,
-        );
+        const markdown = outdent`
+          # Old Rule
+          Rule description.
+        `;
+        const newHeader = outdent`
+          # New Rule
+          {/* end auto-generated rule header */}
+        `;
 
-        expect(replaceOrCreateHeader(context, markdown, newHeader, true)).toBe(
-          `${newHeader}${context.endOfLine}Rule description.`,
+        expect(replaceOrCreateHeader(markdown, newHeader, true)).toBe(
+          `${newHeader}\nRule description.`,
         );
       });
 
       it('should replace everything up to the marker and keep content after the marker', function () {
-        const markdown = normalize(
-          outdent`
-            # Old Rule
-            Intro sentence.
-            {/* end auto-generated rule header */}
-            Rule description.
-          `,
-          context,
-        );
-        const newHeader = normalize(
-          outdent`
-            # New Rule
-            {/* end auto-generated rule header */}
-          `,
-          context,
-        );
+        const markdown = outdent`
+          # Old Rule
+          Intro sentence.
+          {/* end auto-generated rule header */}
+          Rule description.
+        `;
+        const newHeader = outdent`
+          # New Rule
+          {/* end auto-generated rule header */}
+        `;
 
-        expect(replaceOrCreateHeader(context, markdown, newHeader, true)).toBe(
-          `${newHeader}${context.endOfLine}Rule description.`,
+        expect(replaceOrCreateHeader(markdown, newHeader, true)).toBe(
+          `${newHeader}\nRule description.`,
         );
       });
 
       it('should preserve frontmatter and doc body when replacing header', function () {
-        const frontmatter = normalize(
-          outdent`
-            ---
-            title: Old Rule
-            ---
-          `,
-          context,
-        );
-        const markdown = normalize(
-          outdent`
-            ${frontmatter}
-            # Old Rule
-            Rule description.
-          `,
-          context,
-        );
-        const newHeader = normalize(
-          outdent`
-            # New Rule
-            {/* end auto-generated rule header */}
-          `,
-          context,
-        );
+        const frontmatter = outdent`
+          ---
+          title: Old Rule
+          ---
+        `;
+        const markdown = outdent`
+          ${frontmatter}
+          # Old Rule
+          Rule description.
+        `;
+        const newHeader = outdent`
+          # New Rule
+          {/* end auto-generated rule header */}
+        `;
 
-        expect(replaceOrCreateHeader(context, markdown, newHeader, true)).toBe(
-          `${frontmatter}${context.endOfLine}${newHeader}${context.endOfLine}Rule description.`,
+        expect(replaceOrCreateHeader(markdown, newHeader, true)).toBe(
+          `${frontmatter}\n${newHeader}\nRule description.`,
         );
       });
 
       it('should should preserve additional content between frontmatter and header', function () {
-        const frontmatter = normalize(
-          outdent`
-            ---
-            title: Old Rule
-            ---
-          `,
-          context,
-        );
-        const markdown = normalize(
-          outdent`
-            ${frontmatter}
-            > 📌 A blockquote that should be preserved.
-            # Old Rule
-            Rule description.
-          `,
-          context,
-        );
-        const newHeader = normalize(
-          outdent`
-            # New Rule
-            {/* end auto-generated rule header */}
-          `,
-          context,
-        );
+        const frontmatter = outdent`
+          ---
+          title: Old Rule
+          ---
+        `;
+        const markdown = outdent`
+          ${frontmatter}
+          > 📌 A blockquote that should be preserved.
+          # Old Rule
+          Rule description.
+        `;
+        const newHeader = outdent`
+          # New Rule
+          {/* end auto-generated rule header */}
+        `;
 
-        expect(replaceOrCreateHeader(context, markdown, newHeader, true)).toBe(
-          `${frontmatter}${context.endOfLine}> 📌 A blockquote that should be preserved.${context.endOfLine}${newHeader}${context.endOfLine}Rule description.`,
+        expect(replaceOrCreateHeader(markdown, newHeader, true)).toBe(
+          `${frontmatter}\n> 📌 A blockquote that should be preserved.\n${newHeader}\nRule description.`,
         );
       });
 
       it('should should preserve additional content above header when no frontmatter exists', function () {
-        const markdown = normalize(
-          outdent`
-            > 📌 A blockquote that should be preserved.
-            # Old Rule
-            Rule description.
-          `,
-          context,
-        );
-        const newHeader = normalize(
-          outdent`
-            # New Rule
-            {/* end auto-generated rule header */}
-          `,
-          context,
-        );
+        const markdown = outdent`
+          > 📌 A blockquote that should be preserved.
+          # Old Rule
+          Rule description.
+        `;
+        const newHeader = outdent`
+          # New Rule
+          {/* end auto-generated rule header */}
+        `;
 
-        expect(replaceOrCreateHeader(context, markdown, newHeader, true)).toBe(
-          `> 📌 A blockquote that should be preserved.${context.endOfLine}${newHeader}${context.endOfLine}Rule description.`,
+        expect(replaceOrCreateHeader(markdown, newHeader, true)).toBe(
+          `> 📌 A blockquote that should be preserved.\n${newHeader}\nRule description.`,
         );
       });
     });


### PR DESCRIPTION
Fixes #725
Fixes #726

**Alternative approach to #984** — same bug fixes and same regression tests, different architecture. Opened as a separate draft for comparison; only one of the two should be merged.

## Approach

Where #984 detects each file's end of line and threads it through the existing `Context.endOfLine` plumbing (via a per-file context copy), this PR takes the Prettier-style approach: **all markdown content is processed using LF (`\n`) line endings internally, and the end of line becomes purely an I/O concern in the generator.**

- On read, each file's contents are normalized to LF, and its predominant end of line is detected.
- All processing (frontmatter, headers, lists, tables) assumes and produces LF.
- On write, the whole output is converted to the file's detected end of line — falling back to the configured end of line (EditorConfig → Prettier → `os.EOL`) for new files and files without line breaks. `postprocess` still receives content in the file's final end of line, as before.

Consequences:

- `endOfLine` is **removed from `Context`**, along with every `split`/`join`/`RegExp` on it across `markdown.ts`, `frontmatter.ts`, `rule-list.ts`, `config-list.ts`, `rule-options-list.ts`, `rule-doc-notices.ts`, `rule-list-legend.ts`, and `string.ts`. Functions that only needed the end of line (`extractFrontmatter`, `replaceOrCreateFrontmatter`, `replaceOrCreateHeader`, `findSectionHeader`, `expectSectionHeaderOrFail`, `updateRuleOptionsList`, `sanitizeMarkdownTable`) no longer take a context parameter at all.
- `markdown-table`'s hard-coded LF output — one of the two direct causes of #726 — is now correct as-is instead of needing conversion.
- Any future code that splits on `'\n'` or emits `'\n'` in generated content is automatically correct, rather than being a latent line-ending bug. That's the main argument for this version over #984: it removes the bug class instead of patching the instances.

## Behavior (identical to #984)

- Existing files keep their current line endings, even when they differ from the configured end of line.
- Doc content is never deleted due to line ending mismatches (#725), and generated content never introduces mixed line endings (#726).
- Files that already have mixed endings are unified to their predominant end of line on the next run — a one-time diff.
- `--check` passes on up-to-date files regardless of their line endings.

## Tests

Same regression tests as #984 (direct repros of #725 and #726, mixed-endings unification, `--check` mode, unit tests for `detectEndOfLine`/`normalizeEndOfLine`, plus the `chdir` + explicit `\r\n` assertion fixes for the pre-existing editorconfig test gap). The `markdown-test.ts`/`frontmatter-test.ts` updates here are signature changes from dropping the context parameters — net, this PR removes ~190 more lines than it adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)