### PR TITLE
fix: preserve doc content when file EOL differs from configured EOL

### DIFF
--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -223,7 +223,6 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     // Check for required sections.
     for (const section of ruleDocSectionInclude) {
       expectSectionHeaderOrFail(
-        context,
         `\`${name}\` rule doc`,
         contentsNew,
         [section],
@@ -234,7 +233,6 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     // Check for disallowed sections.
     for (const section of ruleDocSectionExclude) {
       expectSectionHeaderOrFail(
-        context,
         `\`${name}\` rule doc`,
         contentsNew,
         [section],
@@ -245,7 +243,6 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     if (ruleDocSectionOptions) {
       // Options section.
       expectSectionHeaderOrFail(
-        context,
         `\`${name}\` rule doc`,
         contentsNew,
         ['Options', 'Config'],

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -3,9 +3,21 @@
 import { END_RULE_HEADER_MARKER, formatComment } from './comment-markers.js';
 import type { Context } from './context.js';
 
+// Matches any end-of-line style. Existing docs are parsed with this instead of
+// the configured EOL so that a doc whose EOL differs from the configured one
+// (e.g. an LF file on Windows after Prettier converts it) is still split into
+// lines correctly rather than having its content misdetected and deleted.
+// The configured EOL is only used when generating output.
+const LINE_BREAK = /\r\n|[\r\n]/u;
+
+/** Split doc content into lines regardless of which EOL style it uses. */
+function splitLines(markdown: string): readonly string[] {
+  return markdown.split(LINE_BREAK);
+}
+
 export function extractFrontmatter(context: Context, markdown: string) {
   const { endOfLine } = context;
-  const lines = markdown.split(endOfLine);
+  const lines = splitLines(markdown);
   const frontMatterStart = lines.indexOf('---');
 
   // Frontmatter must start at the beginning of the file to be considered valid, so if we don't find '---' at the beginning, we want to ignore it.
@@ -37,7 +49,7 @@ export function replaceOrCreateFrontmatter(
 
   const { endOfLine } = context;
 
-  const lines = markdown.split(endOfLine);
+  const lines = splitLines(markdown);
 
   const frontmatterStartIndex = lines.indexOf('---');
 
@@ -67,7 +79,7 @@ export function replaceOrCreateHeader(
 ) {
   const { endOfLine } = context;
 
-  const lines = markdown.split(endOfLine);
+  const lines = splitLines(markdown);
 
   const titleLineIndex = lines.findIndex((line) => line.startsWith('# '));
   const markerLineIndex = lines.indexOf(
@@ -97,14 +109,11 @@ export function replaceOrCreateHeader(
  * Find the section most likely to be the top-level section for a given string.
  */
 export function findSectionHeader(
-  context: Context,
   markdown: string,
   str: string,
 ): string | undefined {
-  const { endOfLine } = context;
-
   // Get all the matching strings.
-  const regexp = new RegExp(`## .*${str}.*${endOfLine}`, 'giu');
+  const regexp = new RegExp(`## .*${str}.*(?:${LINE_BREAK.source})`, 'giu');
   const sectionPotentialMatches = [...markdown.matchAll(regexp)].map(
     (match) => match[0],
   );
@@ -130,11 +139,10 @@ export function findFinalHeaderLevel(
   str: string,
 ): number | undefined {
   const {
-    endOfLine,
     options: { framework },
   } = context;
 
-  const lines = str.split(endOfLine);
+  const lines = splitLines(str);
   const finalHeader = lines
     .toReversed()
     .find((line) => line.match('^(#+) .+$'));
@@ -184,14 +192,13 @@ export function expectContentOrFail(
 }
 
 export function expectSectionHeaderOrFail(
-  context: Context,
   contentName: string,
   contents: string,
   possibleHeaders: readonly string[],
   expected: boolean,
 ) {
   const found = possibleHeaders.some((header) =>
-    findSectionHeader(context, contents, header),
+    findSectionHeader(contents, header),
   );
   if (found !== expected) {
     if (possibleHeaders.length > 1) {

--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -326,7 +326,7 @@ export function updateRulesList(
   let listEndIndex = markdown.indexOf(formattedRuleListMarkerEnd);
 
   // Find the best possible section to insert the rules list into if the markers are missing.
-  const rulesSectionHeader = findSectionHeader(context, markdown, 'rules');
+  const rulesSectionHeader = findSectionHeader(markdown, 'rules');
   const rulesSectionIndex = rulesSectionHeader
     ? markdown.indexOf(rulesSectionHeader)
     : -1;

--- a/test/lib/markdown-test.ts
+++ b/test/lib/markdown-test.ts
@@ -75,6 +75,16 @@ describe('markdown', function () {
       expect(context).toBeDefined();
       expect(extractFrontmatter(context, markdown)).toBeUndefined();
     });
+
+    it('should extract frontmatter from a doc whose EOL differs from the configured one', function () {
+      const contextCrlf = { ...context, endOfLine: '\r\n' };
+      const markdown =
+        '---\ntitle: Test Rule\n---\n# Test Rule\nThis is the content of the rule doc.';
+
+      expect(extractFrontmatter(contextCrlf, markdown)).toBe(
+        '---\r\ntitle: Test Rule\r\n---',
+      );
+    });
   });
 
   describe('findFinalHeaderLevel', function () {
@@ -237,28 +247,27 @@ describe('markdown', function () {
   describe('findSectionHeader', function () {
     it('handles standard section title', function () {
       const title = '## Rules\n';
-      expect(findSectionHeader(context, title, 'rules')).toBe(title);
+      expect(findSectionHeader(title, 'rules')).toBe(title);
     });
 
     it('handles section title with leading emoji', function () {
       const title = '## 🍟 Rules\n';
-      expect(findSectionHeader(context, title, 'rules')).toBe(title);
+      expect(findSectionHeader(title, 'rules')).toBe(title);
     });
 
     it('handles section title with html', function () {
       const title = "## <a name='Rules'></a>Rules\n";
-      expect(findSectionHeader(context, title, 'rules')).toBe(title);
+      expect(findSectionHeader(title, 'rules')).toBe(title);
     });
 
     it('handles sentential section title', function () {
       const title = '## List of supported rules\n';
-      expect(findSectionHeader(context, title, 'rules')).toBe(title);
+      expect(findSectionHeader(title, 'rules')).toBe(title);
     });
 
     it('handles doc with multiple sections', function () {
       expect(
         findSectionHeader(
-          context,
           outdent`
             # eslint-plugin-test
             Description.
@@ -275,7 +284,6 @@ describe('markdown', function () {
     it('handles doc with multiple rules-related sections', function () {
       expect(
         findSectionHeader(
-          context,
           outdent`
             # eslint-plugin-test
             Description.
@@ -439,6 +447,30 @@ describe('markdown', function () {
         expect(replaceOrCreateHeader(context, markdown, newHeader, false)).toBe(
           `${newHeader}${context.endOfLine}Rule description.`,
         );
+      });
+
+      it('should keep content after the marker in an LF doc when the configured EOL is CRLF', function () {
+        // https://github.com/eslint-community/eslint-doc-generator/issues/725
+        const contextCrlf = { ...context, endOfLine: '\r\n' };
+        const markdown =
+          '# Old Rule\nIntro sentence.\n<!-- end auto-generated rule header -->\n## Further Reading\n\nSome docs.';
+        const newHeader =
+          '# New Rule\r\n<!-- end auto-generated rule header -->';
+
+        expect(
+          replaceOrCreateHeader(contextCrlf, markdown, newHeader, false),
+        ).toBe(`${newHeader}\r\n## Further Reading\r\n\r\nSome docs.`);
+      });
+
+      it('should keep content after the marker in a CRLF doc when the configured EOL is LF', function () {
+        const contextLf = { ...context, endOfLine: '\n' };
+        const markdown =
+          '# Old Rule\r\nIntro sentence.\r\n<!-- end auto-generated rule header -->\r\n## Further Reading\r\n\r\nSome docs.';
+        const newHeader = '# New Rule\n<!-- end auto-generated rule header -->';
+
+        expect(
+          replaceOrCreateHeader(contextLf, markdown, newHeader, false),
+        ).toBe(`${newHeader}\n## Further Reading\n\nSome docs.`);
       });
 
       it('should preserve frontmatter and doc body when replacing header', function () {


### PR DESCRIPTION
Fixes #725

## Problem

Doc content was split into lines with the *configured* end-of-line string (from `.editorconfig` / Prettier config / `os.EOL`). When the file on disk used a different EOL, the split produced garbage lines:

- LF file + CRLF configured (the issue's Windows-after-Prettier scenario): the whole file became one "line", the `<!-- end auto-generated rule header -->` marker was never found on its own line, `replaceOrCreateHeader` computed `postHeader` from `titleLineIndex + 1` — and everything below the header was deleted on the next `eslint-doc-generator` run.
- CRLF file + LF configured: lines kept a trailing `\r`, so the marker line comparison failed the same way.

## Fix

Parse existing content with an EOL-agnostic split (`/\r\n|[\r\n]/u`) in `lib/markdown.ts` (`extractFrontmatter`, `replaceOrCreateFrontmatter`, `replaceOrCreateHeader`, `findSectionHeader`, `findFinalHeaderLevel`). The configured EOL is still used for all generated output, so files are normalized to the configured EOL rather than corrupted.

`findSectionHeader` / `expectSectionHeaderOrFail` no longer need `context` and their unused parameter is removed (callers updated).

## Testing

- New regression tests: LF doc with CRLF configured and CRLF doc with LF configured both preserve content after the marker; frontmatter extraction with mismatched EOL.
- Full suite: 353 tests pass, lint clean.

Repro from the issue (`prettier --write` converting docs to LF, then re-running the generator) no longer deletes the `## Further Reading` section.