### PR TITLE
feat: determine line endings per file via EditorConfig, existing content, then os.EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,14 +451,12 @@ Alternatively, you can configure your scripts to run `prettier` after this tool:
 Markdown is processed using LF (`\n`) line endings internally. When writing each file, the end of line is chosen in this order:
 
 1. An **explicit** EditorConfig [`end_of_line`](https://editorconfig.org/) (`lf` / `crlf`) for that file path
-2. An **explicit** Prettier [`endOfLine`](https://prettier.io/docs/en/options.html#end-of-line) (`lf` / `crlf`) for that file path
-3. The predominant end of line already present in the file
-4. Prettier config present without an explicit `endOfLine` (or with `auto`) → LF (back-compat with [#803](https://github.com/eslint-community/eslint-doc-generator/pull/803); only applies when there is no existing line-ending signal)
-5. `os.EOL` (new files and files with no line breaks, and no Prettier config)
+2. The predominant end of line already present in the file
+3. `os.EOL` (new files and files with no line breaks)
 
-Tiers 2 and 4 (reading Prettier config) are **deprecated** and planned for removal in the next major (see `TODO`s in `lib/eol.ts`). Prefer EditorConfig for declarative end-of-line intent, or run Prettier itself via the [`postprocess`](#prettier) hook / a follow-up script.
+Prettier config is not consulted for line endings. To apply Prettier (including its `endOfLine`, ignores, and overrides), run Prettier itself via the [`postprocess`](#prettier) hook or after generation.
 
-When an explicit EditorConfig or Prettier `endOfLine` is set, files that use a different end of line are converted on the next run (a one-time diff), and `--check` fails until they match. Existing files keep their endings when only an implicit Prettier default would apply.
+When EditorConfig sets `end_of_line`, files that use a different end of line are converted on the next run (a one-time diff), and `--check` fails until they match. Without an EditorConfig `end_of_line`, existing file endings are preserved and `--check` compares against those.
 
 ### File Types
 

--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ Markdown is processed using LF (`\n`) line endings internally. When writing each
 4. Prettier config present without an explicit `endOfLine` (or with `auto`) → LF (back-compat with [#803](https://github.com/eslint-community/eslint-doc-generator/pull/803); only applies when there is no existing line-ending signal)
 5. `os.EOL` (new files and files with no line breaks, and no Prettier config)
 
-Tiers 2 and 4 (reading Prettier config) are **deprecated** and planned for removal in the next major. Prefer EditorConfig for declarative end-of-line intent, or run Prettier itself via the [`postprocess`](#prettier) hook / a follow-up script.
+Tiers 2 and 4 (reading Prettier config) are **deprecated** and planned for removal in the next major (see `TODO`s in `lib/eol.ts`). Prefer EditorConfig for declarative end-of-line intent, or run Prettier itself via the [`postprocess`](#prettier) hook / a follow-up script.
 
 When an explicit EditorConfig or Prettier `endOfLine` is set, files that use a different end of line are converted on the next run (a one-time diff), and `--check` fails until they match. Existing files keep their endings when only an implicit Prettier default would apply.
 

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ Markdown is processed using LF (`\n`) line endings internally. When writing each
 2. The predominant end of line already present in the file
 3. `os.EOL` (new files and files with no line breaks)
 
-Prettier config is not consulted for line endings. To apply Prettier (including its `endOfLine`, ignores, and overrides), run Prettier itself via the [`postprocess`](#prettier) hook or after generation.
+Only `lf` and `crlf` are honored from EditorConfig; other values such as `cr` are treated as unset. Prettier config is not consulted for line endings. To apply Prettier (including its `endOfLine`, ignores, and overrides), run Prettier itself via the [`postprocess`](#prettier) hook or after generation.
 
 When EditorConfig sets `end_of_line`, files that use a different end of line are converted on the next run (a one-time diff), and `--check` fails until they match. Without an EditorConfig `end_of_line`, existing file endings are preserved and `--check` compares against those.
 

--- a/README.md
+++ b/README.md
@@ -450,13 +450,13 @@ Alternatively, you can configure your scripts to run `prettier` after this tool:
 
 Markdown is processed using LF (`\n`) line endings internally. When writing each file, the end of line is chosen in this order:
 
-1. An **explicit** EditorConfig `end_of_line` or Prettier `endOfLine` (`lf` / `crlf`) for that file path
+1. An **explicit** EditorConfig [`end_of_line`](https://editorconfig.org/) (`lf` / `crlf`) for that file path
 2. The predominant end of line already present in the file
 3. `os.EOL` (new files and files with no line breaks)
 
-A Prettier config that does not set `endOfLine` (or sets it to `auto`) is ignored for this purpose — only an explicitly configured value counts.
+Prettier config is not read for line endings. To format with Prettier (including its `endOfLine`), use the [`postprocess`](#prettier) hook or run Prettier after this tool — that runs Prettier itself with its full config, ignores, and overrides.
 
-When an explicit config is present, files that use a different end of line are converted on the next run (a one-time diff), and `--check` fails until they match. Without an explicit config, existing file endings are preserved and `--check` compares against those.
+When EditorConfig sets `end_of_line`, files that use a different end of line are converted on the next run (a one-time diff), and `--check` fails until they match. Without an EditorConfig `end_of_line`, existing file endings are preserved and `--check` compares against those.
 
 ### File Types
 

--- a/README.md
+++ b/README.md
@@ -425,12 +425,22 @@ If you use [prettier](https://prettier.io/) to format your markdown, you can pro
 
 ```javascript
 const prettier = require('prettier');
-const { prettier: prettierRC } = require('./package.json'); // or wherever your prettier config lies
 
 /** @type {import('eslint-doc-generator').GenerateOptions} */
 const config = {
-  postprocess: (content, path) =>
-    prettier.format(content, { ...prettierRC, parser: 'markdown' }),
+  postprocess: async (content, path) => {
+    // Skip files that Prettier is configured to ignore.
+    const fileInfo = await prettier.getFileInfo(path, {
+      ignorePath: '.prettierignore',
+    });
+    if (fileInfo.ignored) {
+      return content;
+    }
+
+    // Resolve the Prettier config for this file path (including overrides).
+    const options = await prettier.resolveConfig(path, { editorconfig: true });
+    return prettier.format(content, { ...options, filepath: path });
+  },
 };
 
 module.exports = config;

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Also performs [configurable](#configuration-options) section consistency checks 
   - [Build tools](#build-tools)
   - [markdownlint](#markdownlint)
   - [prettier](#prettier)
+  - [Line endings](#line-endings)
   - [File Types](#file-types)
 - [Semantic versioning policy](#semantic-versioning-policy)
 - [Related](#related)
@@ -444,6 +445,18 @@ Alternatively, you can configure your scripts to run `prettier` after this tool:
   "update:eslint-docs": "eslint-doc-generator && npm run format"
 }
 ```
+
+### Line endings
+
+Markdown is processed using LF (`\n`) line endings internally. When writing each file, the end of line is chosen in this order:
+
+1. An **explicit** EditorConfig `end_of_line` or Prettier `endOfLine` (`lf` / `crlf`) for that file path
+2. The predominant end of line already present in the file
+3. `os.EOL` (new files and files with no line breaks)
+
+A Prettier config that does not set `endOfLine` (or sets it to `auto`) is ignored for this purpose — only an explicitly configured value counts.
+
+When an explicit config is present, files that use a different end of line are converted on the next run (a one-time diff), and `--check` fails until they match. Without an explicit config, existing file endings are preserved and `--check` compares against those.
 
 ### File Types
 

--- a/README.md
+++ b/README.md
@@ -451,12 +451,14 @@ Alternatively, you can configure your scripts to run `prettier` after this tool:
 Markdown is processed using LF (`\n`) line endings internally. When writing each file, the end of line is chosen in this order:
 
 1. An **explicit** EditorConfig [`end_of_line`](https://editorconfig.org/) (`lf` / `crlf`) for that file path
-2. The predominant end of line already present in the file
-3. `os.EOL` (new files and files with no line breaks)
+2. An **explicit** Prettier [`endOfLine`](https://prettier.io/docs/en/options.html#end-of-line) (`lf` / `crlf`) for that file path
+3. The predominant end of line already present in the file
+4. Prettier config present without an explicit `endOfLine` (or with `auto`) → LF (back-compat with [#803](https://github.com/eslint-community/eslint-doc-generator/pull/803); only applies when there is no existing line-ending signal)
+5. `os.EOL` (new files and files with no line breaks, and no Prettier config)
 
-Prettier config is not read for line endings. To format with Prettier (including its `endOfLine`), use the [`postprocess`](#prettier) hook or run Prettier after this tool — that runs Prettier itself with its full config, ignores, and overrides.
+Tiers 2 and 4 (reading Prettier config) are **deprecated** and planned for removal in the next major. Prefer EditorConfig for declarative end-of-line intent, or run Prettier itself via the [`postprocess`](#prettier) hook / a follow-up script.
 
-When EditorConfig sets `end_of_line`, files that use a different end of line are converted on the next run (a one-time diff), and `--check` fails until they match. Without an EditorConfig `end_of_line`, existing file endings are preserved and `--check` compares against those.
+When an explicit EditorConfig or Prettier `endOfLine` is set, files that use a different end of line are converted on the next run (a one-time diff), and `--check` fails until they match. Existing files keep their endings when only an implicit Prettier default would apply.
 
 ### File Types
 

--- a/lib/config-list.ts
+++ b/lib/config-list.ts
@@ -60,7 +60,7 @@ function generateConfigListMarkdown(context: Context): string {
   ];
 
   return markdownTable(
-    sanitizeMarkdownTable(context, rows),
+    sanitizeMarkdownTable(rows),
     { align: 'l' }, // Left-align headers.
   );
 }
@@ -70,7 +70,7 @@ export function updateConfigsList(
   markdown: string,
   isMdx: boolean,
 ): string {
-  const { configsToRules, endOfLine, options } = context;
+  const { configsToRules, options } = context;
   const { ignoreConfig } = options;
 
   const formattedConfigListMarkerBegin = formatComment(
@@ -108,5 +108,5 @@ export function updateConfigsList(
   // New config list.
   const list = generateConfigListMarkdown(context);
 
-  return `${preList}${formattedConfigListMarkerBegin}${endOfLine}${endOfLine}${list}${endOfLine}${endOfLine}${formattedConfigListMarkerEnd}${postList}`;
+  return `${preList}${formattedConfigListMarkerBegin}\n\n${list}\n\n${formattedConfigListMarkerEnd}${postList}`;
 }

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -1,5 +1,4 @@
 import { mockPlugin } from './mock-plugin.js';
-import { getEndOfLine } from './eol.js';
 import { getResolvedOptions } from './options.js';
 import type { ResolvedGenerateOptions } from './options.js';
 import { getPluginName, loadPlugin } from './package-json.js';
@@ -8,12 +7,14 @@ import { getPluginPrefix } from './plugin-prefix.js';
 import { resolveConfigsToRules } from './plugin-config-resolution.js';
 
 /**
- * Context about the current invocation of the program, like what end-of-line
- * character to use.
+ * Context about the current invocation of the program.
+ *
+ * Note: all markdown content is processed using LF (`\n`) line endings
+ * internally. The desired end of line for each file is only applied when
+ * writing the file in the generator.
  */
 export interface Context {
   configsToRules: ConfigsToRules;
-  endOfLine: string;
   options: ResolvedGenerateOptions;
   path: string;
   plugin: Plugin;
@@ -25,7 +26,6 @@ export async function getContext(
   userOptions?: GenerateOptions,
   useMockPlugin = false,
 ): Promise<Context> {
-  const endOfLine = await getEndOfLine();
   const plugin = useMockPlugin ? mockPlugin : await loadPlugin(path);
   const pluginPrefix = getPluginPrefix(
     plugin.meta?.name ?? (await getPluginName(path)),
@@ -36,7 +36,6 @@ export async function getContext(
 
   return {
     configsToRules,
-    endOfLine,
     options,
     path,
     plugin,

--- a/lib/eol.ts
+++ b/lib/eol.ts
@@ -60,6 +60,31 @@ async function getEndOfLineFromPrettierConfig(): Promise<
   return '\n';
 }
 
+/**
+ * Detect the predominant end of line in the given file contents.
+ * Returns undefined if the contents have no line breaks.
+ */
+export function detectEndOfLine(contents: string): '\n' | '\r\n' | undefined {
+  const crlfCount = contents.match(/\r\n/gu)?.length ?? 0;
+  const lfCount = contents.match(/(?<!\r)\n/gu)?.length ?? 0;
+
+  if (crlfCount === 0 && lfCount === 0) {
+    return undefined;
+  }
+
+  return crlfCount > lfCount ? '\r\n' : '\n';
+}
+
+/**
+ * Convert all line endings in the given contents to the given end of line.
+ */
+export function normalizeEndOfLine(
+  contents: string,
+  endOfLine: string,
+): string {
+  return contents.replaceAll(/\r\n|\n/gu, endOfLine);
+}
+
 /* istanbul ignore next */
 /** `EOL` is typed as `string`, so we perform run-time validation to be safe. */
 function getNodeEOL(): '\n' | '\r\n' {

--- a/lib/eol.ts
+++ b/lib/eol.ts
@@ -37,6 +37,13 @@ export type EndOfLineResolver = {
 /**
  * Create a memoized end-of-line resolver scoped to one `generate()` run.
  * Cache keys are absolute file paths so sibling `.md`/`.mdx` files can differ.
+ *
+ * Write-time precedence for `resolve()`:
+ * 1. Explicit EditorConfig `end_of_line`
+ * 2. Explicit Prettier `endOfLine` (`lf`/`crlf`) — TODO: remove next major
+ * 3. Predominant end of line in existing contents (skip when `contents` is undefined)
+ * 4. Implicit Prettier LF when a config exists without `endOfLine` — TODO: remove next major
+ * 5. `os.EOL`
  */
 export function createEndOfLineResolver(): EndOfLineResolver {
   const explicitCache = new Map<string, Promise<EndOfLine | undefined>>();

--- a/lib/eol.ts
+++ b/lib/eol.ts
@@ -1,20 +1,49 @@
 import { EOL } from 'node:os';
+import { dirname, resolve } from 'node:path';
 import editorconfig from 'editorconfig';
 
-export async function getEndOfLine(): Promise<'\n' | '\r\n'> {
-  return (
-    (await getEndOfLineFromEditorConfig()) ??
-    (await getEndOfLineFromPrettierConfig()) ??
-    getNodeEOL()
-  );
+/** Memoize by directory — rule docs share a folder. */
+const configuredEndOfLineCache = new Map<
+  string,
+  Promise<'\n' | '\r\n' | undefined>
+>();
+
+/**
+ * Resolve an explicitly configured end of line for the given file path.
+ * Only EditorConfig `end_of_line` and an explicitly set Prettier `endOfLine`
+ * (`lf` or `crlf`) count as configured. A Prettier config without `endOfLine`
+ * (or with `auto`) does not imply LF — returns undefined so callers can fall
+ * through to per-file detection.
+ */
+export async function getConfiguredEndOfLine(
+  filePath: string,
+): Promise<'\n' | '\r\n' | undefined> {
+  const absolutePath = resolve(filePath);
+  const cacheKey = dirname(absolutePath);
+
+  let cached = configuredEndOfLineCache.get(cacheKey);
+  if (!cached) {
+    cached = resolveConfiguredEndOfLine(absolutePath);
+    configuredEndOfLineCache.set(cacheKey, cached);
+  }
+  const result = await cached;
+  return result;
 }
 
-async function getEndOfLineFromEditorConfig(): Promise<
-  '\n' | '\r\n' | undefined
-> {
-  // The passed `markdown.md` argument is used as an example of a Markdown file in the plugin root
-  // folder in order to check for any specific Markdown configurations.
-  const editorConfigProps = await editorconfig.parse('markdown.md');
+async function resolveConfiguredEndOfLine(
+  absolutePath: string,
+): Promise<'\n' | '\r\n' | undefined> {
+  const fromEditorConfig = await getEndOfLineFromEditorConfig(absolutePath);
+  if (fromEditorConfig !== undefined) {
+    return fromEditorConfig;
+  }
+  return getEndOfLineFromPrettierConfig(absolutePath);
+}
+
+async function getEndOfLineFromEditorConfig(
+  filePath: string,
+): Promise<'\n' | '\r\n' | undefined> {
+  const editorConfigProps = await editorconfig.parse(filePath);
 
   if (editorConfigProps.end_of_line === 'lf') {
     return '\n';
@@ -27,9 +56,9 @@ async function getEndOfLineFromEditorConfig(): Promise<
   return undefined;
 }
 
-async function getEndOfLineFromPrettierConfig(): Promise<
-  '\n' | '\r\n' | undefined
-> {
+async function getEndOfLineFromPrettierConfig(
+  filePath: string,
+): Promise<'\n' | '\r\n' | undefined> {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports -- prettier is an optional peer dependency, must be dynamically imported
   let prettier: typeof import('prettier') | undefined;
   try {
@@ -39,9 +68,7 @@ async function getEndOfLineFromPrettierConfig(): Promise<
     return undefined;
   }
 
-  // The passed `markdown.md` argument is used as an example of a Markdown file in the plugin root
-  // folder in order to check for any specific Markdown configurations.
-  const prettierOptions = await prettier.resolveConfig('markdown.md');
+  const prettierOptions = await prettier.resolveConfig(filePath);
 
   if (prettierOptions === null) {
     return undefined;
@@ -55,9 +82,8 @@ async function getEndOfLineFromPrettierConfig(): Promise<
     return '\r\n';
   }
 
-  // Prettier defaults to "lf" if it is not explicitly specified in the config file:
-  // https://prettier.io/docs/options#end-of-line
-  return '\n';
+  // Unset or `auto` — not an explicit end of line; fall through to detection.
+  return undefined;
 }
 
 /**
@@ -82,7 +108,12 @@ export function normalizeEndOfLine(
   contents: string,
   endOfLine: string,
 ): string {
-  return contents.replaceAll(/\r\n|\n/gu, endOfLine);
+  return contents.replaceAll(/\r\n|[\r\n]/gu, endOfLine);
+}
+
+/** Fallback when there is no explicit config and no detectable end of line. */
+export function getFallbackEndOfLine(): '\n' | '\r\n' {
+  return getNodeEOL();
 }
 
 /* istanbul ignore next */

--- a/lib/eol.ts
+++ b/lib/eol.ts
@@ -5,6 +5,8 @@ import type { Cache as EditorConfigCache } from 'editorconfig';
 
 type EndOfLine = '\n' | '\r\n';
 
+// TODO: remove Prettier end-of-line reading in the next major — prefer
+// EditorConfig and running Prettier via `postprocess` (see README "Line endings").
 type PrettierEndOfLineResult =
   | { kind: 'explicit'; value: EndOfLine }
   | { kind: 'implicit' }
@@ -18,7 +20,8 @@ export type EndOfLineResolver = {
   getExplicitEndOfLine: (filePath: string) => Promise<EndOfLine | undefined>;
   /**
    * #803 back-compat: Prettier config is resolvable but `endOfLine` is unset
-   * or `auto` → LF. Deprecated; planned for removal in the next major.
+   * or `auto` → LF.
+   * TODO: remove in the next major (Prettier implicit LF tier).
    */
   getImplicitEndOfLine: (filePath: string) => Promise<'\n' | undefined>;
   /**
@@ -37,7 +40,9 @@ export type EndOfLineResolver = {
  */
 export function createEndOfLineResolver(): EndOfLineResolver {
   const explicitCache = new Map<string, Promise<EndOfLine | undefined>>();
+  // TODO: remove with Prettier implicit LF tier in the next major.
   const implicitCache = new Map<string, Promise<'\n' | undefined>>();
+  // TODO: remove with Prettier end-of-line reading in the next major.
   const prettierCache = new Map<string, Promise<PrettierEndOfLineResult>>();
   /** Shared across files so EditorConfig does not re-read the same files. */
   const editorConfigFileCache: EditorConfigCache = new Map();
@@ -79,6 +84,7 @@ export function createEndOfLineResolver(): EndOfLineResolver {
       return fromEditorConfig;
     }
 
+    // TODO: remove Prettier explicit endOfLine tier in the next major.
     const prettier = await getPrettierEndOfLine(absolutePath, prettierCache);
     return prettier.kind === 'explicit' ? prettier.value : undefined;
   }
@@ -96,6 +102,7 @@ export function createEndOfLineResolver(): EndOfLineResolver {
       return undefined;
     }
 
+    // TODO: remove Prettier implicit LF tier (#803) in the next major.
     const prettier = await getPrettierEndOfLine(absolutePath, prettierCache);
     return prettier.kind === 'implicit' ? '\n' : undefined;
   }
@@ -107,6 +114,7 @@ export function createEndOfLineResolver(): EndOfLineResolver {
     return (
       (await getExplicitEndOfLine(filePath)) ??
       (contents === undefined ? undefined : detectEndOfLine(contents)) ??
+      // TODO: remove Prettier implicit LF tier in the next major.
       (await getImplicitEndOfLine(filePath)) ??
       getFallbackEndOfLine()
     );
@@ -149,6 +157,8 @@ async function getPrettierEndOfLine(
   return result;
 }
 
+// TODO: remove Prettier end-of-line reading (and the optional `prettier` peer
+// dependency) in the next major — prefer EditorConfig / `postprocess`.
 async function resolvePrettierEndOfLine(
   filePath: string,
 ): Promise<PrettierEndOfLineResult> {

--- a/lib/eol.ts
+++ b/lib/eol.ts
@@ -1,40 +1,129 @@
 import { EOL } from 'node:os';
-import { dirname, resolve } from 'node:path';
+import { resolve } from 'node:path';
 import editorconfig from 'editorconfig';
+import type { Cache as EditorConfigCache } from 'editorconfig';
 
-/** Memoize by directory — rule docs share a folder. */
-const configuredEndOfLineCache = new Map<
-  string,
-  Promise<'\n' | '\r\n' | undefined>
->();
+type EndOfLine = '\n' | '\r\n';
+
+type PrettierEndOfLineResult =
+  | { kind: 'explicit'; value: EndOfLine }
+  | { kind: 'implicit' }
+  | { kind: 'none' };
+
+export type EndOfLineResolver = {
+  /**
+   * Explicit config only: EditorConfig `end_of_line`, then Prettier
+   * `endOfLine` set to `lf`/`crlf`. `auto`/unset Prettier → undefined.
+   */
+  getExplicitEndOfLine: (filePath: string) => Promise<EndOfLine | undefined>;
+  /**
+   * #803 back-compat: Prettier config is resolvable but `endOfLine` is unset
+   * or `auto` → LF. Deprecated; planned for removal in the next major.
+   */
+  getImplicitEndOfLine: (filePath: string) => Promise<'\n' | undefined>;
+  /**
+   * Write-time precedence: explicit → detect(contents) → implicit → os.EOL.
+   * New/empty docs pass `contents` as undefined (skip detection).
+   */
+  resolve: (
+    filePath: string,
+    contents: string | undefined,
+  ) => Promise<EndOfLine>;
+};
 
 /**
- * Resolve an explicitly configured end of line for the given file path from
- * EditorConfig `end_of_line`. Returns undefined when unset so callers can fall
- * through to per-file detection.
- *
- * Prettier config is intentionally not read here — run Prettier via
- * `postprocess` (or a follow-up script) instead of interpreting its options.
+ * Create a memoized end-of-line resolver scoped to one `generate()` run.
+ * Cache keys are absolute file paths so sibling `.md`/`.mdx` files can differ.
  */
-export async function getConfiguredEndOfLine(
-  filePath: string,
-): Promise<'\n' | '\r\n' | undefined> {
-  const absolutePath = resolve(filePath);
-  const cacheKey = dirname(absolutePath);
+export function createEndOfLineResolver(): EndOfLineResolver {
+  const explicitCache = new Map<string, Promise<EndOfLine | undefined>>();
+  const implicitCache = new Map<string, Promise<'\n' | undefined>>();
+  const prettierCache = new Map<string, Promise<PrettierEndOfLineResult>>();
+  /** Shared across files so EditorConfig does not re-read the same files. */
+  const editorConfigFileCache: EditorConfigCache = new Map();
 
-  let cached = configuredEndOfLineCache.get(cacheKey);
-  if (!cached) {
-    cached = getEndOfLineFromEditorConfig(absolutePath);
-    configuredEndOfLineCache.set(cacheKey, cached);
+  async function getExplicitEndOfLine(
+    filePath: string,
+  ): Promise<EndOfLine | undefined> {
+    const absolutePath = resolve(filePath);
+    let cached = explicitCache.get(absolutePath);
+    if (!cached) {
+      cached = resolveExplicitEndOfLine(absolutePath);
+      explicitCache.set(absolutePath, cached);
+    }
+    const result = await cached;
+    return result;
   }
-  const result = await cached;
-  return result;
+
+  async function getImplicitEndOfLine(
+    filePath: string,
+  ): Promise<'\n' | undefined> {
+    const absolutePath = resolve(filePath);
+    let cached = implicitCache.get(absolutePath);
+    if (!cached) {
+      cached = resolveImplicitEndOfLine(absolutePath);
+      implicitCache.set(absolutePath, cached);
+    }
+    const result = await cached;
+    return result;
+  }
+
+  async function resolveExplicitEndOfLine(
+    absolutePath: string,
+  ): Promise<EndOfLine | undefined> {
+    const fromEditorConfig = await getEndOfLineFromEditorConfig(
+      absolutePath,
+      editorConfigFileCache,
+    );
+    if (fromEditorConfig !== undefined) {
+      return fromEditorConfig;
+    }
+
+    const prettier = await getPrettierEndOfLine(absolutePath, prettierCache);
+    return prettier.kind === 'explicit' ? prettier.value : undefined;
+  }
+
+  async function resolveImplicitEndOfLine(
+    absolutePath: string,
+  ): Promise<'\n' | undefined> {
+    // Explicit EditorConfig already handled at the explicit tier; do not treat
+    // it as an implicit Prettier default.
+    const fromEditorConfig = await getEndOfLineFromEditorConfig(
+      absolutePath,
+      editorConfigFileCache,
+    );
+    if (fromEditorConfig !== undefined) {
+      return undefined;
+    }
+
+    const prettier = await getPrettierEndOfLine(absolutePath, prettierCache);
+    return prettier.kind === 'implicit' ? '\n' : undefined;
+  }
+
+  async function resolveFileEndOfLine(
+    filePath: string,
+    contents: string | undefined,
+  ): Promise<EndOfLine> {
+    return (
+      (await getExplicitEndOfLine(filePath)) ??
+      (contents === undefined ? undefined : detectEndOfLine(contents)) ??
+      (await getImplicitEndOfLine(filePath)) ??
+      getFallbackEndOfLine()
+    );
+  }
+
+  return {
+    getExplicitEndOfLine,
+    getImplicitEndOfLine,
+    resolve: resolveFileEndOfLine,
+  };
 }
 
 async function getEndOfLineFromEditorConfig(
   filePath: string,
-): Promise<'\n' | '\r\n' | undefined> {
-  const editorConfigProps = await editorconfig.parse(filePath);
+  cache: EditorConfigCache,
+): Promise<EndOfLine | undefined> {
+  const editorConfigProps = await editorconfig.parse(filePath, { cache });
 
   if (editorConfigProps.end_of_line === 'lf') {
     return '\n';
@@ -47,11 +136,54 @@ async function getEndOfLineFromEditorConfig(
   return undefined;
 }
 
+async function getPrettierEndOfLine(
+  filePath: string,
+  cache: Map<string, Promise<PrettierEndOfLineResult>>,
+): Promise<PrettierEndOfLineResult> {
+  let cached = cache.get(filePath);
+  if (!cached) {
+    cached = resolvePrettierEndOfLine(filePath);
+    cache.set(filePath, cached);
+  }
+  const result = await cached;
+  return result;
+}
+
+async function resolvePrettierEndOfLine(
+  filePath: string,
+): Promise<PrettierEndOfLineResult> {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports -- prettier is an optional peer dependency, must be dynamically imported
+  let prettier: typeof import('prettier') | undefined;
+  try {
+    prettier = await import('prettier');
+  } catch {
+    /* istanbul ignore next */
+    return { kind: 'none' };
+  }
+
+  const prettierOptions = await prettier.resolveConfig(filePath);
+
+  if (prettierOptions === null) {
+    return { kind: 'none' };
+  }
+
+  if (prettierOptions.endOfLine === 'lf') {
+    return { kind: 'explicit', value: '\n' };
+  }
+
+  if (prettierOptions.endOfLine === 'crlf') {
+    return { kind: 'explicit', value: '\r\n' };
+  }
+
+  // Config present but endOfLine unset or `auto` — #803 implicit LF default.
+  return { kind: 'implicit' };
+}
+
 /**
  * Detect the predominant end of line in the given file contents.
  * Returns undefined if the contents have no line breaks.
  */
-export function detectEndOfLine(contents: string): '\n' | '\r\n' | undefined {
+export function detectEndOfLine(contents: string): EndOfLine | undefined {
   const crlfCount = contents.match(/\r\n/gu)?.length ?? 0;
   const lfCount = contents.match(/(?<!\r)\n/gu)?.length ?? 0;
 
@@ -72,14 +204,14 @@ export function normalizeEndOfLine(
   return contents.replaceAll(/\r\n|[\r\n]/gu, endOfLine);
 }
 
-/** Fallback when there is no explicit config and no detectable end of line. */
-export function getFallbackEndOfLine(): '\n' | '\r\n' {
+/** Fallback when there is no config and no detectable end of line. */
+export function getFallbackEndOfLine(): EndOfLine {
   return getNodeEOL();
 }
 
 /* istanbul ignore next */
 /** `EOL` is typed as `string`, so we perform run-time validation to be safe. */
-function getNodeEOL(): '\n' | '\r\n' {
+function getNodeEOL(): EndOfLine {
   if (EOL === '\n' || EOL === '\r\n') {
     return EOL;
   }

--- a/lib/eol.ts
+++ b/lib/eol.ts
@@ -5,27 +5,11 @@ import type { Cache as EditorConfigCache } from 'editorconfig';
 
 type EndOfLine = '\n' | '\r\n';
 
-// TODO: remove Prettier end-of-line reading in the next major — prefer
-// EditorConfig and running Prettier via `postprocess` (see README "Line endings").
-type PrettierEndOfLineResult =
-  | { kind: 'explicit'; value: EndOfLine }
-  | { kind: 'implicit' }
-  | { kind: 'none' };
-
 export type EndOfLineResolver = {
-  /**
-   * Explicit config only: EditorConfig `end_of_line`, then Prettier
-   * `endOfLine` set to `lf`/`crlf`. `auto`/unset Prettier → undefined.
-   */
+  /** EditorConfig `end_of_line` for the file path, if set. */
   getExplicitEndOfLine: (filePath: string) => Promise<EndOfLine | undefined>;
   /**
-   * #803 back-compat: Prettier config is resolvable but `endOfLine` is unset
-   * or `auto` → LF.
-   * TODO: remove in the next major (Prettier implicit LF tier).
-   */
-  getImplicitEndOfLine: (filePath: string) => Promise<'\n' | undefined>;
-  /**
-   * Write-time precedence: explicit → detect(contents) → implicit → os.EOL.
+   * Write-time precedence: EditorConfig → detect(contents) → `os.EOL`.
    * New/empty docs pass `contents` as undefined (skip detection).
    */
   resolve: (
@@ -40,17 +24,13 @@ export type EndOfLineResolver = {
  *
  * Write-time precedence for `resolve()`:
  * 1. Explicit EditorConfig `end_of_line`
- * 2. Explicit Prettier `endOfLine` (`lf`/`crlf`) — TODO: remove next major
- * 3. Predominant end of line in existing contents (skip when `contents` is undefined)
- * 4. Implicit Prettier LF when a config exists without `endOfLine` — TODO: remove next major
- * 5. `os.EOL`
+ * 2. Predominant end of line in existing contents (skip when `contents` is undefined)
+ * 3. `os.EOL`
+ *
+ * Prettier config is not read — run Prettier via `postprocess` if needed.
  */
 export function createEndOfLineResolver(): EndOfLineResolver {
   const explicitCache = new Map<string, Promise<EndOfLine | undefined>>();
-  // TODO: remove with Prettier implicit LF tier in the next major.
-  const implicitCache = new Map<string, Promise<'\n' | undefined>>();
-  // TODO: remove with Prettier end-of-line reading in the next major.
-  const prettierCache = new Map<string, Promise<PrettierEndOfLineResult>>();
   /** Shared across files so EditorConfig does not re-read the same files. */
   const editorConfigFileCache: EditorConfigCache = new Map();
 
@@ -60,58 +40,14 @@ export function createEndOfLineResolver(): EndOfLineResolver {
     const absolutePath = resolve(filePath);
     let cached = explicitCache.get(absolutePath);
     if (!cached) {
-      cached = resolveExplicitEndOfLine(absolutePath);
+      cached = getEndOfLineFromEditorConfig(
+        absolutePath,
+        editorConfigFileCache,
+      );
       explicitCache.set(absolutePath, cached);
     }
     const result = await cached;
     return result;
-  }
-
-  async function getImplicitEndOfLine(
-    filePath: string,
-  ): Promise<'\n' | undefined> {
-    const absolutePath = resolve(filePath);
-    let cached = implicitCache.get(absolutePath);
-    if (!cached) {
-      cached = resolveImplicitEndOfLine(absolutePath);
-      implicitCache.set(absolutePath, cached);
-    }
-    const result = await cached;
-    return result;
-  }
-
-  async function resolveExplicitEndOfLine(
-    absolutePath: string,
-  ): Promise<EndOfLine | undefined> {
-    const fromEditorConfig = await getEndOfLineFromEditorConfig(
-      absolutePath,
-      editorConfigFileCache,
-    );
-    if (fromEditorConfig !== undefined) {
-      return fromEditorConfig;
-    }
-
-    // TODO: remove Prettier explicit endOfLine tier in the next major.
-    const prettier = await getPrettierEndOfLine(absolutePath, prettierCache);
-    return prettier.kind === 'explicit' ? prettier.value : undefined;
-  }
-
-  async function resolveImplicitEndOfLine(
-    absolutePath: string,
-  ): Promise<'\n' | undefined> {
-    // Explicit EditorConfig already handled at the explicit tier; do not treat
-    // it as an implicit Prettier default.
-    const fromEditorConfig = await getEndOfLineFromEditorConfig(
-      absolutePath,
-      editorConfigFileCache,
-    );
-    if (fromEditorConfig !== undefined) {
-      return undefined;
-    }
-
-    // TODO: remove Prettier implicit LF tier (#803) in the next major.
-    const prettier = await getPrettierEndOfLine(absolutePath, prettierCache);
-    return prettier.kind === 'implicit' ? '\n' : undefined;
   }
 
   async function resolveFileEndOfLine(
@@ -121,15 +57,12 @@ export function createEndOfLineResolver(): EndOfLineResolver {
     return (
       (await getExplicitEndOfLine(filePath)) ??
       (contents === undefined ? undefined : detectEndOfLine(contents)) ??
-      // TODO: remove Prettier implicit LF tier in the next major.
-      (await getImplicitEndOfLine(filePath)) ??
       getFallbackEndOfLine()
     );
   }
 
   return {
     getExplicitEndOfLine,
-    getImplicitEndOfLine,
     resolve: resolveFileEndOfLine,
   };
 }
@@ -149,51 +82,6 @@ async function getEndOfLineFromEditorConfig(
   }
 
   return undefined;
-}
-
-async function getPrettierEndOfLine(
-  filePath: string,
-  cache: Map<string, Promise<PrettierEndOfLineResult>>,
-): Promise<PrettierEndOfLineResult> {
-  let cached = cache.get(filePath);
-  if (!cached) {
-    cached = resolvePrettierEndOfLine(filePath);
-    cache.set(filePath, cached);
-  }
-  const result = await cached;
-  return result;
-}
-
-// TODO: remove Prettier end-of-line reading (and the optional `prettier` peer
-// dependency) in the next major — prefer EditorConfig / `postprocess`.
-async function resolvePrettierEndOfLine(
-  filePath: string,
-): Promise<PrettierEndOfLineResult> {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-imports -- prettier is an optional peer dependency, must be dynamically imported
-  let prettier: typeof import('prettier') | undefined;
-  try {
-    prettier = await import('prettier');
-  } catch {
-    /* istanbul ignore next */
-    return { kind: 'none' };
-  }
-
-  const prettierOptions = await prettier.resolveConfig(filePath);
-
-  if (prettierOptions === null) {
-    return { kind: 'none' };
-  }
-
-  if (prettierOptions.endOfLine === 'lf') {
-    return { kind: 'explicit', value: '\n' };
-  }
-
-  if (prettierOptions.endOfLine === 'crlf') {
-    return { kind: 'explicit', value: '\r\n' };
-  }
-
-  // Config present but endOfLine unset or `auto` — #803 implicit LF default.
-  return { kind: 'implicit' };
 }
 
 /**

--- a/lib/eol.ts
+++ b/lib/eol.ts
@@ -89,13 +89,15 @@ async function getEndOfLineFromEditorConfig(
  * Returns undefined if the contents have no line breaks.
  */
 export function detectEndOfLine(contents: string): EndOfLine | undefined {
-  const crlfCount = contents.match(/\r\n/gu)?.length ?? 0;
-  const lfCount = contents.match(/(?<!\r)\n/gu)?.length ?? 0;
+  const crlfCount = contents.split('\r\n').length - 1;
+  // All LFs minus those that are part of a CRLF.
+  const lfCount = contents.split('\n').length - 1 - crlfCount;
 
   if (crlfCount === 0 && lfCount === 0) {
     return undefined;
   }
 
+  // A tie favors LF.
   return crlfCount > lfCount ? '\r\n' : '\n';
 }
 

--- a/lib/eol.ts
+++ b/lib/eol.ts
@@ -9,11 +9,12 @@ const configuredEndOfLineCache = new Map<
 >();
 
 /**
- * Resolve an explicitly configured end of line for the given file path.
- * Only EditorConfig `end_of_line` and an explicitly set Prettier `endOfLine`
- * (`lf` or `crlf`) count as configured. A Prettier config without `endOfLine`
- * (or with `auto`) does not imply LF — returns undefined so callers can fall
+ * Resolve an explicitly configured end of line for the given file path from
+ * EditorConfig `end_of_line`. Returns undefined when unset so callers can fall
  * through to per-file detection.
+ *
+ * Prettier config is intentionally not read here — run Prettier via
+ * `postprocess` (or a follow-up script) instead of interpreting its options.
  */
 export async function getConfiguredEndOfLine(
   filePath: string,
@@ -23,21 +24,11 @@ export async function getConfiguredEndOfLine(
 
   let cached = configuredEndOfLineCache.get(cacheKey);
   if (!cached) {
-    cached = resolveConfiguredEndOfLine(absolutePath);
+    cached = getEndOfLineFromEditorConfig(absolutePath);
     configuredEndOfLineCache.set(cacheKey, cached);
   }
   const result = await cached;
   return result;
-}
-
-async function resolveConfiguredEndOfLine(
-  absolutePath: string,
-): Promise<'\n' | '\r\n' | undefined> {
-  const fromEditorConfig = await getEndOfLineFromEditorConfig(absolutePath);
-  if (fromEditorConfig !== undefined) {
-    return fromEditorConfig;
-  }
-  return getEndOfLineFromPrettierConfig(absolutePath);
 }
 
 async function getEndOfLineFromEditorConfig(
@@ -53,36 +44,6 @@ async function getEndOfLineFromEditorConfig(
     return '\r\n';
   }
 
-  return undefined;
-}
-
-async function getEndOfLineFromPrettierConfig(
-  filePath: string,
-): Promise<'\n' | '\r\n' | undefined> {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-imports -- prettier is an optional peer dependency, must be dynamically imported
-  let prettier: typeof import('prettier') | undefined;
-  try {
-    prettier = await import('prettier');
-  } catch {
-    /* istanbul ignore next */
-    return undefined;
-  }
-
-  const prettierOptions = await prettier.resolveConfig(filePath);
-
-  if (prettierOptions === null) {
-    return undefined;
-  }
-
-  if (prettierOptions.endOfLine === 'lf') {
-    return '\n';
-  }
-
-  if (prettierOptions.endOfLine === 'crlf') {
-    return '\r\n';
-  }
-
-  // Unset or `auto` — not an explicit end of line; fall through to detection.
   return undefined;
 }
 

--- a/lib/frontmatter.ts
+++ b/lib/frontmatter.ts
@@ -19,19 +19,16 @@ export function generateFrontmatterLines(
   frontmatterOld: string | undefined,
 ): string {
   const {
-    endOfLine,
     options: { framework },
   } = context;
   const title = makeRuleDocTitle(context, name, description);
 
-  const oldFrontmatterLines = frontmatterOld
-    ? frontmatterOld.split(endOfLine)
-    : [];
+  const oldFrontmatterLines = frontmatterOld ? frontmatterOld.split('\n') : [];
 
   // If the framework is 'none', then just bail out and return the old frontmatter.
   // We don't want to change anything.
   if (framework === 'none') {
-    return oldFrontmatterLines.join(endOfLine);
+    return oldFrontmatterLines.join('\n');
   }
 
   // If there is currently no frontmatter, then create a new one with the title and description.
@@ -43,7 +40,7 @@ export function generateFrontmatterLines(
       );
     }
     newFrontmatter.push('---');
-    return newFrontmatter.join(endOfLine);
+    return newFrontmatter.join('\n');
   }
 
   const newFrontmatter = [];
@@ -78,5 +75,5 @@ export function generateFrontmatterLines(
       formatFrontmatterProperty('description', description),
     );
   }
-  return newFrontmatter.join(endOfLine);
+  return newFrontmatter.join('\n');
 }

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -174,8 +174,7 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     }
 
     const isRuleDocMdx = isMdx(pathToDoc);
-    const contentsOldBuffer = await readFile(pathToDoc);
-    const contentsOld = contentsOldBuffer.toString();
+    const contentsOld = await readFile(pathToDoc, 'utf8');
 
     // Normalize to LF for processing; restore this file's end of line before write.
     const endOfLine = await endOfLineResolver.resolve(pathToDoc, contentsOld);

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -26,12 +26,7 @@ import { replaceRulePlaceholder } from './rule-link.js';
 import { updateRuleOptionsList } from './rule-options-list.js';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { getContext } from './context.js';
-import {
-  detectEndOfLine,
-  getConfiguredEndOfLine,
-  getFallbackEndOfLine,
-  normalizeEndOfLine,
-} from './eol.js';
+import { createEndOfLineResolver, normalizeEndOfLine } from './eol.js';
 import { generateSuggestedEmojis } from './suggest-emojis.js';
 import { generateFrontmatterLines } from './frontmatter.js';
 
@@ -64,30 +59,16 @@ function resolveDocPath(configuredPath: string): string | undefined {
   return undefined;
 }
 
-/**
- * Resolve the end of line to use when writing a markdown file.
- * Precedence: explicit EditorConfig `end_of_line` → predominant end of line in
- * the existing contents → `os.EOL`.
- */
-async function resolveFileEndOfLine(
-  filePath: string,
-  contents: string | undefined,
-): Promise<'\n' | '\r\n'> {
-  return (
-    (await getConfiguredEndOfLine(filePath)) ??
-    (contents === undefined ? undefined : detectEndOfLine(contents)) ??
-    getFallbackEndOfLine()
-  );
-}
-
 // eslint-disable-next-line complexity
 export async function generate(path: string, userOptions?: GenerateOptions) {
   const context = await getContext(path, userOptions);
   const { options, plugin } = context;
+  const endOfLineResolver = createEndOfLineResolver();
 
   // All markdown content is processed using LF (`\n`) line endings internally.
-  // Each file is written using: explicit EditorConfig `end_of_line`, else the
-  // predominant end of line already in that file, else `os.EOL`.
+  // Each file is written using: explicit EditorConfig/Prettier endOfLine, else
+  // the predominant end of line already in that file, else Prettier's implicit
+  // LF default when a config exists without endOfLine (#803), else `os.EOL`.
 
   // Destructure options that are only used in this function. Other options are passed around using
   // the "context" object.
@@ -183,8 +164,11 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
       }
 
       await mkdir(dirname(pathToDoc), { recursive: true });
-      // New docs have no contents to detect from; use explicit config or os.EOL.
-      const newDocEndOfLine = await resolveFileEndOfLine(pathToDoc, undefined);
+      // New docs have no contents to detect from; use explicit/implicit config or os.EOL.
+      const newDocEndOfLine = await endOfLineResolver.resolve(
+        pathToDoc,
+        undefined,
+      );
       await writeFile(
         pathToDoc,
         normalizeEndOfLine(newRuleDocContents, newDocEndOfLine),
@@ -196,10 +180,11 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     const contentsOldBuffer = await readFile(pathToDoc);
     const contentsOld = contentsOldBuffer.toString();
 
-    // Process the doc using LF line endings. When writing, prefer an explicit
-    // EditorConfig `end_of_line` (converting the file if needed), else keep the
-    // predominant end of line already in the doc, else `os.EOL`.
-    const endOfLine = await resolveFileEndOfLine(pathToDoc, contentsOld);
+    // Process the doc using LF line endings. When writing, prefer explicit
+    // EditorConfig/Prettier endOfLine (converting if needed), else keep the
+    // predominant end of line already in the doc, else Prettier's implicit LF
+    // (#803), else `os.EOL`.
+    const endOfLine = await endOfLineResolver.resolve(pathToDoc, contentsOld);
     const contentsOldNormalized = normalizeEndOfLine(contentsOld, '\n');
 
     const frontmatterOld = extractFrontmatter(contentsOldNormalized);
@@ -320,10 +305,10 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     // Update the rules list in this file.
     const fileContents = await readFile(pathToFile, 'utf8');
 
-    // Process the file using LF line endings. When writing, prefer an explicit
-    // EditorConfig `end_of_line`, else the predominant end of line already in
-    // the file, else `os.EOL`.
-    const endOfLine = await resolveFileEndOfLine(pathToFile, fileContents);
+    // Process the file using LF line endings. When writing, prefer explicit
+    // EditorConfig/Prettier endOfLine, else the predominant end of line already
+    // in the file, else Prettier's implicit LF (#803), else `os.EOL`.
+    const endOfLine = await endOfLineResolver.resolve(pathToFile, fileContents);
     const fileContentsNormalized = normalizeEndOfLine(fileContents, '\n');
 
     const rulesList = updateRulesList(

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -66,8 +66,8 @@ function resolveDocPath(configuredPath: string): string | undefined {
 
 /**
  * Resolve the end of line to use when writing a markdown file.
- * Precedence: explicit EditorConfig/Prettier endOfLine → predominant end of
- * line in the existing contents → `os.EOL`.
+ * Precedence: explicit EditorConfig `end_of_line` → predominant end of line in
+ * the existing contents → `os.EOL`.
  */
 async function resolveFileEndOfLine(
   filePath: string,
@@ -86,8 +86,8 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
   const { options, plugin } = context;
 
   // All markdown content is processed using LF (`\n`) line endings internally.
-  // Each file is written using: explicit EditorConfig/Prettier endOfLine, else
-  // the predominant end of line already in that file, else `os.EOL`.
+  // Each file is written using: explicit EditorConfig `end_of_line`, else the
+  // predominant end of line already in that file, else `os.EOL`.
 
   // Destructure options that are only used in this function. Other options are passed around using
   // the "context" object.
@@ -197,8 +197,8 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     const contentsOld = contentsOldBuffer.toString();
 
     // Process the doc using LF line endings. When writing, prefer an explicit
-    // EditorConfig/Prettier endOfLine (converting the file if needed), else
-    // keep the predominant end of line already in the doc, else `os.EOL`.
+    // EditorConfig `end_of_line` (converting the file if needed), else keep the
+    // predominant end of line already in the doc, else `os.EOL`.
     const endOfLine = await resolveFileEndOfLine(pathToDoc, contentsOld);
     const contentsOldNormalized = normalizeEndOfLine(contentsOld, '\n');
 
@@ -321,8 +321,8 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     const fileContents = await readFile(pathToFile, 'utf8');
 
     // Process the file using LF line endings. When writing, prefer an explicit
-    // EditorConfig/Prettier endOfLine, else the predominant end of line
-    // already in the file, else `os.EOL`.
+    // EditorConfig `end_of_line`, else the predominant end of line already in
+    // the file, else `os.EOL`.
     const endOfLine = await resolveFileEndOfLine(pathToFile, fileContents);
     const fileContentsNormalized = normalizeEndOfLine(fileContents, '\n');
 

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -26,7 +26,12 @@ import { replaceRulePlaceholder } from './rule-link.js';
 import { updateRuleOptionsList } from './rule-options-list.js';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { getContext } from './context.js';
-import { detectEndOfLine, getEndOfLine, normalizeEndOfLine } from './eol.js';
+import {
+  detectEndOfLine,
+  getConfiguredEndOfLine,
+  getFallbackEndOfLine,
+  normalizeEndOfLine,
+} from './eol.js';
 import { generateSuggestedEmojis } from './suggest-emojis.js';
 import { generateFrontmatterLines } from './frontmatter.js';
 
@@ -59,16 +64,30 @@ function resolveDocPath(configuredPath: string): string | undefined {
   return undefined;
 }
 
+/**
+ * Resolve the end of line to use when writing a markdown file.
+ * Precedence: explicit EditorConfig/Prettier endOfLine → predominant end of
+ * line in the existing contents → `os.EOL`.
+ */
+async function resolveFileEndOfLine(
+  filePath: string,
+  contents: string | undefined,
+): Promise<'\n' | '\r\n'> {
+  return (
+    (await getConfiguredEndOfLine(filePath)) ??
+    (contents === undefined ? undefined : detectEndOfLine(contents)) ??
+    getFallbackEndOfLine()
+  );
+}
+
 // eslint-disable-next-line complexity
 export async function generate(path: string, userOptions?: GenerateOptions) {
   const context = await getContext(path, userOptions);
   const { options, plugin } = context;
 
   // All markdown content is processed using LF (`\n`) line endings internally.
-  // Each file is written using the end of line already predominant in that
-  // file, falling back to the configured end of line (EditorConfig, then
-  // Prettier, then `os.EOL`) for new files and files without line breaks.
-  const configuredEndOfLine = await getEndOfLine();
+  // Each file is written using: explicit EditorConfig/Prettier endOfLine, else
+  // the predominant end of line already in that file, else `os.EOL`.
 
   // Destructure options that are only used in this function. Other options are passed around using
   // the "context" object.
@@ -164,9 +183,11 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
       }
 
       await mkdir(dirname(pathToDoc), { recursive: true });
+      // New docs have no contents to detect from; use explicit config or os.EOL.
+      const newDocEndOfLine = await resolveFileEndOfLine(pathToDoc, undefined);
       await writeFile(
         pathToDoc,
-        normalizeEndOfLine(newRuleDocContents, configuredEndOfLine),
+        normalizeEndOfLine(newRuleDocContents, newDocEndOfLine),
       );
       initializedRuleDoc = true;
     }
@@ -175,11 +196,10 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     const contentsOldBuffer = await readFile(pathToDoc);
     const contentsOld = contentsOldBuffer.toString();
 
-    // Process the doc using LF line endings. When writing, use the end of
-    // line already predominant in the doc so that its line endings are
-    // preserved even when they differ from the configured end of line (such
-    // as when another tool like Prettier rewrote the doc).
-    const endOfLine = detectEndOfLine(contentsOld) ?? configuredEndOfLine;
+    // Process the doc using LF line endings. When writing, prefer an explicit
+    // EditorConfig/Prettier endOfLine (converting the file if needed), else
+    // keep the predominant end of line already in the doc, else `os.EOL`.
+    const endOfLine = await resolveFileEndOfLine(pathToDoc, contentsOld);
     const contentsOldNormalized = normalizeEndOfLine(contentsOld, '\n');
 
     const frontmatterOld = extractFrontmatter(contentsOldNormalized);
@@ -300,10 +320,10 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     // Update the rules list in this file.
     const fileContents = await readFile(pathToFile, 'utf8');
 
-    // Process the file using LF line endings. When writing, use the end of
-    // line already predominant in the file so that its line endings are
-    // preserved even when they differ from the configured end of line.
-    const endOfLine = detectEndOfLine(fileContents) ?? configuredEndOfLine;
+    // Process the file using LF line endings. When writing, prefer an explicit
+    // EditorConfig/Prettier endOfLine, else the predominant end of line
+    // already in the file, else `os.EOL`.
+    const endOfLine = await resolveFileEndOfLine(pathToFile, fileContents);
     const fileContentsNormalized = normalizeEndOfLine(fileContents, '\n');
 
     const rulesList = updateRulesList(

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -65,10 +65,8 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
   const { options, plugin } = context;
   const endOfLineResolver = createEndOfLineResolver();
 
-  // All markdown content is processed using LF (`\n`) line endings internally.
-  // Each file is written using: explicit EditorConfig/Prettier endOfLine, else
-  // the predominant end of line already in that file, else Prettier's implicit
-  // LF default when a config exists without endOfLine (#803), else `os.EOL`.
+  // Markdown is processed with LF internally; each file's write end of line
+  // comes from `endOfLineResolver` (see `lib/eol.ts`).
 
   // Destructure options that are only used in this function. Other options are passed around using
   // the "context" object.
@@ -164,7 +162,6 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
       }
 
       await mkdir(dirname(pathToDoc), { recursive: true });
-      // New docs have no contents to detect from; use explicit/implicit config or os.EOL.
       const newDocEndOfLine = await endOfLineResolver.resolve(
         pathToDoc,
         undefined,
@@ -180,10 +177,7 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     const contentsOldBuffer = await readFile(pathToDoc);
     const contentsOld = contentsOldBuffer.toString();
 
-    // Process the doc using LF line endings. When writing, prefer explicit
-    // EditorConfig/Prettier endOfLine (converting if needed), else keep the
-    // predominant end of line already in the doc, else Prettier's implicit LF
-    // (#803), else `os.EOL`.
+    // Normalize to LF for processing; restore this file's end of line before write.
     const endOfLine = await endOfLineResolver.resolve(pathToDoc, contentsOld);
     const contentsOldNormalized = normalizeEndOfLine(contentsOld, '\n');
 
@@ -305,9 +299,7 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     // Update the rules list in this file.
     const fileContents = await readFile(pathToFile, 'utf8');
 
-    // Process the file using LF line endings. When writing, prefer explicit
-    // EditorConfig/Prettier endOfLine, else the predominant end of line already
-    // in the file, else Prettier's implicit LF (#803), else `os.EOL`.
+    // Normalize to LF for processing; restore this file's end of line before write.
     const endOfLine = await endOfLineResolver.resolve(pathToFile, fileContents);
     const fileContentsNormalized = normalizeEndOfLine(fileContents, '\n');
 

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -26,6 +26,7 @@ import { replaceRulePlaceholder } from './rule-link.js';
 import { updateRuleOptionsList } from './rule-options-list.js';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { getContext } from './context.js';
+import { detectEndOfLine, getEndOfLine, normalizeEndOfLine } from './eol.js';
 import { generateSuggestedEmojis } from './suggest-emojis.js';
 import { generateFrontmatterLines } from './frontmatter.js';
 
@@ -61,7 +62,13 @@ function resolveDocPath(configuredPath: string): string | undefined {
 // eslint-disable-next-line complexity
 export async function generate(path: string, userOptions?: GenerateOptions) {
   const context = await getContext(path, userOptions);
-  const { endOfLine, options, plugin } = context;
+  const { options, plugin } = context;
+
+  // All markdown content is processed using LF (`\n`) line endings internally.
+  // Each file is written using the end of line already predominant in that
+  // file, falling back to the configured end of line (EditorConfig, then
+  // Prettier, then `os.EOL`) for new files and files without line breaks.
+  const configuredEndOfLine = await getEndOfLine();
 
   // Destructure options that are only used in this function. Other options are passed around using
   // the "context" object.
@@ -142,31 +149,40 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
       const isRuleDocMdx = isMdx(pathToDoc);
       let newRuleDocContents = [
         ruleDocSectionInclude.length > 0
-          ? ruleDocSectionInclude
-              .map((title) => `## ${title}`)
-              .join(`${endOfLine}${endOfLine}`)
+          ? ruleDocSectionInclude.map((title) => `## ${title}`).join('\n\n')
           : undefined,
         /* istanbul ignore next -- both branches tested but coverage has instrumentation issue with ternary in array */
         ruleHasOptions
-          ? `## Options${endOfLine}${endOfLine}${formatComment(BEGIN_RULE_OPTIONS_LIST_MARKER, isRuleDocMdx)}${endOfLine}${formatComment(END_RULE_OPTIONS_LIST_MARKER, isRuleDocMdx)}`
+          ? `## Options\n\n${formatComment(BEGIN_RULE_OPTIONS_LIST_MARKER, isRuleDocMdx)}\n${formatComment(END_RULE_OPTIONS_LIST_MARKER, isRuleDocMdx)}`
           : undefined,
       ]
         .filter((section) => section !== undefined)
-        .join(`${endOfLine}${endOfLine}`);
+        .join('\n\n');
       /* istanbul ignore next -- V8 branch coverage doesn't detect this branch is tested */
       if (newRuleDocContents !== '') {
-        newRuleDocContents = `${endOfLine}${newRuleDocContents}${endOfLine}`;
+        newRuleDocContents = `\n${newRuleDocContents}\n`;
       }
 
       await mkdir(dirname(pathToDoc), { recursive: true });
-      await writeFile(pathToDoc, newRuleDocContents);
+      await writeFile(
+        pathToDoc,
+        normalizeEndOfLine(newRuleDocContents, configuredEndOfLine),
+      );
       initializedRuleDoc = true;
     }
 
     const isRuleDocMdx = isMdx(pathToDoc);
     const contentsOldBuffer = await readFile(pathToDoc);
     const contentsOld = contentsOldBuffer.toString();
-    const frontmatterOld = extractFrontmatter(context, contentsOld);
+
+    // Process the doc using LF line endings. When writing, use the end of
+    // line already predominant in the doc so that its line endings are
+    // preserved even when they differ from the configured end of line (such
+    // as when another tool like Prettier rewrote the doc).
+    const endOfLine = detectEndOfLine(contentsOld) ?? configuredEndOfLine;
+    const contentsOldNormalized = normalizeEndOfLine(contentsOld, '\n');
+
+    const frontmatterOld = extractFrontmatter(contentsOldNormalized);
 
     // Regenerate the header (title/notices) and frontmatter of each rule doc.
     const newHeaderLines = generateRuleHeaderLines(
@@ -184,23 +200,22 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
 
     // Generate the new content for the rule doc by replacing the header and frontmatter, and updating the rule options list if necessary.
     let contentsNew = replaceOrCreateFrontmatter(
-      context,
-      contentsOld,
+      contentsOldNormalized,
       newFrontmatterLines,
     );
     contentsNew = replaceOrCreateHeader(
-      context,
       contentsNew,
       newHeaderLines,
       isRuleDocMdx,
     );
-    contentsNew = updateRuleOptionsList(
-      context,
-      contentsNew,
-      rule,
-      isRuleDocMdx,
-    );
+    contentsNew = updateRuleOptionsList(contentsNew, rule, isRuleDocMdx);
+
+    // Convert to the doc's end of line before postprocessing and writing.
+    contentsNew = normalizeEndOfLine(contentsNew, endOfLine);
     contentsNew = await postprocess(contentsNew, resolve(pathToDoc));
+
+    // LF-normalized copy of the final contents for the content checks below.
+    const contentsNewNormalized = normalizeEndOfLine(contentsNew, '\n');
 
     if (check) {
       /* istanbul ignore next -- V8 branch coverage doesn't detect this branch is tested */
@@ -223,9 +238,8 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     // Check for required sections.
     for (const section of ruleDocSectionInclude) {
       expectSectionHeaderOrFail(
-        context,
         `\`${name}\` rule doc`,
-        contentsNew,
+        contentsNewNormalized,
         [section],
         true,
       );
@@ -234,9 +248,8 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     // Check for disallowed sections.
     for (const section of ruleDocSectionExclude) {
       expectSectionHeaderOrFail(
-        context,
         `\`${name}\` rule doc`,
-        contentsNew,
+        contentsNewNormalized,
         [section],
         false,
       );
@@ -245,9 +258,8 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     if (ruleDocSectionOptions) {
       // Options section.
       expectSectionHeaderOrFail(
-        context,
         `\`${name}\` rule doc`,
-        contentsNew,
+        contentsNewNormalized,
         ['Options', 'Config'],
         ruleHasOptions,
       );
@@ -258,7 +270,7 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
         expectContentOrFail(
           `\`${name}\` rule doc`,
           'rule option',
-          contentsNew,
+          contentsNewNormalized,
           namedOption,
           true,
         ); // Each rule option is mentioned.
@@ -287,14 +299,24 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
 
     // Update the rules list in this file.
     const fileContents = await readFile(pathToFile, 'utf8');
+
+    // Process the file using LF line endings. When writing, use the end of
+    // line already predominant in the file so that its line endings are
+    // preserved even when they differ from the configured end of line.
+    const endOfLine = detectEndOfLine(fileContents) ?? configuredEndOfLine;
+    const fileContentsNormalized = normalizeEndOfLine(fileContents, '\n');
+
     const rulesList = updateRulesList(
       context,
       ruleNamesAndRules,
-      fileContents,
+      fileContentsNormalized,
       pathToFile,
     );
     const fileContentsNew = await postprocess(
-      updateConfigsList(context, rulesList, isRuleListMdx),
+      normalizeEndOfLine(
+        updateConfigsList(context, rulesList, isRuleListMdx),
+        endOfLine,
+      ),
       resolve(pathToFile),
     );
 

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -1,11 +1,12 @@
 // General helpers for dealing with markdown files / content.
+// All markdown content is processed using LF (`\n`) line endings. The desired
+// end of line for each file is only applied when writing the file.
 
 import { END_RULE_HEADER_MARKER, formatComment } from './comment-markers.js';
 import type { Context } from './context.js';
 
-export function extractFrontmatter(context: Context, markdown: string) {
-  const { endOfLine } = context;
-  const lines = markdown.split(endOfLine);
+export function extractFrontmatter(markdown: string) {
+  const lines = markdown.split('\n');
   const frontMatterStart = lines.indexOf('---');
 
   // Frontmatter must start at the beginning of the file to be considered valid, so if we don't find '---' at the beginning, we want to ignore it.
@@ -14,19 +15,17 @@ export function extractFrontmatter(context: Context, markdown: string) {
   }
   const frontMatterEnd = lines.indexOf('---', frontMatterStart + 1);
   if (frontMatterEnd !== -1) {
-    return lines.slice(frontMatterStart, frontMatterEnd + 1).join(endOfLine);
+    return lines.slice(frontMatterStart, frontMatterEnd + 1).join('\n');
   }
   return undefined;
 }
 
 /**
  * Replace the frontmatter, if present.  If not and we have newFrontmatter to add, then add it at the beginning.
- * @param context - execution context
  * @param markdown - doc content
  * @param newFrontmatter - new frontmatter
  */
 export function replaceOrCreateFrontmatter(
-  context: Context,
   markdown: string,
   newFrontmatter: string | undefined,
 ): string {
@@ -35,39 +34,33 @@ export function replaceOrCreateFrontmatter(
     return markdown;
   }
 
-  const { endOfLine } = context;
-
-  const lines = markdown.split(endOfLine);
+  const lines = markdown.split('\n');
 
   const frontmatterStartIndex = lines.indexOf('---');
 
   // If there's no existing frontmatter, just add it to the top.
   if (frontmatterStartIndex !== 0) {
-    return [newFrontmatter, markdown].join(endOfLine);
+    return [newFrontmatter, markdown].join('\n');
   }
 
   const frontmatterEndIndex = lines.indexOf('---', frontmatterStartIndex + 1);
-  const postFrontmatter = lines.slice(frontmatterEndIndex + 1).join(endOfLine);
-  return [newFrontmatter, postFrontmatter].join(endOfLine);
+  const postFrontmatter = lines.slice(frontmatterEndIndex + 1).join('\n');
+  return [newFrontmatter, postFrontmatter].join('\n');
 }
 
 /**
  * Replace the header of a doc up to and including the specified marker.
  * Insert at beginning if header doesn't exist.
- * @param context - execution context
  * @param markdown - doc content
  * @param newHeader - new header including marker
  * @param isMdx - is the file we're working on mdx or just regular md
  */
 export function replaceOrCreateHeader(
-  context: Context,
   markdown: string,
   newHeader: string,
   isMdx: boolean,
 ) {
-  const { endOfLine } = context;
-
-  const lines = markdown.split(endOfLine);
+  const lines = markdown.split('\n');
 
   const titleLineIndex = lines.findIndex((line) => line.startsWith('# '));
   const markerLineIndex = lines.indexOf(
@@ -79,32 +72,27 @@ export function replaceOrCreateHeader(
   // Any YAML front matter or anything else above the title should be kept as-is ahead of the new header.
   const preHeader = lines
     .slice(0, Math.max(titleLineIndex, dashesLineIndex2 + 1))
-    .join(endOfLine);
+    .join('\n');
 
   // Anything after the marker comment, title, or YAML front matter should be kept as-is after the new header.
   const postHeader = lines
     .slice(
       Math.max(markerLineIndex + 1, titleLineIndex + 1, dashesLineIndex2 + 1),
     )
-    .join(endOfLine);
+    .join('\n');
 
-  return `${
-    preHeader ? `${preHeader}${endOfLine}` : ''
-  }${newHeader}${endOfLine}${postHeader}`;
+  return `${preHeader ? `${preHeader}\n` : ''}${newHeader}\n${postHeader}`;
 }
 
 /**
  * Find the section most likely to be the top-level section for a given string.
  */
 export function findSectionHeader(
-  context: Context,
   markdown: string,
   str: string,
 ): string | undefined {
-  const { endOfLine } = context;
-
   // Get all the matching strings.
-  const regexp = new RegExp(`## .*${str}.*${endOfLine}`, 'giu');
+  const regexp = new RegExp(`## .*${str}.*\n`, 'giu');
   const sectionPotentialMatches = [...markdown.matchAll(regexp)].map(
     (match) => match[0],
   );
@@ -130,11 +118,10 @@ export function findFinalHeaderLevel(
   str: string,
 ): number | undefined {
   const {
-    endOfLine,
     options: { framework },
   } = context;
 
-  const lines = str.split(endOfLine);
+  const lines = str.split('\n');
   const finalHeader = lines
     .toReversed()
     .find((line) => line.match('^(#+) .+$'));
@@ -143,7 +130,7 @@ export function findFinalHeaderLevel(
     return finalHeader.indexOf(' ');
   }
   // If the framework is `starlight` and there's frontmatter at the top, treat that as an H1
-  else if (framework === 'starlight' && extractFrontmatter(context, str)) {
+  else if (framework === 'starlight' && extractFrontmatter(str)) {
     return 1;
   }
 
@@ -184,14 +171,13 @@ export function expectContentOrFail(
 }
 
 export function expectSectionHeaderOrFail(
-  context: Context,
   contentName: string,
   contents: string,
   possibleHeaders: readonly string[],
   expected: boolean,
 ) {
   const found = possibleHeaders.some((header) =>
-    findSectionHeader(context, contents, header),
+    findSectionHeader(contents, header),
   );
   if (found !== expected) {
     if (possibleHeaders.length > 1) {

--- a/lib/rule-doc-notices.ts
+++ b/lib/rule-doc-notices.ts
@@ -481,7 +481,6 @@ export function generateRuleHeaderLines(
   isMdx: boolean,
 ): string {
   const {
-    endOfLine,
     options: { framework },
   } = context;
 
@@ -492,5 +491,5 @@ export function generateRuleHeaderLines(
     ...getRuleNoticeLines(context, name),
     '',
     formatComment(END_RULE_HEADER_MARKER, isMdx),
-  ].join(endOfLine);
+  ].join('\n');
 }

--- a/lib/rule-list-legend.ts
+++ b/lib/rule-list-legend.ts
@@ -169,8 +169,6 @@ export function generateLegend(
   context: Context,
   columns: Record<COLUMN_TYPE, boolean>,
 ) {
-  const { endOfLine } = context;
-
   const legends = (
     Object.entries(columns) as readonly [COLUMN_TYPE, boolean][]
   ).flatMap(([columnType, enabled]) => {
@@ -208,5 +206,5 @@ export function generateLegend(
   }
 
   // The backslashes ensure that they end up displayed on separate lines.
-  return legends.join(`\\${endOfLine}`);
+  return legends.join('\\\n');
 }

--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -162,7 +162,7 @@ function generateRulesListMarkdown(
   });
 
   return markdownTable(
-    sanitizeMarkdownTable(context, [
+    sanitizeMarkdownTable([
       listHeaderRow,
       ...ruleNamesAndRules.map(([name, rule]) =>
         buildRuleRow(context, name, rule, columns, pathToFile),
@@ -186,7 +186,6 @@ function generateRuleListMarkdownForRulesAndHeaders(
   columns: Record<COLUMN_TYPE, boolean>,
   pathToFile: string,
 ): string {
-  const { endOfLine } = context;
   const parts: string[] = [];
 
   for (const { title, rules, description } of rulesAndHeaders) {
@@ -199,7 +198,7 @@ function generateRuleListMarkdownForRulesAndHeaders(
     parts.push(generateRulesListMarkdown(context, rules, columns, pathToFile));
   }
 
-  return parts.join(`${endOfLine}${endOfLine}`);
+  return parts.join('\n\n');
 }
 
 /**
@@ -312,7 +311,7 @@ export function updateRulesList(
   markdown: string,
   pathToFile: string,
 ): string {
-  const { endOfLine, path, options } = context;
+  const { path, options } = context;
   const { ruleListSplit } = options;
 
   const isMdx = pathToFile.endsWith('.mdx');
@@ -326,7 +325,7 @@ export function updateRulesList(
   let listEndIndex = markdown.indexOf(formattedRuleListMarkerEnd);
 
   // Find the best possible section to insert the rules list into if the markers are missing.
-  const rulesSectionHeader = findSectionHeader(context, markdown, 'rules');
+  const rulesSectionHeader = findSectionHeader(markdown, 'rules');
   const rulesSectionIndex = rulesSectionHeader
     ? markdown.indexOf(rulesSectionHeader)
     : -1;
@@ -438,7 +437,7 @@ export function updateRulesList(
     pathToFile,
   );
 
-  const newContent = `${legend ? `${legend}${endOfLine}${endOfLine}` : ''}${list}`;
+  const newContent = `${legend ? `${legend}\n\n` : ''}${list}`;
 
-  return `${preList}${formattedRuleListMarkerBegin}${endOfLine}${endOfLine}${newContent}${endOfLine}${endOfLine}${formattedRuleListMarkerEnd}${postList}`;
+  return `${preList}${formattedRuleListMarkerBegin}\n\n${newContent}\n\n${formattedRuleListMarkerEnd}${postList}`;
 }

--- a/lib/rule-options-list.ts
+++ b/lib/rule-options-list.ts
@@ -8,7 +8,6 @@ import type { RuleModule } from './types.js';
 import { getAllNamedOptions } from './rule-options.js';
 import type { RuleOption } from './rule-options.js';
 import { sanitizeMarkdownTable } from './string.js';
-import type { Context } from './context.js';
 
 const COLUMN_TYPE = {
   // Alphabetical order.
@@ -113,10 +112,7 @@ function ruleOptionsToColumnsToDisplay(ruleOptions: readonly RuleOption[]): {
   return columnsToDisplay;
 }
 
-function generateRuleOptionsListMarkdown(
-  context: Context,
-  rule: RuleModule,
-): string {
+function generateRuleOptionsListMarkdown(rule: RuleModule): string {
   const ruleOptions = getAllNamedOptions(
     rule.meta?.schema,
     rule.meta?.defaultOptions,
@@ -145,19 +141,16 @@ function generateRuleOptionsListMarkdown(
     });
 
   return markdownTable(
-    sanitizeMarkdownTable(context, [listHeaderRow, ...rows]),
+    sanitizeMarkdownTable([listHeaderRow, ...rows]),
     { align: 'l' }, // Left-align headers.
   );
 }
 
 export function updateRuleOptionsList(
-  context: Context,
   markdown: string,
   rule: RuleModule,
   isMdx: boolean,
 ): string {
-  const { endOfLine } = context;
-
   const formattedRuleOptionsListMarkerBegin = formatComment(
     BEGIN_RULE_OPTIONS_LIST_MARKER,
     isMdx,
@@ -182,7 +175,7 @@ export function updateRuleOptionsList(
   const postList = markdown.slice(Math.max(0, listEndIndex));
 
   // New rule options list.
-  const list = generateRuleOptionsListMarkdown(context, rule);
+  const list = generateRuleOptionsListMarkdown(rule);
 
-  return `${preList}${formattedRuleOptionsListMarkerBegin}${endOfLine}${endOfLine}${list}${endOfLine}${endOfLine}${formattedRuleOptionsListMarkerEnd}${postList}`;
+  return `${preList}${formattedRuleOptionsListMarkerBegin}\n\n${list}\n\n${formattedRuleOptionsListMarkerEnd}${postList}`;
 }

--- a/lib/string.ts
+++ b/lib/string.ts
@@ -1,5 +1,3 @@
-import type { Context } from './context.js';
-
 export function toSentenceCase(str: string) {
   return str.replace(/^\w/u, function (txt) {
     return txt.charAt(0).toUpperCase() + txt.slice(1).toLowerCase();
@@ -21,19 +19,13 @@ export function capitalizeOnlyFirstLetter(str: string) {
   return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 }
 
-function sanitizeMarkdownTableCell(context: Context, text: string): string {
-  const { endOfLine } = context;
-
-  return text
-    .replaceAll('|', String.raw`\|`)
-    .replaceAll(new RegExp(endOfLine, 'gu'), '<br/>');
+function sanitizeMarkdownTableCell(text: string): string {
+  // Handle CRLF line endings too since cell text can come from rule metadata.
+  return text.replaceAll('|', String.raw`\|`).replaceAll(/\r?\n/gu, '<br/>');
 }
 
 export function sanitizeMarkdownTable(
-  context: Context,
   text: readonly (readonly string[])[],
 ): readonly (readonly string[])[] {
-  return text.map((row) =>
-    row.map((col) => sanitizeMarkdownTableCell(context, col)),
-  );
+  return text.map((row) => row.map((col) => sanitizeMarkdownTableCell(col)));
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-doc-generator",
-  "version": "3.6.0",
+  "version": "3.7.0-beta.0",
   "description": "Automatic documentation generator for ESLint plugins and rules.",
   "keywords": [
     "doc",

--- a/package.json
+++ b/package.json
@@ -85,13 +85,7 @@
     "vitest": "^4.0.16"
   },
   "peerDependencies": {
-    "eslint": ">= 8.57.1",
-    "prettier": ">= 3.0.0"
-  },
-  "peerDependenciesMeta": {
-    "prettier": {
-      "optional": true
-    }
+    "eslint": ">= 8.57.1"
   },
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,13 @@
     "vitest": "^4.0.16"
   },
   "peerDependencies": {
-    "eslint": ">= 8.57.1"
+    "eslint": ">= 8.57.1",
+    "prettier": ">= 3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "prettier": {
+      "optional": true
+    }
   },
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-doc-generator",
-  "version": "3.7.0-beta.0",
+  "version": "3.6.0",
   "description": "Automatic documentation generator for ESLint plugins and rules.",
   "keywords": [
     "doc",

--- a/test/lib/frontmatter-test.ts
+++ b/test/lib/frontmatter-test.ts
@@ -4,10 +4,6 @@ import { getContext, type Context } from '../../lib/context.js';
 
 const cwd = process.cwd();
 
-function normalize(context: Context, markdown: string) {
-  return markdown.split('\n').join(context.endOfLine);
-}
-
 const name = 'no-foo';
 const description = 'Description for no-foo.';
 
@@ -27,15 +23,12 @@ describe('frontmatter', function () {
       });
 
       it('should return old frontmatter if it exists', function () {
-        const frontmatter = normalize(
-          context,
-          outdent`
-            ---
-            title: no-foo
-            description: Description for no-foo.
-            ---
-          `,
-        );
+        const frontmatter = outdent`
+          ---
+          title: no-foo
+          description: Description for no-foo.
+          ---
+        `;
         expect(
           generateFrontmatterLines(context, name, description, frontmatter),
         ).toBe(frontmatter);
@@ -48,135 +41,108 @@ describe('frontmatter', function () {
       });
 
       it('should create new frontmatter if no old frontmatter existed', function () {
-        const expected = normalize(
-          context,
-          outdent`
-            ---
-            title: "eslint-doc-generator/no-foo"
-            description: "Description for no-foo."
-            ---
-          `,
-        );
+        const expected = outdent`
+          ---
+          title: "eslint-doc-generator/no-foo"
+          description: "Description for no-foo."
+          ---
+        `;
         expect(
           generateFrontmatterLines(context, name, description, undefined),
         ).toBe(expected);
       });
 
       it('should add title and description to old frontmatter', function () {
-        const oldFrontmatter = normalize(
-          context,
-          outdent`
-            ---
-            tableOfContents:
-              minHeadingLevel: 2
-              maxHeadingLevel: 2
-            ---
-          `,
-        );
+        const oldFrontmatter = outdent`
+          ---
+          tableOfContents:
+            minHeadingLevel: 2
+            maxHeadingLevel: 2
+          ---
+        `;
 
-        const expected = normalize(
-          context,
-          outdent`
-            ---
-            title: "eslint-doc-generator/no-foo"
-            description: "Description for no-foo."
-            tableOfContents:
-              minHeadingLevel: 2
-              maxHeadingLevel: 2
-            ---
-          `,
-        );
+        const expected = outdent`
+          ---
+          title: "eslint-doc-generator/no-foo"
+          description: "Description for no-foo."
+          tableOfContents:
+            minHeadingLevel: 2
+            maxHeadingLevel: 2
+          ---
+        `;
         expect(
           generateFrontmatterLines(context, name, description, oldFrontmatter),
         ).toBe(expected);
       });
 
       it('should add title to old frontmatter and replace description', function () {
-        const oldFrontmatter = normalize(
-          context,
-          outdent`
-            ---
-            tableOfContents:
-              minHeadingLevel: 2
-              maxHeadingLevel: 2
-            description: "Description for no-bar."
-            ---
-          `,
-        );
+        const oldFrontmatter = outdent`
+          ---
+          tableOfContents:
+            minHeadingLevel: 2
+            maxHeadingLevel: 2
+          description: "Description for no-bar."
+          ---
+        `;
 
-        const expected = normalize(
-          context,
-          outdent`
-            ---
-            title: "eslint-doc-generator/no-foo"
-            tableOfContents:
-              minHeadingLevel: 2
-              maxHeadingLevel: 2
-            description: "Description for no-foo."
-            ---
-          `,
-        );
+        const expected = outdent`
+          ---
+          title: "eslint-doc-generator/no-foo"
+          tableOfContents:
+            minHeadingLevel: 2
+            maxHeadingLevel: 2
+          description: "Description for no-foo."
+          ---
+        `;
         expect(
           generateFrontmatterLines(context, name, description, oldFrontmatter),
         ).toBe(expected);
       });
 
       it('should add description to old frontmatter and replace title', function () {
-        const oldFrontmatter = normalize(
-          context,
-          outdent`
-            ---
-            tableOfContents:
-              minHeadingLevel: 2
-              maxHeadingLevel: 2
-            title: "eslint-doc-generator/no-bar"
-            ---
-          `,
-        );
+        const oldFrontmatter = outdent`
+          ---
+          tableOfContents:
+            minHeadingLevel: 2
+            maxHeadingLevel: 2
+          title: "eslint-doc-generator/no-bar"
+          ---
+        `;
 
-        const expected = normalize(
-          context,
-          outdent`
-            ---
-            tableOfContents:
-              minHeadingLevel: 2
-              maxHeadingLevel: 2
-            title: "eslint-doc-generator/no-foo"
-            description: "Description for no-foo."
-            ---
-          `,
-        );
+        const expected = outdent`
+          ---
+          tableOfContents:
+            minHeadingLevel: 2
+            maxHeadingLevel: 2
+          title: "eslint-doc-generator/no-foo"
+          description: "Description for no-foo."
+          ---
+        `;
         expect(
           generateFrontmatterLines(context, name, description, oldFrontmatter),
         ).toBe(expected);
       });
 
       it('should should replace title and description in old frontmatter', function () {
-        const oldFrontmatter = normalize(
-          context,
-          outdent`
-            ---
-            tableOfContents:
-              minHeadingLevel: 2
-              maxHeadingLevel: 2
-            title: "eslint-doc-generator/no-bar"
-            description: "Description for no-bar."
-            ---
-          `,
-        );
+        const oldFrontmatter = outdent`
+          ---
+          tableOfContents:
+            minHeadingLevel: 2
+            maxHeadingLevel: 2
+          title: "eslint-doc-generator/no-bar"
+          description: "Description for no-bar."
+          ---
+        `;
 
-        const expected = normalize(
-          context,
-          outdent`
-            ---
-            tableOfContents:
-              minHeadingLevel: 2
-              maxHeadingLevel: 2
-            title: "eslint-doc-generator/no-foo"
-            description: "Description for no-foo."
-            ---
-          `,
-        );
+        const expected = outdent`
+          ---
+          tableOfContents:
+            minHeadingLevel: 2
+            maxHeadingLevel: 2
+          title: "eslint-doc-generator/no-foo"
+          description: "Description for no-foo."
+          ---
+        `;
         expect(
           generateFrontmatterLines(context, name, description, oldFrontmatter),
         ).toBe(expected);
@@ -185,31 +151,25 @@ describe('frontmatter', function () {
       it('should properly escape values', function () {
         const descriptionSpecial = 'Description of my "special" rule.';
 
-        const oldFrontmatter = normalize(
-          context,
-          outdent`
-            ---
-            tableOfContents:
-              minHeadingLevel: 2
-              maxHeadingLevel: 2
-            title: "eslint-doc-generator/no-bar"
-            description: "Description for no-bar."
-            ---
-          `,
-        );
+        const oldFrontmatter = outdent`
+          ---
+          tableOfContents:
+            minHeadingLevel: 2
+            maxHeadingLevel: 2
+          title: "eslint-doc-generator/no-bar"
+          description: "Description for no-bar."
+          ---
+        `;
 
-        const expected = normalize(
-          context,
-          outdent`
-            ---
-            tableOfContents:
-              minHeadingLevel: 2
-              maxHeadingLevel: 2
-            title: "eslint-doc-generator/no-foo"
-            description: "Description of my \\"special\\" rule."
-            ---
-          `,
-        );
+        const expected = outdent`
+          ---
+          tableOfContents:
+            minHeadingLevel: 2
+            maxHeadingLevel: 2
+          title: "eslint-doc-generator/no-foo"
+          description: "Description of my \\"special\\" rule."
+          ---
+        `;
         expect(
           generateFrontmatterLines(
             context,

--- a/test/lib/generate/__snapshots__/eol-test.ts.snap
+++ b/test/lib/generate/__snapshots__/eol-test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`getEndOfLine > with a ".editorconfig" file > generates using the correct end of line when ".editorconfig" exists > generates using crlf end of line from ".editorconfig" 1`] = `
+exports[`generate with end of line > with a ".editorconfig" file > generates using crlf end of line from ".editorconfig" 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->
 
@@ -18,7 +18,7 @@ exports[`getEndOfLine > with a ".editorconfig" file > generates using the correc
 <!-- end auto-generated rules list -->"
 `;
 
-exports[`getEndOfLine > with a ".editorconfig" file > generates using the correct end of line when ".editorconfig" exists > generates using crlf end of line from ".editorconfig" 2`] = `
+exports[`generate with end of line > with a ".editorconfig" file > generates using crlf end of line from ".editorconfig" 2`] = `
 "# test/a
 
 💼 This rule is enabled in the following configs: 🅰️ \`a\`, 🅱️ \`B\`, 🌊 \`c\`.
@@ -27,21 +27,21 @@ exports[`getEndOfLine > with a ".editorconfig" file > generates using the correc
 "
 `;
 
-exports[`getEndOfLine > with a ".editorconfig" file > generates using the correct end of line when ".editorconfig" exists > generates using crlf end of line from ".editorconfig" 3`] = `
+exports[`generate with end of line > with a ".editorconfig" file > generates using crlf end of line from ".editorconfig" 3`] = `
 "# test/B
 
 <!-- end auto-generated rule header -->
 "
 `;
 
-exports[`getEndOfLine > with a ".editorconfig" file > generates using the correct end of line when ".editorconfig" exists > generates using crlf end of line from ".editorconfig" 4`] = `
+exports[`generate with end of line > with a ".editorconfig" file > generates using crlf end of line from ".editorconfig" 4`] = `
 "# test/c
 
 <!-- end auto-generated rule header -->
 "
 `;
 
-exports[`getEndOfLine > with a ".editorconfig" file > generates using the correct end of line when ".editorconfig" exists > generates using lf end of line from ".editorconfig" 1`] = `
+exports[`generate with end of line > with a ".editorconfig" file > generates using lf end of line from ".editorconfig" 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->
 
@@ -59,7 +59,7 @@ exports[`getEndOfLine > with a ".editorconfig" file > generates using the correc
 <!-- end auto-generated rules list -->"
 `;
 
-exports[`getEndOfLine > with a ".editorconfig" file > generates using the correct end of line when ".editorconfig" exists > generates using lf end of line from ".editorconfig" 2`] = `
+exports[`generate with end of line > with a ".editorconfig" file > generates using lf end of line from ".editorconfig" 2`] = `
 "# test/a
 
 💼 This rule is enabled in the following configs: 🅰️ \`a\`, 🅱️ \`B\`, 🌊 \`c\`.
@@ -68,21 +68,21 @@ exports[`getEndOfLine > with a ".editorconfig" file > generates using the correc
 "
 `;
 
-exports[`getEndOfLine > with a ".editorconfig" file > generates using the correct end of line when ".editorconfig" exists > generates using lf end of line from ".editorconfig" 3`] = `
+exports[`generate with end of line > with a ".editorconfig" file > generates using lf end of line from ".editorconfig" 3`] = `
 "# test/B
 
 <!-- end auto-generated rule header -->
 "
 `;
 
-exports[`getEndOfLine > with a ".editorconfig" file > generates using the correct end of line when ".editorconfig" exists > generates using lf end of line from ".editorconfig" 4`] = `
+exports[`generate with end of line > with a ".editorconfig" file > generates using lf end of line from ".editorconfig" 4`] = `
 "# test/c
 
 <!-- end auto-generated rule header -->
 "
 `;
 
-exports[`getEndOfLine > with a ".editorconfig" file > generates using the correct end of line when ".editorconfig" exists > generates using the end of line from ".editorconfig" while respecting the .md specific end of line setting 1`] = `
+exports[`generate with end of line > with a ".editorconfig" file > generates using the end of line from ".editorconfig" while respecting the .md specific end of line setting 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->
 
@@ -100,7 +100,7 @@ exports[`getEndOfLine > with a ".editorconfig" file > generates using the correc
 <!-- end auto-generated rules list -->"
 `;
 
-exports[`getEndOfLine > with a ".editorconfig" file > generates using the correct end of line when ".editorconfig" exists > generates using the end of line from ".editorconfig" while respecting the .md specific end of line setting 2`] = `
+exports[`generate with end of line > with a ".editorconfig" file > generates using the end of line from ".editorconfig" while respecting the .md specific end of line setting 2`] = `
 "# test/a
 
 💼 This rule is enabled in the following configs: 🅰️ \`a\`, 🅱️ \`B\`, 🌊 \`c\`.
@@ -109,14 +109,14 @@ exports[`getEndOfLine > with a ".editorconfig" file > generates using the correc
 "
 `;
 
-exports[`getEndOfLine > with a ".editorconfig" file > generates using the correct end of line when ".editorconfig" exists > generates using the end of line from ".editorconfig" while respecting the .md specific end of line setting 3`] = `
+exports[`generate with end of line > with a ".editorconfig" file > generates using the end of line from ".editorconfig" while respecting the .md specific end of line setting 3`] = `
 "# test/B
 
 <!-- end auto-generated rule header -->
 "
 `;
 
-exports[`getEndOfLine > with a ".editorconfig" file > generates using the correct end of line when ".editorconfig" exists > generates using the end of line from ".editorconfig" while respecting the .md specific end of line setting 4`] = `
+exports[`generate with end of line > with a ".editorconfig" file > generates using the end of line from ".editorconfig" while respecting the .md specific end of line setting 4`] = `
 "# test/c
 
 <!-- end auto-generated rule header -->

--- a/test/lib/generate/eol-test.ts
+++ b/test/lib/generate/eol-test.ts
@@ -1,7 +1,42 @@
 import { generate } from '../../../lib/generator.js';
-import { getEndOfLine } from '../../../lib/eol.js';
+import {
+  detectEndOfLine,
+  getEndOfLine,
+  normalizeEndOfLine,
+} from '../../../lib/eol.js';
 import { EOL } from 'node:os';
 import { setupFixture, type FixtureContext } from '../../helpers/fixture.js';
+
+describe('detectEndOfLine', function () {
+  it('returns undefined for contents without line breaks', function () {
+    expect(detectEndOfLine('')).toBeUndefined();
+    expect(detectEndOfLine('no line breaks')).toBeUndefined();
+  });
+
+  it('detects lf', function () {
+    expect(detectEndOfLine('a\nb\nc\n')).toStrictEqual('\n');
+  });
+
+  it('detects crlf', function () {
+    expect(detectEndOfLine('a\r\nb\r\nc\r\n')).toStrictEqual('\r\n');
+  });
+
+  it('detects the predominant end of line in contents with mixed line endings', function () {
+    expect(detectEndOfLine('a\r\nb\r\nc\n')).toStrictEqual('\r\n');
+    expect(detectEndOfLine('a\nb\nc\r\n')).toStrictEqual('\n');
+  });
+});
+
+describe('normalizeEndOfLine', function () {
+  it('converts mixed line endings to the given end of line', function () {
+    expect(normalizeEndOfLine('a\r\nb\nc\r\n', '\n')).toStrictEqual(
+      'a\nb\nc\n',
+    );
+    expect(normalizeEndOfLine('a\r\nb\nc\r\n', '\r\n')).toStrictEqual(
+      'a\r\nb\r\nc\r\n',
+    );
+  });
+});
 
 describe('getEndOfLine', function () {
   describe('with a ".editorconfig" file', function () {
@@ -72,8 +107,14 @@ describe('getEndOfLine', function () {
 
     describe('generates using the correct end of line when ".editorconfig" exists', function () {
       let fixture: FixtureContext;
+      let originalCwd: string;
+
+      beforeEach(function () {
+        originalCwd = process.cwd();
+      });
 
       afterEach(async function () {
+        process.chdir(originalCwd);
         await fixture.cleanup();
       });
 
@@ -106,6 +147,7 @@ describe('getEndOfLine', function () {
                   end_of_line = lf`,
           },
         });
+        process.chdir(fixture.path);
 
         await generate(fixture.path, {
           configEmoji: [
@@ -114,6 +156,10 @@ describe('getEndOfLine', function () {
             ['c', '🌊'],
           ],
         });
+        // Explicit line ending assertions since snapshots normalize CRLF to LF.
+        expect(await fixture.readFile('README.md')).not.toContain('\r');
+        expect(await fixture.readFile('docs/rules/a.md')).not.toContain('\r');
+
         expect(await fixture.readFile('README.md')).toMatchSnapshot();
         expect(await fixture.readFile('docs/rules/a.md')).toMatchSnapshot();
         expect(await fixture.readFile('docs/rules/B.md')).toMatchSnapshot();
@@ -149,6 +195,7 @@ describe('getEndOfLine', function () {
                   end_of_line = crlf`,
           },
         });
+        process.chdir(fixture.path);
 
         await generate(fixture.path, {
           configEmoji: [
@@ -157,6 +204,15 @@ describe('getEndOfLine', function () {
             ['c', '🌊'],
           ],
         });
+        // Explicit line ending assertions since snapshots normalize CRLF to LF.
+        // The README already used CRLF, and the empty rule docs use CRLF from the config.
+        const readme = await fixture.readFile('README.md');
+        expect(readme).toContain('\r\n');
+        expect(readme.replaceAll('\r\n', '')).not.toContain('\n');
+        const docA = await fixture.readFile('docs/rules/a.md');
+        expect(docA).toContain('\r\n');
+        expect(docA.replaceAll('\r\n', '')).not.toContain('\n');
+
         expect(await fixture.readFile('README.md')).toMatchSnapshot();
         expect(await fixture.readFile('docs/rules/a.md')).toMatchSnapshot();
         expect(await fixture.readFile('docs/rules/B.md')).toMatchSnapshot();
@@ -195,6 +251,7 @@ describe('getEndOfLine', function () {
                   end_of_line = crlf`,
           },
         });
+        process.chdir(fixture.path);
 
         await generate(fixture.path, {
           configEmoji: [
@@ -203,6 +260,15 @@ describe('getEndOfLine', function () {
             ['c', '🌊'],
           ],
         });
+        // Explicit line ending assertions since snapshots normalize CRLF to LF.
+        // The README already used CRLF, and the empty rule docs use CRLF from the `*.md` config.
+        const readme = await fixture.readFile('README.md');
+        expect(readme).toContain('\r\n');
+        expect(readme.replaceAll('\r\n', '')).not.toContain('\n');
+        const docA = await fixture.readFile('docs/rules/a.md');
+        expect(docA).toContain('\r\n');
+        expect(docA.replaceAll('\r\n', '')).not.toContain('\n');
+
         expect(await fixture.readFile('README.md')).toMatchSnapshot();
         expect(await fixture.readFile('docs/rules/a.md')).toMatchSnapshot();
         expect(await fixture.readFile('docs/rules/B.md')).toMatchSnapshot();
@@ -269,6 +335,123 @@ describe('getEndOfLine', function () {
       process.chdir(fixture.path);
 
       expect(await getEndOfLine()).toStrictEqual('\n');
+    });
+  });
+
+  describe('end-of-line detection from existing files', function () {
+    let fixture: FixtureContext;
+    let originalCwd: string;
+
+    beforeEach(function () {
+      originalCwd = process.cwd();
+    });
+
+    afterEach(async function () {
+      process.chdir(originalCwd);
+      await fixture.cleanup();
+    });
+
+    it('preserves content after the rule header marker when the rule doc uses different line endings than the configured end of line (#725)', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          // Rule doc uses LF line endings.
+          'docs/rules/no-foo.md':
+            '# Description of no-foo (`test/no-foo`)\n\n<!-- end auto-generated rule header -->\n\nSome description.\n\n## Further Reading\n\n- [link](https://example.com/)\n',
+          'README.md':
+            '## Rules\n\n<!-- begin auto-generated rules list -->\n<!-- end auto-generated rules list -->\n',
+          // But the configured end of line is CRLF (same situation as the `os.EOL` fallback on Windows).
+          '.editorconfig': `
+                root = true
+
+                [*]
+                end_of_line = crlf`,
+        },
+      });
+      process.chdir(fixture.path);
+
+      await generate(fixture.path);
+
+      const ruleDoc = await fixture.readFile('docs/rules/no-foo.md');
+      expect(ruleDoc).toContain('## Further Reading');
+      expect(ruleDoc).not.toContain('\r'); // Keeps its existing LF line endings.
+    });
+
+    it('inserts the rules list using the line endings of the existing file (#726)', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'docs/rules/no-foo.md': '',
+          // README uses CRLF line endings but the configured end of line is LF.
+          'README.md':
+            '## Rules\r\n\r\n<!-- begin auto-generated rules list -->\r\n<!-- end auto-generated rules list -->\r\n',
+          '.editorconfig': `
+                root = true
+
+                [*]
+                end_of_line = lf`,
+        },
+      });
+      process.chdir(fixture.path);
+
+      await generate(fixture.path);
+
+      const readme = await fixture.readFile('README.md');
+      expect(readme).toContain('\r\n');
+      // No mixed line endings: every LF should be part of a CRLF.
+      expect(readme.replaceAll('\r\n', '')).not.toContain('\n');
+    });
+
+    it('unifies mixed line endings to the predominant one in the file', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'docs/rules/no-foo.md': '',
+          // README has mostly-CRLF but mixed line endings (as could be produced by older versions of this tool).
+          'README.md':
+            '# eslint-plugin-test\n\r\n## Rules\r\n\r\n<!-- begin auto-generated rules list -->\r\n<!-- end auto-generated rules list -->\r\n',
+          '.editorconfig': `
+                root = true
+
+                [*]
+                end_of_line = lf`,
+        },
+      });
+      process.chdir(fixture.path);
+
+      await generate(fixture.path);
+
+      const readme = await fixture.readFile('README.md');
+      expect(readme).toContain('\r\n');
+      // No mixed line endings: every LF should be part of a CRLF.
+      expect(readme.replaceAll('\r\n', '')).not.toContain('\n');
+    });
+
+    it('passes in --check mode when up-to-date files use different line endings than the configured end of line', async function () {
+      const ruleDocCrlf =
+        '# Description of no-foo (`test/no-foo`)\r\n\r\n<!-- end auto-generated rule header -->\r\n\r\nSome description.\r\n';
+      const readmeCrlf =
+        '## Rules\r\n\r\n<!-- begin auto-generated rules list -->\r\n<!-- end auto-generated rules list -->\r\n';
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'docs/rules/no-foo.md': ruleDocCrlf,
+          'README.md': readmeCrlf,
+          '.editorconfig': `
+                root = true
+
+                [*]
+                end_of_line = lf`,
+        },
+      });
+      process.chdir(fixture.path);
+
+      // First, bring the CRLF docs up-to-date.
+      await generate(fixture.path);
+
+      // Then, --check should pass since nothing needs to change.
+      await generate(fixture.path, { check: true });
+      expect(process.exitCode).toBeUndefined();
     });
   });
 

--- a/test/lib/generate/eol-test.ts
+++ b/test/lib/generate/eol-test.ts
@@ -1,7 +1,7 @@
 import { generate } from '../../../lib/generator.js';
 import {
+  createEndOfLineResolver,
   detectEndOfLine,
-  getConfiguredEndOfLine,
   getFallbackEndOfLine,
   normalizeEndOfLine,
 } from '../../../lib/eol.js';
@@ -57,7 +57,7 @@ describe('normalizeEndOfLine', function () {
   });
 });
 
-describe('getConfiguredEndOfLine', function () {
+describe('createEndOfLineResolver', function () {
   describe('with a ".editorconfig" file', function () {
     let fixture: FixtureContext;
 
@@ -77,9 +77,13 @@ describe('getConfiguredEndOfLine', function () {
         },
       });
 
+      const eol = createEndOfLineResolver();
       expect(
-        await getConfiguredEndOfLine(join(fixture.path, 'README.md')),
+        await eol.getExplicitEndOfLine(join(fixture.path, 'README.md')),
       ).toStrictEqual('\n');
+      expect(
+        await eol.getImplicitEndOfLine(join(fixture.path, 'README.md')),
+      ).toBeUndefined();
     });
 
     it('returns crlf when ".editorconfig" is configured with crlf', async function () {
@@ -94,8 +98,9 @@ describe('getConfiguredEndOfLine', function () {
         },
       });
 
+      const eol = createEndOfLineResolver();
       expect(
-        await getConfiguredEndOfLine(join(fixture.path, 'README.md')),
+        await eol.getExplicitEndOfLine(join(fixture.path, 'README.md')),
       ).toStrictEqual('\r\n');
     });
 
@@ -114,8 +119,9 @@ describe('getConfiguredEndOfLine', function () {
         },
       });
 
+      const eol = createEndOfLineResolver();
       expect(
-        await getConfiguredEndOfLine(join(fixture.path, 'README.md')),
+        await eol.getExplicitEndOfLine(join(fixture.path, 'README.md')),
       ).toStrictEqual('\r\n');
     });
 
@@ -134,12 +140,41 @@ describe('getConfiguredEndOfLine', function () {
         },
       });
 
+      const eol = createEndOfLineResolver();
       expect(
-        await getConfiguredEndOfLine(join(fixture.path, 'README.md')),
+        await eol.getExplicitEndOfLine(join(fixture.path, 'README.md')),
       ).toStrictEqual('\n');
       expect(
-        await getConfiguredEndOfLine(
+        await eol.getExplicitEndOfLine(
           join(fixture.path, 'docs/rules/no-foo.md'),
+        ),
+      ).toStrictEqual('\r\n');
+    });
+
+    it('resolves sibling .md and .mdx files independently (cache keyed by path)', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          '.editorconfig': `
+                  root = true
+
+                  [*.md]
+                  end_of_line = lf
+
+                  [*.mdx]
+                  end_of_line = crlf`,
+        },
+      });
+
+      const eol = createEndOfLineResolver();
+      expect(
+        await eol.getExplicitEndOfLine(
+          join(fixture.path, 'docs/rules/no-foo.md'),
+        ),
+      ).toStrictEqual('\n');
+      expect(
+        await eol.getExplicitEndOfLine(
+          join(fixture.path, 'docs/rules/no-bar.mdx'),
         ),
       ).toStrictEqual('\r\n');
     });
@@ -152,7 +187,28 @@ describe('getConfiguredEndOfLine', function () {
       await fixture.cleanup();
     });
 
-    it('ignores Prettier config even when endOfLine is set (use postprocess to run Prettier)', async function () {
+    it('returns lf when ".prettierrc.json" is configured with lf', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          '.prettierrc.json': `
+                  {
+                    "$schema": "https://json.schemastore.org/prettierrc",
+                    "endOfLine": "lf"
+                  }`,
+        },
+      });
+
+      const eol = createEndOfLineResolver();
+      expect(
+        await eol.getExplicitEndOfLine(join(fixture.path, 'README.md')),
+      ).toStrictEqual('\n');
+      expect(
+        await eol.getImplicitEndOfLine(join(fixture.path, 'README.md')),
+      ).toBeUndefined();
+    });
+
+    it('returns crlf when ".prettierrc.json" is configured with crlf', async function () {
       fixture = await setupFixture({
         fixture: 'esm-base',
         overrides: {
@@ -164,9 +220,51 @@ describe('getConfiguredEndOfLine', function () {
         },
       });
 
+      const eol = createEndOfLineResolver();
       expect(
-        await getConfiguredEndOfLine(join(fixture.path, 'README.md')),
+        await eol.getExplicitEndOfLine(join(fixture.path, 'README.md')),
+      ).toStrictEqual('\r\n');
+    });
+
+    it('treats Prettier config without endOfLine as implicit LF (#803)', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          '.prettierrc.json': `
+                  {
+                    "$schema": "https://json.schemastore.org/prettierrc"
+                  }`,
+        },
+      });
+
+      const eol = createEndOfLineResolver();
+      expect(
+        await eol.getExplicitEndOfLine(join(fixture.path, 'README.md')),
       ).toBeUndefined();
+      expect(
+        await eol.getImplicitEndOfLine(join(fixture.path, 'README.md')),
+      ).toStrictEqual('\n');
+    });
+
+    it('treats Prettier endOfLine auto as implicit LF (falls through explicit tier)', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          '.prettierrc.json': `
+                  {
+                    "$schema": "https://json.schemastore.org/prettierrc",
+                    "endOfLine": "auto"
+                  }`,
+        },
+      });
+
+      const eol = createEndOfLineResolver();
+      expect(
+        await eol.getExplicitEndOfLine(join(fixture.path, 'README.md')),
+      ).toBeUndefined();
+      expect(
+        await eol.getImplicitEndOfLine(join(fixture.path, 'README.md')),
+      ).toStrictEqual('\n');
     });
   });
 
@@ -182,8 +280,12 @@ describe('getConfiguredEndOfLine', function () {
         fixture: 'esm-base',
       });
 
+      const eol = createEndOfLineResolver();
       expect(
-        await getConfiguredEndOfLine(join(fixture.path, 'README.md')),
+        await eol.getExplicitEndOfLine(join(fixture.path, 'README.md')),
+      ).toBeUndefined();
+      expect(
+        await eol.getImplicitEndOfLine(join(fixture.path, 'README.md')),
       ).toBeUndefined();
       expect(getFallbackEndOfLine()).toStrictEqual(EOL);
     });
@@ -366,6 +468,46 @@ describe('generate with end of line', function () {
         '\r\n',
       );
     });
+
+    // eslint-disable-next-line vitest/expect-expect -- assertions via assertUniformEndOfLine
+    it('writes sibling .md and .mdx docs with their own editorconfig end_of_line', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'index.js': `
+          export default {
+            rules: {
+              'no-foo': { meta: { docs: { description: 'Description of no-foo.' } }, create(context) {} },
+              'no-bar': { meta: { docs: { description: 'Description of no-bar.' } }, create(context) {} },
+            },
+          };`,
+          'docs/rules/no-foo.md': '',
+          // Only the .mdx file exists; resolveDocPath falls back from .md → .mdx.
+          'docs/rules/no-bar.mdx': '',
+          'README.md':
+            '## Rules\n\n<!-- begin auto-generated rules list -->\n<!-- end auto-generated rules list -->\n',
+          '.editorconfig': `
+                  root = true
+
+                  [*.md]
+                  end_of_line = lf
+
+                  [*.mdx]
+                  end_of_line = crlf`,
+        },
+      });
+
+      await generate(fixture.path);
+
+      assertUniformEndOfLine(
+        await fixture.readFile('docs/rules/no-foo.md'),
+        '\n',
+      );
+      assertUniformEndOfLine(
+        await fixture.readFile('docs/rules/no-bar.mdx'),
+        '\r\n',
+      );
+    });
   });
 
   describe('explicit config precedence', function () {
@@ -424,7 +566,32 @@ describe('generate with end of line', function () {
     });
 
     // eslint-disable-next-line vitest/expect-expect -- assertions via assertUniformEndOfLine
-    it('preserves file endings when Prettier sets endOfLine (Prettier is not consulted for EOL)', async function () {
+    it('converts an LF file to CRLF when prettier explicitly sets endOfLine: crlf', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'docs/rules/no-foo.md': '',
+          'README.md':
+            '## Rules\n\n<!-- begin auto-generated rules list -->\n<!-- end auto-generated rules list -->\n',
+          '.prettierrc.json': `
+                  {
+                    "$schema": "https://json.schemastore.org/prettierrc",
+                    "endOfLine": "crlf"
+                  }`,
+        },
+      });
+
+      await generate(fixture.path);
+
+      assertUniformEndOfLine(await fixture.readFile('README.md'), '\r\n');
+      assertUniformEndOfLine(
+        await fixture.readFile('docs/rules/no-foo.md'),
+        '\r\n',
+      );
+    });
+
+    // eslint-disable-next-line vitest/expect-expect -- assertions via assertUniformEndOfLine
+    it('preserves CRLF when prettier config exists but does not set endOfLine (eslint-plugin-cypress / #726)', async function () {
       fixture = await setupFixture({
         fixture: 'esm-base',
         overrides: {
@@ -433,8 +600,7 @@ describe('generate with end of line', function () {
             '## Rules\r\n\r\n<!-- begin auto-generated rules list -->\r\n<!-- end auto-generated rules list -->\r\n',
           '.prettierrc.json': `
                   {
-                    "$schema": "https://json.schemastore.org/prettierrc",
-                    "endOfLine": "lf"
+                    "$schema": "https://json.schemastore.org/prettierrc"
                   }`,
         },
       });
@@ -445,7 +611,30 @@ describe('generate with end of line', function () {
     });
 
     // eslint-disable-next-line vitest/expect-expect -- assertions via assertUniformEndOfLine
-    it('preserves CRLF when prettier config exists but does not set endOfLine (eslint-plugin-cypress case)', async function () {
+    it('uses implicit LF for new/empty docs when prettier config has no endOfLine (#803)', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'docs/rules/no-foo.md': '',
+          'README.md':
+            '## Rules\n\n<!-- begin auto-generated rules list -->\n<!-- end auto-generated rules list -->\n',
+          '.prettierrc.json': `
+                  {
+                    "$schema": "https://json.schemastore.org/prettierrc"
+                  }`,
+        },
+      });
+
+      await generate(fixture.path);
+
+      assertUniformEndOfLine(
+        await fixture.readFile('docs/rules/no-foo.md'),
+        '\n',
+      );
+    });
+
+    // eslint-disable-next-line vitest/expect-expect -- assertions via assertUniformEndOfLine
+    it('falls through prettier endOfLine auto to per-file detection', async function () {
       fixture = await setupFixture({
         fixture: 'esm-base',
         overrides: {
@@ -454,7 +643,8 @@ describe('generate with end of line', function () {
             '## Rules\r\n\r\n<!-- begin auto-generated rules list -->\r\n<!-- end auto-generated rules list -->\r\n',
           '.prettierrc.json': `
                   {
-                    "$schema": "https://json.schemastore.org/prettierrc"
+                    "$schema": "https://json.schemastore.org/prettierrc",
+                    "endOfLine": "auto"
                   }`,
         },
       });

--- a/test/lib/generate/eol-test.ts
+++ b/test/lib/generate/eol-test.ts
@@ -152,24 +152,7 @@ describe('getConfiguredEndOfLine', function () {
       await fixture.cleanup();
     });
 
-    it('returns lf when ".prettierrc.json" is configured with lf', async function () {
-      fixture = await setupFixture({
-        fixture: 'esm-base',
-        overrides: {
-          '.prettierrc.json': `
-                  {
-                    "$schema": "https://json.schemastore.org/prettierrc",
-                    "endOfLine": "lf"
-                  }`,
-        },
-      });
-
-      expect(
-        await getConfiguredEndOfLine(join(fixture.path, 'README.md')),
-      ).toStrictEqual('\n');
-    });
-
-    it('returns crlf when ".prettierrc.json" is configured with crlf', async function () {
+    it('ignores Prettier config even when endOfLine is set (use postprocess to run Prettier)', async function () {
       fixture = await setupFixture({
         fixture: 'esm-base',
         overrides: {
@@ -177,22 +160,6 @@ describe('getConfiguredEndOfLine', function () {
                   {
                     "$schema": "https://json.schemastore.org/prettierrc",
                     "endOfLine": "crlf"
-                  }`,
-        },
-      });
-
-      expect(
-        await getConfiguredEndOfLine(join(fixture.path, 'README.md')),
-      ).toStrictEqual('\r\n');
-    });
-
-    it('returns undefined when ".prettierrc.json" does not set "endOfLine"', async function () {
-      fixture = await setupFixture({
-        fixture: 'esm-base',
-        overrides: {
-          '.prettierrc.json': `
-                  {
-                    "$schema": "https://json.schemastore.org/prettierrc"
                   }`,
         },
       });
@@ -457,17 +424,17 @@ describe('generate with end of line', function () {
     });
 
     // eslint-disable-next-line vitest/expect-expect -- assertions via assertUniformEndOfLine
-    it('converts an LF file to CRLF when prettier explicitly sets endOfLine: crlf', async function () {
+    it('preserves file endings when Prettier sets endOfLine (Prettier is not consulted for EOL)', async function () {
       fixture = await setupFixture({
         fixture: 'esm-base',
         overrides: {
           'docs/rules/no-foo.md': '',
           'README.md':
-            '## Rules\n\n<!-- begin auto-generated rules list -->\n<!-- end auto-generated rules list -->\n',
+            '## Rules\r\n\r\n<!-- begin auto-generated rules list -->\r\n<!-- end auto-generated rules list -->\r\n',
           '.prettierrc.json': `
                   {
                     "$schema": "https://json.schemastore.org/prettierrc",
-                    "endOfLine": "crlf"
+                    "endOfLine": "lf"
                   }`,
         },
       });
@@ -475,10 +442,6 @@ describe('generate with end of line', function () {
       await generate(fixture.path);
 
       assertUniformEndOfLine(await fixture.readFile('README.md'), '\r\n');
-      assertUniformEndOfLine(
-        await fixture.readFile('docs/rules/no-foo.md'),
-        '\r\n',
-      );
     });
 
     // eslint-disable-next-line vitest/expect-expect -- assertions via assertUniformEndOfLine

--- a/test/lib/generate/eol-test.ts
+++ b/test/lib/generate/eol-test.ts
@@ -1,11 +1,23 @@
 import { generate } from '../../../lib/generator.js';
 import {
   detectEndOfLine,
-  getEndOfLine,
+  getConfiguredEndOfLine,
+  getFallbackEndOfLine,
   normalizeEndOfLine,
 } from '../../../lib/eol.js';
 import { EOL } from 'node:os';
+import { join } from 'node:path';
 import { setupFixture, type FixtureContext } from '../../helpers/fixture.js';
+
+function assertUniformEndOfLine(contents: string, endOfLine: '\n' | '\r\n') {
+  if (endOfLine === '\r\n') {
+    expect(contents.includes('\r\n')).toBe(true);
+    expect(contents.replaceAll('\r\n', '').includes('\n')).toBe(false);
+    expect(contents.replaceAll('\r\n', '').includes('\r')).toBe(false);
+  } else {
+    expect(contents.includes('\r')).toBe(false);
+  }
+}
 
 describe('detectEndOfLine', function () {
   it('returns undefined for contents without line breaks', function () {
@@ -36,212 +48,62 @@ describe('normalizeEndOfLine', function () {
       'a\r\nb\r\nc\r\n',
     );
   });
+
+  it('converts lone CR to the given end of line', function () {
+    expect(normalizeEndOfLine('a\rb\nc\r\n', '\n')).toStrictEqual('a\nb\nc\n');
+    expect(normalizeEndOfLine('a\rb\nc\r\n', '\r\n')).toStrictEqual(
+      'a\r\nb\r\nc\r\n',
+    );
+  });
 });
 
-describe('getEndOfLine', function () {
+describe('getConfiguredEndOfLine', function () {
   describe('with a ".editorconfig" file', function () {
-    describe('returns the correct end of line when ".editorconfig" exists', function () {
-      let fixture: FixtureContext;
-      let originalCwd: string;
+    let fixture: FixtureContext;
 
-      beforeEach(function () {
-        originalCwd = process.cwd();
-      });
+    afterEach(async function () {
+      await fixture.cleanup();
+    });
 
-      afterEach(async function () {
-        process.chdir(originalCwd);
-        await fixture.cleanup();
-      });
-
-      it('returns lf end of line when ".editorconfig" is configured with lf', async function () {
-        fixture = await setupFixture({
-          fixture: 'esm-base',
-          overrides: {
-            '.editorconfig': `
+    it('returns lf when ".editorconfig" is configured with lf', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          '.editorconfig': `
                   root = true
 
                   [*]
                   end_of_line = lf`,
-          },
-        });
-        process.chdir(fixture.path);
-
-        expect(await getEndOfLine()).toStrictEqual('\n');
+        },
       });
 
-      it('returns crlf end of line when ".editorconfig" is configured with crlf', async function () {
-        fixture = await setupFixture({
-          fixture: 'esm-base',
-          overrides: {
-            '.editorconfig': `
+      expect(
+        await getConfiguredEndOfLine(join(fixture.path, 'README.md')),
+      ).toStrictEqual('\n');
+    });
+
+    it('returns crlf when ".editorconfig" is configured with crlf', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          '.editorconfig': `
                 root = true
 
                 [*]
                 end_of_line = crlf`,
-          },
-        });
-        process.chdir(fixture.path);
-
-        expect(await getEndOfLine()).toStrictEqual('\r\n');
+        },
       });
 
-      it('respects the .md specific end of line settings when ".editorconfig" is configured', async function () {
-        fixture = await setupFixture({
-          fixture: 'esm-base',
-          overrides: {
-            '.editorconfig': `
-                  root = true
-
-                  [*]
-                  end_of_line = lf
-
-                  [*.md]
-                  end_of_line = crlf`,
-          },
-        });
-        process.chdir(fixture.path);
-
-        expect(await getEndOfLine()).toStrictEqual('\r\n');
-      });
+      expect(
+        await getConfiguredEndOfLine(join(fixture.path, 'README.md')),
+      ).toStrictEqual('\r\n');
     });
 
-    describe('generates using the correct end of line when ".editorconfig" exists', function () {
-      let fixture: FixtureContext;
-      let originalCwd: string;
-
-      beforeEach(function () {
-        originalCwd = process.cwd();
-      });
-
-      afterEach(async function () {
-        process.chdir(originalCwd);
-        await fixture.cleanup();
-      });
-
-      it('generates using lf end of line from ".editorconfig"', async function () {
-        fixture = await setupFixture({
-          fixture: 'esm-base',
-          overrides: {
-            'index.js': `
-          export default {
-            rules: {
-              'c': { meta: { docs: {} }, create(context) {} },
-              'a': { meta: { docs: {} }, create(context) {} },
-              'B': { meta: { docs: {} }, create(context) {} },
-            },
-            configs: {
-              'c': { rules: { 'test/a': 'error', } },
-              'a': { rules: { 'test/a': 'error', } },
-              'B': { rules: { 'test/a': 'error', } },
-            }
-          };`,
-            'docs/rules/a.md': '',
-            'docs/rules/B.md': '',
-            'docs/rules/c.md': '',
-            'README.md':
-              '## Rules\n<!-- begin auto-generated rules list -->\n<!-- end auto-generated rules list -->',
-            '.editorconfig': `
-                  root = true
-
-                  [*]
-                  end_of_line = lf`,
-          },
-        });
-        process.chdir(fixture.path);
-
-        await generate(fixture.path, {
-          configEmoji: [
-            ['a', '🅰️'],
-            ['B', '🅱️'],
-            ['c', '🌊'],
-          ],
-        });
-        // Explicit line ending assertions since snapshots normalize CRLF to LF.
-        expect(await fixture.readFile('README.md')).not.toContain('\r');
-        expect(await fixture.readFile('docs/rules/a.md')).not.toContain('\r');
-
-        expect(await fixture.readFile('README.md')).toMatchSnapshot();
-        expect(await fixture.readFile('docs/rules/a.md')).toMatchSnapshot();
-        expect(await fixture.readFile('docs/rules/B.md')).toMatchSnapshot();
-        expect(await fixture.readFile('docs/rules/c.md')).toMatchSnapshot();
-      });
-
-      it('generates using crlf end of line from ".editorconfig"', async function () {
-        fixture = await setupFixture({
-          fixture: 'esm-base',
-          overrides: {
-            'index.js': `
-          export default {
-            rules: {
-              'c': { meta: { docs: {} }, create(context) {} },
-              'a': { meta: { docs: {} }, create(context) {} },
-              'B': { meta: { docs: {} }, create(context) {} },
-            },
-            configs: {
-              'c': { rules: { 'test/a': 'error', } },
-              'a': { rules: { 'test/a': 'error', } },
-              'B': { rules: { 'test/a': 'error', } },
-            }
-          };`,
-            'docs/rules/a.md': '',
-            'docs/rules/B.md': '',
-            'docs/rules/c.md': '',
-            'README.md':
-              '## Rules\r\n<!-- begin auto-generated rules list -->\r\n<!-- end auto-generated rules list -->',
-            '.editorconfig': `
-                  root = true
-
-                  [*]
-                  end_of_line = crlf`,
-          },
-        });
-        process.chdir(fixture.path);
-
-        await generate(fixture.path, {
-          configEmoji: [
-            ['a', '🅰️'],
-            ['B', '🅱️'],
-            ['c', '🌊'],
-          ],
-        });
-        // Explicit line ending assertions since snapshots normalize CRLF to LF.
-        // The README already used CRLF, and the empty rule docs use CRLF from the config.
-        const readme = await fixture.readFile('README.md');
-        expect(readme).toContain('\r\n');
-        expect(readme.replaceAll('\r\n', '')).not.toContain('\n');
-        const docA = await fixture.readFile('docs/rules/a.md');
-        expect(docA).toContain('\r\n');
-        expect(docA.replaceAll('\r\n', '')).not.toContain('\n');
-
-        expect(await fixture.readFile('README.md')).toMatchSnapshot();
-        expect(await fixture.readFile('docs/rules/a.md')).toMatchSnapshot();
-        expect(await fixture.readFile('docs/rules/B.md')).toMatchSnapshot();
-        expect(await fixture.readFile('docs/rules/c.md')).toMatchSnapshot();
-      });
-
-      it('generates using the end of line from ".editorconfig" while respecting the .md specific end of line setting', async function () {
-        fixture = await setupFixture({
-          fixture: 'esm-base',
-          overrides: {
-            'index.js': `
-          export default {
-            rules: {
-              'c': { meta: { docs: {} }, create(context) {} },
-              'a': { meta: { docs: {} }, create(context) {} },
-              'B': { meta: { docs: {} }, create(context) {} },
-            },
-            configs: {
-              'c': { rules: { 'test/a': 'error', } },
-              'a': { rules: { 'test/a': 'error', } },
-              'B': { rules: { 'test/a': 'error', } },
-            }
-          };`,
-            'docs/rules/a.md': '',
-            'docs/rules/B.md': '',
-            'docs/rules/c.md': '',
-            'README.md':
-              '## Rules\r\n<!-- begin auto-generated rules list -->\r\n<!-- end auto-generated rules list -->',
-            '.editorconfig': `
+    it('respects the .md specific end of line settings when ".editorconfig" is configured', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          '.editorconfig': `
                   root = true
 
                   [*]
@@ -249,48 +111,48 @@ describe('getEndOfLine', function () {
 
                   [*.md]
                   end_of_line = crlf`,
-          },
-        });
-        process.chdir(fixture.path);
-
-        await generate(fixture.path, {
-          configEmoji: [
-            ['a', '🅰️'],
-            ['B', '🅱️'],
-            ['c', '🌊'],
-          ],
-        });
-        // Explicit line ending assertions since snapshots normalize CRLF to LF.
-        // The README already used CRLF, and the empty rule docs use CRLF from the `*.md` config.
-        const readme = await fixture.readFile('README.md');
-        expect(readme).toContain('\r\n');
-        expect(readme.replaceAll('\r\n', '')).not.toContain('\n');
-        const docA = await fixture.readFile('docs/rules/a.md');
-        expect(docA).toContain('\r\n');
-        expect(docA.replaceAll('\r\n', '')).not.toContain('\n');
-
-        expect(await fixture.readFile('README.md')).toMatchSnapshot();
-        expect(await fixture.readFile('docs/rules/a.md')).toMatchSnapshot();
-        expect(await fixture.readFile('docs/rules/B.md')).toMatchSnapshot();
-        expect(await fixture.readFile('docs/rules/c.md')).toMatchSnapshot();
+        },
       });
+
+      expect(
+        await getConfiguredEndOfLine(join(fixture.path, 'README.md')),
+      ).toStrictEqual('\r\n');
+    });
+
+    it('resolves per-file globs so README and rule docs can differ', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          '.editorconfig': `
+                  root = true
+
+                  [*]
+                  end_of_line = lf
+
+                  [docs/rules/*.md]
+                  end_of_line = crlf`,
+        },
+      });
+
+      expect(
+        await getConfiguredEndOfLine(join(fixture.path, 'README.md')),
+      ).toStrictEqual('\n');
+      expect(
+        await getConfiguredEndOfLine(
+          join(fixture.path, 'docs/rules/no-foo.md'),
+        ),
+      ).toStrictEqual('\r\n');
     });
   });
 
   describe('with a Prettier config', function () {
     let fixture: FixtureContext;
-    let originalCwd: string;
-
-    beforeEach(function () {
-      originalCwd = process.cwd();
-    });
 
     afterEach(async function () {
-      process.chdir(originalCwd);
       await fixture.cleanup();
     });
 
-    it('returns lf end of line when ".prettierrc.json" is configured with lf', async function () {
+    it('returns lf when ".prettierrc.json" is configured with lf', async function () {
       fixture = await setupFixture({
         fixture: 'esm-base',
         overrides: {
@@ -301,12 +163,13 @@ describe('getEndOfLine', function () {
                   }`,
         },
       });
-      process.chdir(fixture.path);
 
-      expect(await getEndOfLine()).toStrictEqual('\n');
+      expect(
+        await getConfiguredEndOfLine(join(fixture.path, 'README.md')),
+      ).toStrictEqual('\n');
     });
 
-    it('returns crlf end of line when ".prettierrc.json" is configured with crlf', async function () {
+    it('returns crlf when ".prettierrc.json" is configured with crlf', async function () {
       fixture = await setupFixture({
         fixture: 'esm-base',
         overrides: {
@@ -317,12 +180,13 @@ describe('getEndOfLine', function () {
                   }`,
         },
       });
-      process.chdir(fixture.path);
 
-      expect(await getEndOfLine()).toStrictEqual('\r\n');
+      expect(
+        await getConfiguredEndOfLine(join(fixture.path, 'README.md')),
+      ).toStrictEqual('\r\n');
     });
 
-    it('returns lf when ".prettierrc.json" is not configured with the "endOfLine" option', async function () {
+    it('returns undefined when ".prettierrc.json" does not set "endOfLine"', async function () {
       fixture = await setupFixture({
         fixture: 'esm-base',
         overrides: {
@@ -332,35 +196,226 @@ describe('getEndOfLine', function () {
                   }`,
         },
       });
-      process.chdir(fixture.path);
 
-      expect(await getEndOfLine()).toStrictEqual('\n');
+      expect(
+        await getConfiguredEndOfLine(join(fixture.path, 'README.md')),
+      ).toBeUndefined();
     });
   });
 
-  describe('end-of-line detection from existing files', function () {
+  describe('fallback', function () {
     let fixture: FixtureContext;
-    let originalCwd: string;
-
-    beforeEach(function () {
-      originalCwd = process.cwd();
-    });
 
     afterEach(async function () {
-      process.chdir(originalCwd);
       await fixture.cleanup();
     });
 
-    it('preserves content after the rule header marker when the rule doc uses different line endings than the configured end of line (#725)', async function () {
+    it('returns undefined when config files do not exist', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+      });
+
+      expect(
+        await getConfiguredEndOfLine(join(fixture.path, 'README.md')),
+      ).toBeUndefined();
+      expect(getFallbackEndOfLine()).toStrictEqual(EOL);
+    });
+  });
+});
+
+describe('generate with end of line', function () {
+  describe('with a ".editorconfig" file', function () {
+    let fixture: FixtureContext;
+
+    afterEach(async function () {
+      await fixture.cleanup();
+    });
+
+    it('generates using lf end of line from ".editorconfig"', async function () {
       fixture = await setupFixture({
         fixture: 'esm-base',
         overrides: {
-          // Rule doc uses LF line endings.
+          'index.js': `
+          export default {
+            rules: {
+              'c': { meta: { docs: {} }, create(context) {} },
+              'a': { meta: { docs: {} }, create(context) {} },
+              'B': { meta: { docs: {} }, create(context) {} },
+            },
+            configs: {
+              'c': { rules: { 'test/a': 'error', } },
+              'a': { rules: { 'test/a': 'error', } },
+              'B': { rules: { 'test/a': 'error', } },
+            }
+          };`,
+          'docs/rules/a.md': '',
+          'docs/rules/B.md': '',
+          'docs/rules/c.md': '',
+          'README.md':
+            '## Rules\n<!-- begin auto-generated rules list -->\n<!-- end auto-generated rules list -->',
+          '.editorconfig': `
+                  root = true
+
+                  [*]
+                  end_of_line = lf`,
+        },
+      });
+
+      await generate(fixture.path, {
+        configEmoji: [
+          ['a', '🅰️'],
+          ['B', '🅱️'],
+          ['c', '🌊'],
+        ],
+      });
+      assertUniformEndOfLine(await fixture.readFile('README.md'), '\n');
+      assertUniformEndOfLine(await fixture.readFile('docs/rules/a.md'), '\n');
+
+      expect(await fixture.readFile('README.md')).toMatchSnapshot();
+      expect(await fixture.readFile('docs/rules/a.md')).toMatchSnapshot();
+      expect(await fixture.readFile('docs/rules/B.md')).toMatchSnapshot();
+      expect(await fixture.readFile('docs/rules/c.md')).toMatchSnapshot();
+    });
+
+    it('generates using crlf end of line from ".editorconfig"', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'index.js': `
+          export default {
+            rules: {
+              'c': { meta: { docs: {} }, create(context) {} },
+              'a': { meta: { docs: {} }, create(context) {} },
+              'B': { meta: { docs: {} }, create(context) {} },
+            },
+            configs: {
+              'c': { rules: { 'test/a': 'error', } },
+              'a': { rules: { 'test/a': 'error', } },
+              'B': { rules: { 'test/a': 'error', } },
+            }
+          };`,
+          'docs/rules/a.md': '',
+          'docs/rules/B.md': '',
+          'docs/rules/c.md': '',
+          'README.md':
+            '## Rules\r\n<!-- begin auto-generated rules list -->\r\n<!-- end auto-generated rules list -->',
+          '.editorconfig': `
+                  root = true
+
+                  [*]
+                  end_of_line = crlf`,
+        },
+      });
+
+      await generate(fixture.path, {
+        configEmoji: [
+          ['a', '🅰️'],
+          ['B', '🅱️'],
+          ['c', '🌊'],
+        ],
+      });
+      assertUniformEndOfLine(await fixture.readFile('README.md'), '\r\n');
+      assertUniformEndOfLine(await fixture.readFile('docs/rules/a.md'), '\r\n');
+
+      expect(await fixture.readFile('README.md')).toMatchSnapshot();
+      expect(await fixture.readFile('docs/rules/a.md')).toMatchSnapshot();
+      expect(await fixture.readFile('docs/rules/B.md')).toMatchSnapshot();
+      expect(await fixture.readFile('docs/rules/c.md')).toMatchSnapshot();
+    });
+
+    it('generates using the end of line from ".editorconfig" while respecting the .md specific end of line setting', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'index.js': `
+          export default {
+            rules: {
+              'c': { meta: { docs: {} }, create(context) {} },
+              'a': { meta: { docs: {} }, create(context) {} },
+              'B': { meta: { docs: {} }, create(context) {} },
+            },
+            configs: {
+              'c': { rules: { 'test/a': 'error', } },
+              'a': { rules: { 'test/a': 'error', } },
+              'B': { rules: { 'test/a': 'error', } },
+            }
+          };`,
+          'docs/rules/a.md': '',
+          'docs/rules/B.md': '',
+          'docs/rules/c.md': '',
+          'README.md':
+            '## Rules\r\n<!-- begin auto-generated rules list -->\r\n<!-- end auto-generated rules list -->',
+          '.editorconfig': `
+                  root = true
+
+                  [*]
+                  end_of_line = lf
+
+                  [*.md]
+                  end_of_line = crlf`,
+        },
+      });
+
+      await generate(fixture.path, {
+        configEmoji: [
+          ['a', '🅰️'],
+          ['B', '🅱️'],
+          ['c', '🌊'],
+        ],
+      });
+      assertUniformEndOfLine(await fixture.readFile('README.md'), '\r\n');
+      assertUniformEndOfLine(await fixture.readFile('docs/rules/a.md'), '\r\n');
+
+      expect(await fixture.readFile('README.md')).toMatchSnapshot();
+      expect(await fixture.readFile('docs/rules/a.md')).toMatchSnapshot();
+      expect(await fixture.readFile('docs/rules/B.md')).toMatchSnapshot();
+      expect(await fixture.readFile('docs/rules/c.md')).toMatchSnapshot();
+    });
+
+    // eslint-disable-next-line vitest/expect-expect -- assertions via assertUniformEndOfLine
+    it('applies per-glob editorconfig end_of_line to README vs rule docs', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'docs/rules/no-foo.md': '',
+          'README.md':
+            '## Rules\r\n\r\n<!-- begin auto-generated rules list -->\r\n<!-- end auto-generated rules list -->\r\n',
+          '.editorconfig': `
+                  root = true
+
+                  [*]
+                  end_of_line = lf
+
+                  [docs/rules/*.md]
+                  end_of_line = crlf`,
+        },
+      });
+
+      await generate(fixture.path);
+
+      assertUniformEndOfLine(await fixture.readFile('README.md'), '\n');
+      assertUniformEndOfLine(
+        await fixture.readFile('docs/rules/no-foo.md'),
+        '\r\n',
+      );
+    });
+  });
+
+  describe('explicit config precedence', function () {
+    let fixture: FixtureContext;
+
+    afterEach(async function () {
+      await fixture.cleanup();
+    });
+
+    it('converts an LF rule doc to CRLF when editorconfig sets end_of_line = crlf, preserving content (#725)', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
           'docs/rules/no-foo.md':
             '# Description of no-foo (`test/no-foo`)\n\n<!-- end auto-generated rule header -->\n\nSome description.\n\n## Further Reading\n\n- [link](https://example.com/)\n',
           'README.md':
             '## Rules\n\n<!-- begin auto-generated rules list -->\n<!-- end auto-generated rules list -->\n',
-          // But the configured end of line is CRLF (same situation as the `os.EOL` fallback on Windows).
           '.editorconfig': `
                 root = true
 
@@ -368,21 +423,21 @@ describe('getEndOfLine', function () {
                 end_of_line = crlf`,
         },
       });
-      process.chdir(fixture.path);
 
       await generate(fixture.path);
 
       const ruleDoc = await fixture.readFile('docs/rules/no-foo.md');
       expect(ruleDoc).toContain('## Further Reading');
-      expect(ruleDoc).not.toContain('\r'); // Keeps its existing LF line endings.
+      expect(ruleDoc).toContain('Some description.');
+      assertUniformEndOfLine(ruleDoc, '\r\n');
     });
 
-    it('inserts the rules list using the line endings of the existing file (#726)', async function () {
+    it('converts a CRLF rule doc to LF when editorconfig sets end_of_line = lf, preserving content', async function () {
       fixture = await setupFixture({
         fixture: 'esm-base',
         overrides: {
-          'docs/rules/no-foo.md': '',
-          // README uses CRLF line endings but the configured end of line is LF.
+          'docs/rules/no-foo.md':
+            '# Description of no-foo (`test/no-foo`)\r\n\r\n<!-- end auto-generated rule header -->\r\n\r\nSome description.\r\n\r\n## Further Reading\r\n\r\n- [link](https://example.com/)\r\n',
           'README.md':
             '## Rules\r\n\r\n<!-- begin auto-generated rules list -->\r\n<!-- end auto-generated rules list -->\r\n',
           '.editorconfig': `
@@ -392,42 +447,61 @@ describe('getEndOfLine', function () {
                 end_of_line = lf`,
         },
       });
-      process.chdir(fixture.path);
 
       await generate(fixture.path);
 
-      const readme = await fixture.readFile('README.md');
-      expect(readme).toContain('\r\n');
-      // No mixed line endings: every LF should be part of a CRLF.
-      expect(readme.replaceAll('\r\n', '')).not.toContain('\n');
+      const ruleDoc = await fixture.readFile('docs/rules/no-foo.md');
+      expect(ruleDoc).toContain('## Further Reading');
+      expect(ruleDoc).toContain('Some description.');
+      assertUniformEndOfLine(ruleDoc, '\n');
     });
 
-    it('unifies mixed line endings to the predominant one in the file', async function () {
+    // eslint-disable-next-line vitest/expect-expect -- assertions via assertUniformEndOfLine
+    it('converts an LF file to CRLF when prettier explicitly sets endOfLine: crlf', async function () {
       fixture = await setupFixture({
         fixture: 'esm-base',
         overrides: {
           'docs/rules/no-foo.md': '',
-          // README has mostly-CRLF but mixed line endings (as could be produced by older versions of this tool).
           'README.md':
-            '# eslint-plugin-test\n\r\n## Rules\r\n\r\n<!-- begin auto-generated rules list -->\r\n<!-- end auto-generated rules list -->\r\n',
-          '.editorconfig': `
-                root = true
-
-                [*]
-                end_of_line = lf`,
+            '## Rules\n\n<!-- begin auto-generated rules list -->\n<!-- end auto-generated rules list -->\n',
+          '.prettierrc.json': `
+                  {
+                    "$schema": "https://json.schemastore.org/prettierrc",
+                    "endOfLine": "crlf"
+                  }`,
         },
       });
-      process.chdir(fixture.path);
 
       await generate(fixture.path);
 
-      const readme = await fixture.readFile('README.md');
-      expect(readme).toContain('\r\n');
-      // No mixed line endings: every LF should be part of a CRLF.
-      expect(readme.replaceAll('\r\n', '')).not.toContain('\n');
+      assertUniformEndOfLine(await fixture.readFile('README.md'), '\r\n');
+      assertUniformEndOfLine(
+        await fixture.readFile('docs/rules/no-foo.md'),
+        '\r\n',
+      );
     });
 
-    it('passes in --check mode when up-to-date files use different line endings than the configured end of line', async function () {
+    // eslint-disable-next-line vitest/expect-expect -- assertions via assertUniformEndOfLine
+    it('preserves CRLF when prettier config exists but does not set endOfLine (eslint-plugin-cypress case)', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'docs/rules/no-foo.md': '',
+          'README.md':
+            '## Rules\r\n\r\n<!-- begin auto-generated rules list -->\r\n<!-- end auto-generated rules list -->\r\n',
+          '.prettierrc.json': `
+                  {
+                    "$schema": "https://json.schemastore.org/prettierrc"
+                  }`,
+        },
+      });
+
+      await generate(fixture.path);
+
+      assertUniformEndOfLine(await fixture.readFile('README.md'), '\r\n');
+    });
+
+    it('fails --check when an existing file violates an explicit end_of_line config', async function () {
       const ruleDocCrlf =
         '# Description of no-foo (`test/no-foo`)\r\n\r\n<!-- end auto-generated rule header -->\r\n\r\nSome description.\r\n';
       const readmeCrlf =
@@ -444,39 +518,83 @@ describe('getEndOfLine', function () {
                 end_of_line = lf`,
         },
       });
-      process.chdir(fixture.path);
 
-      // First, bring the CRLF docs up-to-date.
+      // Bring content up-to-date while converting to LF from the config.
       await generate(fixture.path);
+      assertUniformEndOfLine(await fixture.readFile('README.md'), '\n');
 
-      // Then, --check should pass since nothing needs to change.
+      // Rewrite the README with CRLF so it again violates the explicit config.
+      const { writeFile } = await import('node:fs/promises');
+      await writeFile(
+        join(fixture.path, 'README.md'),
+        normalizeEndOfLine(await fixture.readFile('README.md'), '\r\n'),
+      );
+
+      process.exitCode = undefined;
       await generate(fixture.path, { check: true });
-      expect(process.exitCode).toBeUndefined();
+      expect(process.exitCode).toBe(1);
+      process.exitCode = undefined;
     });
   });
 
-  describe('fallback', function () {
+  describe('end-of-line detection from existing files', function () {
     let fixture: FixtureContext;
-    let originalCwd: string;
-
-    beforeEach(function () {
-      originalCwd = process.cwd();
-    });
 
     afterEach(async function () {
-      process.chdir(originalCwd);
       await fixture.cleanup();
     });
 
-    it('handles fallback to to `EOL` from `node:os` when config files do not exist', async function () {
-      // Run from a fixture directory that has no editorconfig or prettier config
+    // eslint-disable-next-line vitest/expect-expect -- assertions via assertUniformEndOfLine
+    it('inserts the rules list using the line endings of the existing file when there is no explicit config (#726)', async function () {
       fixture = await setupFixture({
         fixture: 'esm-base',
-        // No config files - just the base fixture
+        overrides: {
+          'docs/rules/no-foo.md': '',
+          'README.md':
+            '## Rules\r\n\r\n<!-- begin auto-generated rules list -->\r\n<!-- end auto-generated rules list -->\r\n',
+        },
       });
-      process.chdir(fixture.path);
 
-      expect(await getEndOfLine()).toStrictEqual(EOL);
+      await generate(fixture.path);
+
+      assertUniformEndOfLine(await fixture.readFile('README.md'), '\r\n');
+    });
+
+    // eslint-disable-next-line vitest/expect-expect -- assertions via assertUniformEndOfLine
+    it('unifies mixed line endings to the predominant one when there is no explicit config', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'docs/rules/no-foo.md': '',
+          // README has mostly-CRLF but mixed line endings (as could be produced by older versions of this tool).
+          'README.md':
+            '# eslint-plugin-test\n\r\n## Rules\r\n\r\n<!-- begin auto-generated rules list -->\r\n<!-- end auto-generated rules list -->\r\n',
+        },
+      });
+
+      await generate(fixture.path);
+
+      assertUniformEndOfLine(await fixture.readFile('README.md'), '\r\n');
+    });
+
+    it('passes in --check mode when up-to-date files match detected endings and there is no explicit config', async function () {
+      const ruleDocCrlf =
+        '# Description of no-foo (`test/no-foo`)\r\n\r\n<!-- end auto-generated rule header -->\r\n\r\nSome description.\r\n';
+      const readmeCrlf =
+        '## Rules\r\n\r\n<!-- begin auto-generated rules list -->\r\n<!-- end auto-generated rules list -->\r\n';
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'docs/rules/no-foo.md': ruleDocCrlf,
+          'README.md': readmeCrlf,
+        },
+      });
+
+      await generate(fixture.path);
+
+      process.exitCode = undefined;
+      await generate(fixture.path, { check: true });
+      expect(process.exitCode).toBeUndefined();
     });
   });
 });

--- a/test/lib/generate/eol-test.ts
+++ b/test/lib/generate/eol-test.ts
@@ -81,9 +81,6 @@ describe('createEndOfLineResolver', function () {
       expect(
         await eol.getExplicitEndOfLine(join(fixture.path, 'README.md')),
       ).toStrictEqual('\n');
-      expect(
-        await eol.getImplicitEndOfLine(join(fixture.path, 'README.md')),
-      ).toBeUndefined();
     });
 
     it('returns crlf when ".editorconfig" is configured with crlf', async function () {
@@ -180,7 +177,6 @@ describe('createEndOfLineResolver', function () {
     });
   });
 
-  // TODO: remove Prettier end-of-line tests in the next major with the Prettier tiers.
   describe('with a Prettier config', function () {
     let fixture: FixtureContext;
 
@@ -188,28 +184,7 @@ describe('createEndOfLineResolver', function () {
       await fixture.cleanup();
     });
 
-    it('returns lf when ".prettierrc.json" is configured with lf', async function () {
-      fixture = await setupFixture({
-        fixture: 'esm-base',
-        overrides: {
-          '.prettierrc.json': `
-                  {
-                    "$schema": "https://json.schemastore.org/prettierrc",
-                    "endOfLine": "lf"
-                  }`,
-        },
-      });
-
-      const eol = createEndOfLineResolver();
-      expect(
-        await eol.getExplicitEndOfLine(join(fixture.path, 'README.md')),
-      ).toStrictEqual('\n');
-      expect(
-        await eol.getImplicitEndOfLine(join(fixture.path, 'README.md')),
-      ).toBeUndefined();
-    });
-
-    it('returns crlf when ".prettierrc.json" is configured with crlf', async function () {
+    it('does not consult Prettier config for end of line', async function () {
       fixture = await setupFixture({
         fixture: 'esm-base',
         overrides: {
@@ -224,48 +199,7 @@ describe('createEndOfLineResolver', function () {
       const eol = createEndOfLineResolver();
       expect(
         await eol.getExplicitEndOfLine(join(fixture.path, 'README.md')),
-      ).toStrictEqual('\r\n');
-    });
-
-    it('treats Prettier config without endOfLine as implicit LF (#803)', async function () {
-      fixture = await setupFixture({
-        fixture: 'esm-base',
-        overrides: {
-          '.prettierrc.json': `
-                  {
-                    "$schema": "https://json.schemastore.org/prettierrc"
-                  }`,
-        },
-      });
-
-      const eol = createEndOfLineResolver();
-      expect(
-        await eol.getExplicitEndOfLine(join(fixture.path, 'README.md')),
       ).toBeUndefined();
-      expect(
-        await eol.getImplicitEndOfLine(join(fixture.path, 'README.md')),
-      ).toStrictEqual('\n');
-    });
-
-    it('treats Prettier endOfLine auto as implicit LF (falls through explicit tier)', async function () {
-      fixture = await setupFixture({
-        fixture: 'esm-base',
-        overrides: {
-          '.prettierrc.json': `
-                  {
-                    "$schema": "https://json.schemastore.org/prettierrc",
-                    "endOfLine": "auto"
-                  }`,
-        },
-      });
-
-      const eol = createEndOfLineResolver();
-      expect(
-        await eol.getExplicitEndOfLine(join(fixture.path, 'README.md')),
-      ).toBeUndefined();
-      expect(
-        await eol.getImplicitEndOfLine(join(fixture.path, 'README.md')),
-      ).toStrictEqual('\n');
     });
   });
 
@@ -284,9 +218,6 @@ describe('createEndOfLineResolver', function () {
       const eol = createEndOfLineResolver();
       expect(
         await eol.getExplicitEndOfLine(join(fixture.path, 'README.md')),
-      ).toBeUndefined();
-      expect(
-        await eol.getImplicitEndOfLine(join(fixture.path, 'README.md')),
       ).toBeUndefined();
       expect(getFallbackEndOfLine()).toStrictEqual(EOL);
     });
@@ -566,9 +497,8 @@ describe('generate with end of line', function () {
       assertUniformEndOfLine(ruleDoc, '\n');
     });
 
-    // TODO: remove with Prettier explicit endOfLine tier in the next major.
     // eslint-disable-next-line vitest/expect-expect -- assertions via assertUniformEndOfLine
-    it('converts an LF file to CRLF when prettier explicitly sets endOfLine: crlf', async function () {
+    it('preserves LF when prettier sets endOfLine: crlf (Prettier is not consulted)', async function () {
       fixture = await setupFixture({
         fixture: 'esm-base',
         overrides: {
@@ -585,14 +515,9 @@ describe('generate with end of line', function () {
 
       await generate(fixture.path);
 
-      assertUniformEndOfLine(await fixture.readFile('README.md'), '\r\n');
-      assertUniformEndOfLine(
-        await fixture.readFile('docs/rules/no-foo.md'),
-        '\r\n',
-      );
+      assertUniformEndOfLine(await fixture.readFile('README.md'), '\n');
     });
 
-    // Detection outranks implicit Prettier LF — keep this after Prettier-tier removal.
     // eslint-disable-next-line vitest/expect-expect -- assertions via assertUniformEndOfLine
     it('preserves CRLF when prettier config exists but does not set endOfLine (eslint-plugin-cypress / #726)', async function () {
       fixture = await setupFixture({
@@ -613,9 +538,8 @@ describe('generate with end of line', function () {
       assertUniformEndOfLine(await fixture.readFile('README.md'), '\r\n');
     });
 
-    // TODO: remove with Prettier implicit LF tier (#803) in the next major.
     // eslint-disable-next-line vitest/expect-expect -- assertions via assertUniformEndOfLine
-    it('uses implicit LF for new/empty docs when prettier config has no endOfLine (#803)', async function () {
+    it('uses os.EOL for new/empty docs even when prettier sets endOfLine: crlf', async function () {
       fixture = await setupFixture({
         fixture: 'esm-base',
         overrides: {
@@ -624,7 +548,8 @@ describe('generate with end of line', function () {
             '## Rules\n\n<!-- begin auto-generated rules list -->\n<!-- end auto-generated rules list -->\n',
           '.prettierrc.json': `
                   {
-                    "$schema": "https://json.schemastore.org/prettierrc"
+                    "$schema": "https://json.schemastore.org/prettierrc",
+                    "endOfLine": "crlf"
                   }`,
         },
       });
@@ -633,30 +558,8 @@ describe('generate with end of line', function () {
 
       assertUniformEndOfLine(
         await fixture.readFile('docs/rules/no-foo.md'),
-        '\n',
+        getFallbackEndOfLine(),
       );
-    });
-
-    // TODO: remove with Prettier endOfLine reading in the next major (`auto` becomes irrelevant).
-    // eslint-disable-next-line vitest/expect-expect -- assertions via assertUniformEndOfLine
-    it('falls through prettier endOfLine auto to per-file detection', async function () {
-      fixture = await setupFixture({
-        fixture: 'esm-base',
-        overrides: {
-          'docs/rules/no-foo.md': '',
-          'README.md':
-            '## Rules\r\n\r\n<!-- begin auto-generated rules list -->\r\n<!-- end auto-generated rules list -->\r\n',
-          '.prettierrc.json': `
-                  {
-                    "$schema": "https://json.schemastore.org/prettierrc",
-                    "endOfLine": "auto"
-                  }`,
-        },
-      });
-
-      await generate(fixture.path);
-
-      assertUniformEndOfLine(await fixture.readFile('README.md'), '\r\n');
     });
 
     it('fails --check when an existing file violates an explicit end_of_line config', async function () {

--- a/test/lib/generate/eol-test.ts
+++ b/test/lib/generate/eol-test.ts
@@ -180,6 +180,7 @@ describe('createEndOfLineResolver', function () {
     });
   });
 
+  // TODO: remove Prettier end-of-line tests in the next major with the Prettier tiers.
   describe('with a Prettier config', function () {
     let fixture: FixtureContext;
 
@@ -565,6 +566,7 @@ describe('generate with end of line', function () {
       assertUniformEndOfLine(ruleDoc, '\n');
     });
 
+    // TODO: remove with Prettier explicit endOfLine tier in the next major.
     // eslint-disable-next-line vitest/expect-expect -- assertions via assertUniformEndOfLine
     it('converts an LF file to CRLF when prettier explicitly sets endOfLine: crlf', async function () {
       fixture = await setupFixture({
@@ -590,6 +592,7 @@ describe('generate with end of line', function () {
       );
     });
 
+    // Detection outranks implicit Prettier LF — keep this after Prettier-tier removal.
     // eslint-disable-next-line vitest/expect-expect -- assertions via assertUniformEndOfLine
     it('preserves CRLF when prettier config exists but does not set endOfLine (eslint-plugin-cypress / #726)', async function () {
       fixture = await setupFixture({
@@ -610,6 +613,7 @@ describe('generate with end of line', function () {
       assertUniformEndOfLine(await fixture.readFile('README.md'), '\r\n');
     });
 
+    // TODO: remove with Prettier implicit LF tier (#803) in the next major.
     // eslint-disable-next-line vitest/expect-expect -- assertions via assertUniformEndOfLine
     it('uses implicit LF for new/empty docs when prettier config has no endOfLine (#803)', async function () {
       fixture = await setupFixture({
@@ -633,6 +637,7 @@ describe('generate with end of line', function () {
       );
     });
 
+    // TODO: remove with Prettier endOfLine reading in the next major (`auto` becomes irrelevant).
     // eslint-disable-next-line vitest/expect-expect -- assertions via assertUniformEndOfLine
     it('falls through prettier endOfLine auto to per-file detection', async function () {
       fixture = await setupFixture({

--- a/test/lib/generate/eol-test.ts
+++ b/test/lib/generate/eol-test.ts
@@ -37,6 +37,10 @@ describe('detectEndOfLine', function () {
     expect(detectEndOfLine('a\r\nb\r\nc\n')).toStrictEqual('\r\n');
     expect(detectEndOfLine('a\nb\nc\r\n')).toStrictEqual('\n');
   });
+
+  it('prefers lf when CRLF and LF counts are equal', function () {
+    expect(detectEndOfLine('a\r\nb\n')).toStrictEqual('\n');
+  });
 });
 
 describe('normalizeEndOfLine', function () {
@@ -174,6 +178,24 @@ describe('createEndOfLineResolver', function () {
           join(fixture.path, 'docs/rules/no-bar.mdx'),
         ),
       ).toStrictEqual('\r\n');
+    });
+
+    it('treats EditorConfig end_of_line = cr as unset', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          '.editorconfig': `
+                  root = true
+
+                  [*]
+                  end_of_line = cr`,
+        },
+      });
+
+      const eol = createEndOfLineResolver();
+      expect(
+        await eol.getExplicitEndOfLine(join(fixture.path, 'README.md')),
+      ).toBeUndefined();
     });
   });
 
@@ -656,6 +678,93 @@ describe('generate with end of line', function () {
       process.exitCode = undefined;
       await generate(fixture.path, { check: true });
       expect(process.exitCode).toBeUndefined();
+    });
+
+    // eslint-disable-next-line vitest/expect-expect -- assertions via assertUniformEndOfLine
+    it('unifies stray lone CR when updating an existing file', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'docs/rules/no-foo.md': '',
+          // Mostly LF with a stray classic Mac CR so normalization must clear it.
+          'README.md':
+            '## Rules\n\n<!-- begin auto-generated rules list -->\r<!-- end auto-generated rules list -->\n',
+        },
+      });
+
+      await generate(fixture.path);
+
+      assertUniformEndOfLine(await fixture.readFile('README.md'), '\n');
+    });
+  });
+
+  describe('--init-rule-docs', function () {
+    let fixture: FixtureContext;
+
+    afterEach(async function () {
+      await fixture.cleanup();
+    });
+
+    // eslint-disable-next-line vitest/expect-expect -- assertions via assertUniformEndOfLine
+    it('creates new rule docs using editorconfig end_of_line', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'index.js': `
+          export default {
+            rules: {
+              'no-new': {
+                meta: { docs: { description: 'Description of no-new.' } },
+                create(context) {}
+              },
+            },
+          };`,
+          'README.md':
+            '## Rules\n\n<!-- begin auto-generated rules list -->\n<!-- end auto-generated rules list -->\n',
+          '.editorconfig': `
+                root = true
+
+                [*]
+                end_of_line = crlf`,
+        },
+      });
+
+      await generate(fixture.path, { initRuleDocs: true });
+
+      assertUniformEndOfLine(
+        await fixture.readFile('docs/rules/no-new.md'),
+        '\r\n',
+      );
+    });
+  });
+
+  describe('postprocess', function () {
+    let fixture: FixtureContext;
+
+    afterEach(async function () {
+      await fixture.cleanup();
+    });
+
+    // eslint-disable-next-line vitest/expect-expect -- assertions via assertUniformEndOfLine
+    it('writes postprocess output endings verbatim', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'docs/rules/no-foo.md': '',
+          'README.md':
+            '## Rules\n\n<!-- begin auto-generated rules list -->\n<!-- end auto-generated rules list -->\n',
+        },
+      });
+
+      await generate(fixture.path, {
+        postprocess: (content) => content.replaceAll('\n', '\r\n'),
+      });
+
+      assertUniformEndOfLine(await fixture.readFile('README.md'), '\r\n');
+      assertUniformEndOfLine(
+        await fixture.readFile('docs/rules/no-foo.md'),
+        '\r\n',
+      );
     });
   });
 });

--- a/test/lib/generate/eol-test.ts
+++ b/test/lib/generate/eol-test.ts
@@ -105,6 +105,24 @@ describe('createEndOfLineResolver', function () {
       ).toStrictEqual('\r\n');
     });
 
+    it('treats unsupported values like "cr" as unset', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          '.editorconfig': `
+                root = true
+
+                [*]
+                end_of_line = cr`,
+        },
+      });
+
+      const eol = createEndOfLineResolver();
+      expect(
+        await eol.getExplicitEndOfLine(join(fixture.path, 'README.md')),
+      ).toBeUndefined();
+    });
+
     it('respects the .md specific end of line settings when ".editorconfig" is configured', async function () {
       fixture = await setupFixture({
         fixture: 'esm-base',

--- a/test/lib/markdown-test.ts
+++ b/test/lib/markdown-test.ts
@@ -10,10 +10,6 @@ import { getContext, type Context } from '../../lib/context.js';
 
 const cwd = process.cwd();
 
-function normalize(markdown: string, context: Context) {
-  return markdown.split('\n').join(context.endOfLine);
-}
-
 describe('markdown', function () {
   let context: Context;
 
@@ -33,7 +29,7 @@ describe('markdown', function () {
       `;
 
       expect(context).toBeDefined();
-      expect(extractFrontmatter(context, markdown)).toBe(outdent`
+      expect(extractFrontmatter(markdown)).toBe(outdent`
         ---
         title: Test Rule
         description: This is a test rule.
@@ -48,7 +44,7 @@ describe('markdown', function () {
       `;
 
       expect(context).toBeDefined();
-      expect(extractFrontmatter(context, markdown)).toBeUndefined();
+      expect(extractFrontmatter(markdown)).toBeUndefined();
     });
 
     it('should return undefined if there is only one frontmatter delimiter', function () {
@@ -59,7 +55,7 @@ describe('markdown', function () {
       `;
 
       expect(context).toBeDefined();
-      expect(extractFrontmatter(context, markdown)).toBeUndefined();
+      expect(extractFrontmatter(markdown)).toBeUndefined();
     });
 
     it('should return undefined if there is a frontmatter-like section that does not start at the beginning of the file', function () {
@@ -73,20 +69,17 @@ describe('markdown', function () {
       `;
 
       expect(context).toBeDefined();
-      expect(extractFrontmatter(context, markdown)).toBeUndefined();
+      expect(extractFrontmatter(markdown)).toBeUndefined();
     });
   });
 
   describe('findFinalHeaderLevel', function () {
     describe("framework='none'", () => {
       it('should detect top header', function () {
-        const markdown = normalize(
-          outdent`
-            # Header
-            Some description
-          `,
-          context,
-        );
+        const markdown = outdent`
+          # Header
+          Some description
+        `;
         expect(findFinalHeaderLevel(context, markdown)).toBe(1);
       });
 
@@ -103,19 +96,16 @@ describe('markdown', function () {
         expect(
           findFinalHeaderLevel(
             context,
-            normalize(
-              outdent`
-                # eslint-plugin-test
-                Description.
-                ## Configs
-                Configs
-                ### Some config
-                Description
-                ## Rules
-                Rules
-              `,
-              context,
-            ),
+            outdent`
+              # eslint-plugin-test
+              Description.
+              ## Configs
+              Configs
+              ### Some config
+              Description
+              ## Rules
+              Rules
+            `,
           ),
         ).toBe(2);
       });
@@ -128,16 +118,13 @@ describe('markdown', function () {
         expect(
           findFinalHeaderLevel(
             context,
-            normalize(
-              outdent`
-                ---
-                title: Test Rule
-                description: This is a test rule.
-                ---
-                Rules
-              `,
-              context,
-            ),
+            outdent`
+              ---
+              title: Test Rule
+              description: This is a test rule.
+              ---
+              Rules
+            `,
           ),
         ).toBeUndefined();
       });
@@ -149,25 +136,19 @@ describe('markdown', function () {
       });
 
       it('should detect top header', function () {
-        const markdown = normalize(
-          outdent`
-            # Header
-            Some description
-          `,
-          context,
-        );
+        const markdown = outdent`
+          # Header
+          Some description
+        `;
         expect(findFinalHeaderLevel(context, markdown)).toBe(1);
       });
 
       it('should detect sub-header', function () {
-        const markdown = normalize(
-          outdent`
-            # Header
-            Some description
-            ## Rules
-          `,
-          context,
-        );
+        const markdown = outdent`
+          # Header
+          Some description
+          ## Rules
+        `;
         expect(findFinalHeaderLevel(context, markdown)).toBe(2);
       });
 
@@ -175,19 +156,16 @@ describe('markdown', function () {
         expect(
           findFinalHeaderLevel(
             context,
-            normalize(
-              outdent`
-                # eslint-plugin-test
-                Description.
-                ## Configs
-                Configs
-                ### Some config
-                Description
-                ## Rules
-                Rules
-              `,
-              context,
-            ),
+            outdent`
+              # eslint-plugin-test
+              Description.
+              ## Configs
+              Configs
+              ### Some config
+              Description
+              ## Rules
+              Rules
+            `,
           ),
         ).toBe(2);
       });
@@ -200,16 +178,13 @@ describe('markdown', function () {
         expect(
           findFinalHeaderLevel(
             context,
-            normalize(
-              outdent`
-                ---
-                title: Test Rule
-                description: This is a test rule.
-                ---
-                Rules
-              `,
-              context,
-            ),
+            outdent`
+              ---
+              title: Test Rule
+              description: This is a test rule.
+              ---
+              Rules
+            `,
           ),
         ).toBe(1);
       });
@@ -218,16 +193,13 @@ describe('markdown', function () {
         expect(
           findFinalHeaderLevel(
             context,
-            normalize(
-              outdent`
-                ---
-                title: Test Rule
-                description: This is a test rule.
-                ---
-                ## Rules
-              `,
-              context,
-            ),
+            outdent`
+              ---
+              title: Test Rule
+              description: This is a test rule.
+              ---
+              ## Rules
+            `,
           ),
         ).toBe(2);
       });
@@ -237,28 +209,27 @@ describe('markdown', function () {
   describe('findSectionHeader', function () {
     it('handles standard section title', function () {
       const title = '## Rules\n';
-      expect(findSectionHeader(context, title, 'rules')).toBe(title);
+      expect(findSectionHeader(title, 'rules')).toBe(title);
     });
 
     it('handles section title with leading emoji', function () {
       const title = '## 🍟 Rules\n';
-      expect(findSectionHeader(context, title, 'rules')).toBe(title);
+      expect(findSectionHeader(title, 'rules')).toBe(title);
     });
 
     it('handles section title with html', function () {
       const title = "## <a name='Rules'></a>Rules\n";
-      expect(findSectionHeader(context, title, 'rules')).toBe(title);
+      expect(findSectionHeader(title, 'rules')).toBe(title);
     });
 
     it('handles sentential section title', function () {
       const title = '## List of supported rules\n';
-      expect(findSectionHeader(context, title, 'rules')).toBe(title);
+      expect(findSectionHeader(title, 'rules')).toBe(title);
     });
 
     it('handles doc with multiple sections', function () {
       expect(
         findSectionHeader(
-          context,
           outdent`
             # eslint-plugin-test
             Description.
@@ -275,7 +246,6 @@ describe('markdown', function () {
     it('handles doc with multiple rules-related sections', function () {
       expect(
         findSectionHeader(
-          context,
           outdent`
             # eslint-plugin-test
             Description.
@@ -294,382 +264,276 @@ describe('markdown', function () {
 
   describe('replaceOrCreateFrontmatter', function () {
     it('should leave everything as it was when no frontmatter was passed in (none existing)', function () {
-      const markdown = normalize(
-        outdent`
-          # Rule
-          Intro sentence.
-          <!-- end auto-generated rule header -->
-          Rule description.
-        `,
-        context,
-      );
+      const markdown = outdent`
+        # Rule
+        Intro sentence.
+        <!-- end auto-generated rule header -->
+        Rule description.
+      `;
 
-      expect(replaceOrCreateFrontmatter(context, markdown, undefined)).toBe(
-        markdown,
-      );
+      expect(replaceOrCreateFrontmatter(markdown, undefined)).toBe(markdown);
     });
 
     it('should leave everything as it was when no frontmatter was passed in (existing frontmatter)', function () {
-      const markdown = normalize(
-        outdent`
-          ---
-          name: no-foo
-          description: Some description
-          ---
-          # Rule
-          Intro sentence.
-          <!-- end auto-generated rule header -->
-          Rule description.
-        `,
-        context,
-      );
+      const markdown = outdent`
+        ---
+        name: no-foo
+        description: Some description
+        ---
+        # Rule
+        Intro sentence.
+        <!-- end auto-generated rule header -->
+        Rule description.
+      `;
 
-      expect(replaceOrCreateFrontmatter(context, markdown, undefined)).toBe(
-        markdown,
-      );
+      expect(replaceOrCreateFrontmatter(markdown, undefined)).toBe(markdown);
     });
 
     it('should create new frontmatter when no existing frontmatter exists', function () {
-      const markdown = normalize(
-        outdent`
-          Rule description.
-        `,
-        context,
-      );
-      const newFrontmatter = normalize(
-        outdent`
-          ---
-          title: New Rule
-          ---
-        `,
-        context,
-      );
+      const markdown = outdent`
+        Rule description.
+      `;
+      const newFrontmatter = outdent`
+        ---
+        title: New Rule
+        ---
+      `;
 
-      expect(
-        replaceOrCreateFrontmatter(context, markdown, newFrontmatter),
-      ).toBe(`${newFrontmatter}${context.endOfLine}${markdown}`);
+      expect(replaceOrCreateFrontmatter(markdown, newFrontmatter)).toBe(
+        `${newFrontmatter}\n${markdown}`,
+      );
     });
 
     it('should replace existing frontmatter with the specified new frontmatter', function () {
-      const markdown = normalize(
-        outdent`
-          ---
-          title: Old Rule
-          ---
-          Rule description.
-        `,
-        context,
-      );
-      const newFrontmatter = normalize(
-        outdent`
-          ---
-          title: New Rule
-          ---
-        `,
-        context,
-      );
+      const markdown = outdent`
+        ---
+        title: Old Rule
+        ---
+        Rule description.
+      `;
+      const newFrontmatter = outdent`
+        ---
+        title: New Rule
+        ---
+      `;
 
-      expect(
-        replaceOrCreateFrontmatter(context, markdown, newFrontmatter),
-      ).toBe(`${newFrontmatter}${context.endOfLine}Rule description.`);
+      expect(replaceOrCreateFrontmatter(markdown, newFrontmatter)).toBe(
+        `${newFrontmatter}\nRule description.`,
+      );
     });
   });
 
   describe('replaceOrCreateHeader', function () {
     describe('for md files', function () {
       it('should create a new header when no existing header or marker exists', function () {
-        const markdown = normalize(
-          outdent`
-            This is the content of the rule doc.
-          `,
-          context,
-        );
-        const newHeader = normalize(
-          outdent`
-            # New Rule
-            <!-- end auto-generated rule header -->
-          `,
-          context,
-        );
+        const markdown = outdent`
+          This is the content of the rule doc.
+        `;
+        const newHeader = outdent`
+          # New Rule
+          <!-- end auto-generated rule header -->
+        `;
 
-        expect(replaceOrCreateHeader(context, markdown, newHeader, false)).toBe(
-          `${newHeader}${context.endOfLine}${markdown}`,
+        expect(replaceOrCreateHeader(markdown, newHeader, false)).toBe(
+          `${newHeader}\n${markdown}`,
         );
       });
 
       it('should replace an existing title header and preserve the original body', function () {
-        const markdown = normalize(
-          outdent`
-            # Old Rule
-            Rule description.
-          `,
-          context,
-        );
-        const newHeader = normalize(
-          outdent`
-            # New Rule
-            <!-- end auto-generated rule header -->
-          `,
-          context,
-        );
+        const markdown = outdent`
+          # Old Rule
+          Rule description.
+        `;
+        const newHeader = outdent`
+          # New Rule
+          <!-- end auto-generated rule header -->
+        `;
 
-        expect(replaceOrCreateHeader(context, markdown, newHeader, false)).toBe(
-          `${newHeader}${context.endOfLine}Rule description.`,
+        expect(replaceOrCreateHeader(markdown, newHeader, false)).toBe(
+          `${newHeader}\nRule description.`,
         );
       });
 
       it('should replace everything up to the marker and keep content after the marker', function () {
-        const markdown = normalize(
-          outdent`
-            # Old Rule
-            Intro sentence.
-            <!-- end auto-generated rule header -->
-            Rule description.
-          `,
-          context,
-        );
-        const newHeader = normalize(
-          outdent`
-            # New Rule
-            <!-- end auto-generated rule header -->
-          `,
-          context,
-        );
+        const markdown = outdent`
+          # Old Rule
+          Intro sentence.
+          <!-- end auto-generated rule header -->
+          Rule description.
+        `;
+        const newHeader = outdent`
+          # New Rule
+          <!-- end auto-generated rule header -->
+        `;
 
-        expect(replaceOrCreateHeader(context, markdown, newHeader, false)).toBe(
-          `${newHeader}${context.endOfLine}Rule description.`,
+        expect(replaceOrCreateHeader(markdown, newHeader, false)).toBe(
+          `${newHeader}\nRule description.`,
         );
       });
 
       it('should preserve frontmatter and doc body when replacing header', function () {
-        const frontmatter = normalize(
-          outdent`
-            ---
-            title: Old Rule
-            ---
-          `,
-          context,
-        );
-        const markdown = normalize(
-          outdent`
-            ${frontmatter}
-            # Old Rule
-            Rule description.
-          `,
-          context,
-        );
-        const newHeader = normalize(
-          outdent`
-            # New Rule
-            <!-- end auto-generated rule header -->
-          `,
-          context,
-        );
+        const frontmatter = outdent`
+          ---
+          title: Old Rule
+          ---
+        `;
+        const markdown = outdent`
+          ${frontmatter}
+          # Old Rule
+          Rule description.
+        `;
+        const newHeader = outdent`
+          # New Rule
+          <!-- end auto-generated rule header -->
+        `;
 
-        expect(replaceOrCreateHeader(context, markdown, newHeader, false)).toBe(
-          `${frontmatter}${context.endOfLine}${newHeader}${context.endOfLine}Rule description.`,
+        expect(replaceOrCreateHeader(markdown, newHeader, false)).toBe(
+          `${frontmatter}\n${newHeader}\nRule description.`,
         );
       });
 
       it('should should preserve additional content between frontmatter and header', function () {
-        const frontmatter = normalize(
-          outdent`
-            ---
-            title: Old Rule
-            ---
-          `,
-          context,
-        );
-        const markdown = normalize(
-          outdent`
-            ${frontmatter}
-            > 📌 A blockquote that should be preserved.
-            # Old Rule
-            Rule description.
-          `,
-          context,
-        );
-        const newHeader = normalize(
-          outdent`
-            # New Rule
-            <!-- end auto-generated rule header -->
-          `,
-          context,
-        );
+        const frontmatter = outdent`
+          ---
+          title: Old Rule
+          ---
+        `;
+        const markdown = outdent`
+          ${frontmatter}
+          > 📌 A blockquote that should be preserved.
+          # Old Rule
+          Rule description.
+        `;
+        const newHeader = outdent`
+          # New Rule
+          <!-- end auto-generated rule header -->
+        `;
 
-        expect(replaceOrCreateHeader(context, markdown, newHeader, false)).toBe(
-          `${frontmatter}${context.endOfLine}> 📌 A blockquote that should be preserved.${context.endOfLine}${newHeader}${context.endOfLine}Rule description.`,
+        expect(replaceOrCreateHeader(markdown, newHeader, false)).toBe(
+          `${frontmatter}\n> 📌 A blockquote that should be preserved.\n${newHeader}\nRule description.`,
         );
       });
 
       it('should should preserve additional content above header when no frontmatter exists', function () {
-        const markdown = normalize(
-          outdent`
-            > 📌 A blockquote that should be preserved.
-            # Old Rule
-            Rule description.
-          `,
-          context,
-        );
-        const newHeader = normalize(
-          outdent`
-            # New Rule
-            <!-- end auto-generated rule header -->
-          `,
-          context,
-        );
+        const markdown = outdent`
+          > 📌 A blockquote that should be preserved.
+          # Old Rule
+          Rule description.
+        `;
+        const newHeader = outdent`
+          # New Rule
+          <!-- end auto-generated rule header -->
+        `;
 
-        expect(replaceOrCreateHeader(context, markdown, newHeader, false)).toBe(
-          `> 📌 A blockquote that should be preserved.${context.endOfLine}${newHeader}${context.endOfLine}Rule description.`,
+        expect(replaceOrCreateHeader(markdown, newHeader, false)).toBe(
+          `> 📌 A blockquote that should be preserved.\n${newHeader}\nRule description.`,
         );
       });
     });
 
     describe('for mdx files', function () {
       it('should create a new header when no existing header or marker exists', function () {
-        const markdown = normalize(
-          outdent`
-            This is the content of the rule doc.
-          `,
-          context,
-        );
-        const newHeader = normalize(
-          outdent`
-            # New Rule
-            {/* end auto-generated rule header */}
-          `,
-          context,
-        );
+        const markdown = outdent`
+          This is the content of the rule doc.
+        `;
+        const newHeader = outdent`
+          # New Rule
+          {/* end auto-generated rule header */}
+        `;
 
-        expect(replaceOrCreateHeader(context, markdown, newHeader, true)).toBe(
-          `${newHeader}${context.endOfLine}${markdown}`,
+        expect(replaceOrCreateHeader(markdown, newHeader, true)).toBe(
+          `${newHeader}\n${markdown}`,
         );
       });
 
       it('should replace an existing title header and preserve the original body', function () {
-        const markdown = normalize(
-          outdent`
-            # Old Rule
-            Rule description.
-          `,
-          context,
-        );
-        const newHeader = normalize(
-          outdent`
-            # New Rule
-            {/* end auto-generated rule header */}
-          `,
-          context,
-        );
+        const markdown = outdent`
+          # Old Rule
+          Rule description.
+        `;
+        const newHeader = outdent`
+          # New Rule
+          {/* end auto-generated rule header */}
+        `;
 
-        expect(replaceOrCreateHeader(context, markdown, newHeader, true)).toBe(
-          `${newHeader}${context.endOfLine}Rule description.`,
+        expect(replaceOrCreateHeader(markdown, newHeader, true)).toBe(
+          `${newHeader}\nRule description.`,
         );
       });
 
       it('should replace everything up to the marker and keep content after the marker', function () {
-        const markdown = normalize(
-          outdent`
-            # Old Rule
-            Intro sentence.
-            {/* end auto-generated rule header */}
-            Rule description.
-          `,
-          context,
-        );
-        const newHeader = normalize(
-          outdent`
-            # New Rule
-            {/* end auto-generated rule header */}
-          `,
-          context,
-        );
+        const markdown = outdent`
+          # Old Rule
+          Intro sentence.
+          {/* end auto-generated rule header */}
+          Rule description.
+        `;
+        const newHeader = outdent`
+          # New Rule
+          {/* end auto-generated rule header */}
+        `;
 
-        expect(replaceOrCreateHeader(context, markdown, newHeader, true)).toBe(
-          `${newHeader}${context.endOfLine}Rule description.`,
+        expect(replaceOrCreateHeader(markdown, newHeader, true)).toBe(
+          `${newHeader}\nRule description.`,
         );
       });
 
       it('should preserve frontmatter and doc body when replacing header', function () {
-        const frontmatter = normalize(
-          outdent`
-            ---
-            title: Old Rule
-            ---
-          `,
-          context,
-        );
-        const markdown = normalize(
-          outdent`
-            ${frontmatter}
-            # Old Rule
-            Rule description.
-          `,
-          context,
-        );
-        const newHeader = normalize(
-          outdent`
-            # New Rule
-            {/* end auto-generated rule header */}
-          `,
-          context,
-        );
+        const frontmatter = outdent`
+          ---
+          title: Old Rule
+          ---
+        `;
+        const markdown = outdent`
+          ${frontmatter}
+          # Old Rule
+          Rule description.
+        `;
+        const newHeader = outdent`
+          # New Rule
+          {/* end auto-generated rule header */}
+        `;
 
-        expect(replaceOrCreateHeader(context, markdown, newHeader, true)).toBe(
-          `${frontmatter}${context.endOfLine}${newHeader}${context.endOfLine}Rule description.`,
+        expect(replaceOrCreateHeader(markdown, newHeader, true)).toBe(
+          `${frontmatter}\n${newHeader}\nRule description.`,
         );
       });
 
       it('should should preserve additional content between frontmatter and header', function () {
-        const frontmatter = normalize(
-          outdent`
-            ---
-            title: Old Rule
-            ---
-          `,
-          context,
-        );
-        const markdown = normalize(
-          outdent`
-            ${frontmatter}
-            > 📌 A blockquote that should be preserved.
-            # Old Rule
-            Rule description.
-          `,
-          context,
-        );
-        const newHeader = normalize(
-          outdent`
-            # New Rule
-            {/* end auto-generated rule header */}
-          `,
-          context,
-        );
+        const frontmatter = outdent`
+          ---
+          title: Old Rule
+          ---
+        `;
+        const markdown = outdent`
+          ${frontmatter}
+          > 📌 A blockquote that should be preserved.
+          # Old Rule
+          Rule description.
+        `;
+        const newHeader = outdent`
+          # New Rule
+          {/* end auto-generated rule header */}
+        `;
 
-        expect(replaceOrCreateHeader(context, markdown, newHeader, true)).toBe(
-          `${frontmatter}${context.endOfLine}> 📌 A blockquote that should be preserved.${context.endOfLine}${newHeader}${context.endOfLine}Rule description.`,
+        expect(replaceOrCreateHeader(markdown, newHeader, true)).toBe(
+          `${frontmatter}\n> 📌 A blockquote that should be preserved.\n${newHeader}\nRule description.`,
         );
       });
 
       it('should should preserve additional content above header when no frontmatter exists', function () {
-        const markdown = normalize(
-          outdent`
-            > 📌 A blockquote that should be preserved.
-            # Old Rule
-            Rule description.
-          `,
-          context,
-        );
-        const newHeader = normalize(
-          outdent`
-            # New Rule
-            {/* end auto-generated rule header */}
-          `,
-          context,
-        );
+        const markdown = outdent`
+          > 📌 A blockquote that should be preserved.
+          # Old Rule
+          Rule description.
+        `;
+        const newHeader = outdent`
+          # New Rule
+          {/* end auto-generated rule header */}
+        `;
 
-        expect(replaceOrCreateHeader(context, markdown, newHeader, true)).toBe(
-          `> 📌 A blockquote that should be preserved.${context.endOfLine}${newHeader}${context.endOfLine}Rule description.`,
+        expect(replaceOrCreateHeader(markdown, newHeader, true)).toBe(
+          `> 📌 A blockquote that should be preserved.\n${newHeader}\nRule description.`,
         );
       });
     });


### PR DESCRIPTION
Fixes #725
Fixes #726

Line endings are now determined **per file** when writing: an explicit EditorConfig `end_of_line` for that file path, else the end of line already predominant in the file, else `os.EOL`. Markdown is processed using LF internally, so parsing never depends on matching a configured end of line. Completes the behavior originally requested in #527. Supersedes #985.

## Problem

All content was parsed *and* generated using a single end of line chosen once per run (EditorConfig via a fake `markdown.md` path in `cwd`, else LF whenever any Prettier config was present, else `os.EOL`). When that guess disagreed with what a file actually used:

- Splitting on the wrong end of line broke title/marker matching, silently deleting doc content (#725).
- Generated tables and lists were inserted with the wrong end of line, leaving files with mixed LF/CRLF (#726).

Both were reported on Windows — where the `os.EOL` fallback (CRLF) collides with Prettier-rewritten LF files — but the root cause is platform-independent.

## Fix

**Parse safely:** all markdown is normalized to LF on read and processed as LF; the end of line is applied once at write time. Content can no longer be corrupted by a mismatch, and `Context.endOfLine` is gone — the end of line is purely an I/O concern in `generator.ts`.

**Write predictably**, per file:

| Priority | Before (3.6.0) | After |
| --- | --- | --- |
| 1 | EditorConfig `end_of_line` (fake `markdown.md` path in `cwd`) | EditorConfig `end_of_line` (actual file path) |
| 2 | Prettier config present → always LF | End of line already predominant in the file |
| 3 | `os.EOL` | `os.EOL` (new files / files with no line breaks) |

Config is resolved for the actual file path (memoized per `generate()` run), so EditorConfig glob sections like `[*.md]` vs `[*.mdx]` work correctly and results no longer depend on the working directory.

## Notes for upgraders

- Files with previously mixed line endings are unified to their predominant end of line on the first run — a one-time diff.
- With an explicit EditorConfig `end_of_line`, files using a different end of line are converted (one-time diff), and `--check` fails until they match.
- **Prettier config is no longer read for line endings** (removes the #803 behavior and the optional `prettier` peer dependency). That inference was added without a motivating issue as a workaround for the then-missing per-file detection, and interpreting `endOfLine` out of a Prettier config forks Prettier's own semantics (`.prettierignore`, `overrides`) — it is what produced the mixed endings in eslint-plugin-cypress, where all markdown is prettierignored. To apply Prettier (including its `endOfLine`), run Prettier itself via [`postprocess`](https://github.com/eslint-community/eslint-doc-generator#prettier) or after generation. The README `postprocess` example has been updated to honor `.prettierignore`, per-path config, and `overrides` (via `prettier.getFileInfo()` / `prettier.resolveConfig()`).

See the new README ["Line endings"](https://github.com/eslint-community/eslint-doc-generator/blob/main/README.md) section for the documented behavior. Only `lf` and `crlf` are honored from EditorConfig; other values such as `cr` are treated as unset (documented and pinned by a test).

## Testing

- Unit and generate-level tests cover: detection (LF / CRLF / mixed, LF preferred on an exact tie), EditorConfig (`lf` / `crlf`, `[*.md]` sections, per-glob paths, same-directory `.md` + `.mdx`, `cr` treated as unset), conversion in both directions with content preserved (#725), rules-list insertion using detected endings (#726), mixed-file unification, `--check` enforcement and pass-through, Prettier-not-consulted (explicit `endOfLine` ignored; new/empty docs use `os.EOL`), and lone-CR normalization. The suite runs on the Windows CI matrix, so CRLF paths are exercised natively.
- E2E replay of the reporter's eslint-plugin-cypress repro branches: released 3.6.0 reproduces the mixed endings; this branch's build produces uniform CRLF with all content preserved, and the #725 flow (doc rewritten to LF by Prettier) keeps content intact.

Retest note (@MikeMcC399): the package version is still `3.6.0`, so when testing a packed tarball of this branch, please verify provenance via `npm ls -g eslint-doc-generator` (the tarball path) rather than `--version` alone.