### PR TITLE
chore: build on prepack so npm pack and git installs include dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lint:package-json-sorting": "sort-package-json --check",
     "lint:package-json-sorting:fix": "sort-package-json package.json",
     "lint:types": "tsgo",
-    "prepublishOnly": "npm run build",
+    "prepack": "npm run build",
     "test": "vitest run --coverage"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Replace `prepublishOnly` with `prepack` so the TypeScript build runs whenever a package tarball is created—not only on `npm publish`.
- `dist/` is gitignored, so previously only a full publish ran the build. Bare `npm pack` shipped a 2-file tarball (package.json + README) without compiled output.
- `prepack` runs for `npm pack`, `npm publish`, and git/URL installs, so consumers get a usable package. release-please publish still works because publish also triggers `prepack`.

## Test plan
- [x] `npm run lint && npm test`
- [ ] Optionally confirm `npm pack` produces a tarball that includes `dist/` (more than the previous 2-file package)


Made with [Cursor](https://cursor.com)

## Context

Found empirically during the #987 review: with the build wired to `prepublishOnly` and `dist/` git-ignored, a bare `npm pack` produced an installable-but-nonfunctional 2-file tarball (8.9 kB: `package.json` + README, no `dist/`). Beyond git installs, this is a footgun for contributors packing tarballs to test PRs — a dist-less tarball silently leaves `npx` resolving whatever version is in local `node_modules`, which contributed to the retest confusion on #726/#987.
