### PR TITLE
feat!: add exports map to package.json

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,5 @@
-// Exported as part of this package's Node API.
-// Type exports controlled by `types` in package.json, non-type exports controlled by `exports` in package.json.
+// Public API is types-only (`GenerateOptions`). Top-level `types` and the
+// `exports` map in package.json document the types entry; `exports` also seals
+// deep imports into the package.
 
 export type { GenerateOptions } from './types.js';

--- a/package.json
+++ b/package.json
@@ -21,6 +21,12 @@
   "license": "ISC",
   "author": "Bryan Mishkin",
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/lib/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "types": "./dist/lib/index.d.ts",
   "bin": {
     "eslint-doc-generator": "./dist/bin/eslint-doc-generator.js"


### PR DESCRIPTION
## Summary

Adds an `exports` map so the public package surface is explicit: types entry for `.` plus `./package.json`. **Parked until next major** — sealing exports blocks deep imports into `dist/*`, treated as breaking; keep `feat!` for release-please; do not merge until the major cycle.

Also updates the stale comment in `lib/index.ts` to describe the types-only public API (`GenerateOptions`).

## Test plan

- [x] `npm run lint`
- [x] `npm test` (373 tests passed)


Made with [Cursor](https://cursor.com)

## Context

From the post-#987 standards audit: `package.json` had neither `main` nor `exports`, while `lib/index.ts` claimed non-type exports were "controlled by `exports`" — a field that didn't exist. Since there is no runtime entry today, sealing deep `dist/*` imports is the only observable change; it is treated as **breaking by policy** (hence `feat!` and parked until the next major cycle even though deep imports were never supported API).

Extra verification beyond CI: `npx @arethetypeswrong/cli --pack .` should report clean resolution under `node16`/`bundler`.
