### PR TITLE
fix: print non-Error throwables on CLI failure

### DIFF
--- a/bin/eslint-doc-generator.ts
+++ b/bin/eslint-doc-generator.ts
@@ -4,14 +4,12 @@
 // rule was renamed in https://github.com/eslint-community/eslint-plugin-n/releases/tag/v17.0.0
 // from n/shebang to n/hashbang
 
-import { run } from '../lib/cli.js';
+import { printCliError, run } from '../lib/cli.js';
 import { generate } from '../lib/generator.js';
 
 try {
   await run(process.argv, (path, options) => generate(path, options));
 } catch (error: unknown) {
-  if (error instanceof Error) {
-    console.error(error.message);
-  }
+  printCliError(error);
   process.exitCode = 1;
 }

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -187,6 +187,18 @@ async function loadConfigFileOptions(): Promise<GenerateOptions> {
 }
 
 /**
+ * Print a CLI failure to stderr.
+ * Handles non-Error throwables that would otherwise exit with empty stderr.
+ */
+export function printCliError(error: unknown): void {
+  if (error instanceof Error) {
+    console.error(error.message);
+  } else {
+    console.error(String(error));
+  }
+}
+
+/**
  * Run the CLI and gather options.
  * When this is done, load any config file and merge with the CLI options.
  * Finally, invoke a callback with the merged options.

--- a/test/lib/cli-test.ts
+++ b/test/lib/cli-test.ts
@@ -1,4 +1,4 @@
-import { run } from '../../lib/cli.js';
+import { printCliError, run } from '../../lib/cli.js';
 import { OPTION_TYPE } from '../../lib/types.js';
 import { type FixtureContext, setupFixture } from '../helpers/fixture.js';
 
@@ -557,6 +557,26 @@ describe('cli', () => {
           'config file/ruleListSplit must be string, config file/ruleListSplit must NOT have fewer than 1 items, config file/ruleListSplit must match a schema in anyOf',
         );
       });
+    });
+  });
+
+  describe('printCliError', function () {
+    it('prints Error.message for Error instances', function () {
+      const consoleErrorStub = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      printCliError(new Error('boom'));
+      expect(consoleErrorStub.mock.calls).toStrictEqual([['boom']]);
+      consoleErrorStub.mockRestore();
+    });
+
+    it('prints String(error) for non-Error throwables', function () {
+      const consoleErrorStub = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      printCliError('boom');
+      expect(consoleErrorStub.mock.calls).toStrictEqual([['boom']]);
+      consoleErrorStub.mockRestore();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Extract CLI catch handling into exported `printCliError()` so non-`Error` throwables (strings/objects) print to stderr instead of exiting with empty output
- Wire the bin entrypoint through `printCliError` and add unit coverage for both `Error` and non-`Error` branches

## Test plan
- [x] `npm run lint`
- [x] `npm test` (including new `printCliError` cases in `test/lib/cli-test.ts`)


Made with [Cursor](https://cursor.com)

## Context

From the post-#987 standards audit: the bin catch only printed `error instanceof Error`, so a non-`Error` throwable (`throw 'boom'`) exited 1 with completely empty stderr — a silent failure with no message to act on.
