### PR TITLE
fix: escape regex metacharacters in rule doc section matching

### DIFF
--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -4,6 +4,7 @@
 
 import { END_RULE_HEADER_MARKER, formatComment } from './comment-markers.js';
 import type { Context } from './context.js';
+import { escapeRegExp } from './string.js';
 
 export function extractFrontmatter(markdown: string) {
   const lines = markdown.split('\n');
@@ -92,7 +93,7 @@ export function findSectionHeader(
   str: string,
 ): string | undefined {
   // Get all the matching strings.
-  const regexp = new RegExp(`## .*${str}.*\n`, 'giu');
+  const regexp = new RegExp(`## .*${escapeRegExp(str)}.*\n`, 'giu');
   const sectionPotentialMatches = [...markdown.matchAll(regexp)].map(
     (match) => match[0],
   );

--- a/lib/string.ts
+++ b/lib/string.ts
@@ -1,3 +1,8 @@
+/** Escape special characters so `str` can be used as a literal in a RegExp. */
+export function escapeRegExp(str: string): string {
+  return str.replaceAll(/[$()*+.?[\\\]^{|}]/gu, String.raw`\$&`);
+}
+
 /** Uppercase the first character of a string, leaving the rest unchanged. */
 function upperFirst(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1);

--- a/test/lib/markdown-test.ts
+++ b/test/lib/markdown-test.ts
@@ -260,6 +260,38 @@ describe('markdown', function () {
         ),
       ).toBe('## Rules\n');
     });
+
+    it('treats character class metacharacters as literal', function () {
+      const title = '## Options [x\n';
+      expect(findSectionHeader(title, 'Options [x')).toBe(title);
+    });
+
+    it('treats parentheses as literal', function () {
+      const markdown = outdent`
+        ## Options advanced
+        Not this one.
+        ## Options (advanced)
+        This one.
+      `;
+      expect(findSectionHeader(markdown, 'Options (advanced)')).toBe(
+        '## Options (advanced)\n',
+      );
+    });
+
+    it('treats plus signs as literal', function () {
+      const title = '## C++\n';
+      expect(findSectionHeader(title, 'C++')).toBe(title);
+    });
+
+    it('treats dots as literal', function () {
+      const markdown = outdent`
+        ## Options X
+        Not this one.
+        ## Options .
+        This one.
+      `;
+      expect(findSectionHeader(markdown, 'Options .')).toBe('## Options .\n');
+    });
   });
 
   describe('replaceOrCreateFrontmatter', function () {

--- a/test/lib/string-test.ts
+++ b/test/lib/string-test.ts
@@ -1,10 +1,26 @@
 import {
   addTrailingPeriod,
+  escapeRegExp,
   removeTrailingPeriod,
   toSentenceCase,
 } from '../../lib/string.js';
 
 describe('strings', function () {
+  describe('#escapeRegExp', function () {
+    it('escapes regex metacharacters', function () {
+      expect(escapeRegExp('Options [x')).toBe(String.raw`Options \[x`);
+      expect(escapeRegExp('Options (advanced)')).toBe(
+        String.raw`Options \(advanced\)`,
+      );
+      expect(escapeRegExp('C++')).toBe(String.raw`C\+\+`);
+      expect(escapeRegExp('Options .')).toBe(String.raw`Options \.`);
+    });
+
+    it('leaves ordinary characters unchanged', function () {
+      expect(escapeRegExp('rules')).toBe('rules');
+    });
+  });
+
   describe('#addTrailingPeriod', function () {
     it('handles when already has period', function () {
       expect(addTrailingPeriod('foo.')).toStrictEqual('foo.');


### PR DESCRIPTION
## Summary
- Escape regex metacharacters in section name needles before `findSectionHeader` builds its `## …` match pattern
- Add `escapeRegExp` helper in `lib/string.ts` (no `RegExp.escape`, no new dependency)
- Cover literal matching for names with `[`, `()`, `+`, and `.`

## Test plan
- [x] `npm run lint && npm test`
- [ ] Repro: `--rule-doc-section-include "Options [x"` exits with the normal missing-header message, not `Invalid regular expression`


Made with [Cursor](https://cursor.com)

## Context

Empirically confirmed during the post-#987 audit against a real plugin repo:

```console
$ npx eslint-doc-generator --rule-doc-section-include "Options [x"
Invalid regular expression: /## .*Options [x.*
/giu: Unterminated character class
```

Section names that are *valid* regex (`.`, `()`, `+`) didn't crash but silently changed matching semantics (e.g. `Options (advanced)` also matched `Options advanced`).

`RegExp.escape` was deliberately not used: it requires Node 24+, and `engines` still allows Node 20.19 / 22.13.
