### PR TITLE
fix: URL-encode rule doc link targets

### DIFF
--- a/lib/rule-link.ts
+++ b/lib/rule-link.ts
@@ -14,10 +14,44 @@ export function replaceRulePlaceholder(
 }
 
 /**
+ * Encode a URL path segment for markdown link destinations.
+ * `encodeURIComponent` leaves `()`, `!` unencoded; CommonMark treats
+ * parentheses as link destination terminators, so encode those too.
+ */
+function encodeUrlPathSegment(segment: string): string {
+  return encodeURIComponent(segment)
+    .replaceAll('(', '%28')
+    .replaceAll(')', '%29')
+    .replaceAll('!', '%21');
+}
+
+/**
+ * Encode each `/`-separated segment of a URL path.
+ */
+function encodeUrlPath(urlPath: string): string {
+  return urlPath
+    .split('/')
+    .map((segment) => encodeUrlPathSegment(segment))
+    .join('/');
+}
+
+/**
  * Account for how Windows paths use backslashes instead of the forward slashes that URLs require.
+ * Also URL-encodes each path segment so spaces, parentheses, etc. are safe in markdown links.
  */
 function pathToUrl(path: string): string {
-  return path.split(sep).join('/');
+  return path
+    .split(sep)
+    .map((segment) => encodeUrlPathSegment(segment))
+    .join('/');
+}
+
+/**
+ * Encode a relative URL path. Absolute URLs (with a scheme) are left as-is so
+ * user-provided `urlRuleDoc` function return values are not corrupted.
+ */
+function encodeUrlIfRelative(url: string): string {
+  return url.includes('://') ? url : encodeUrlPath(url);
 }
 
 /**
@@ -64,15 +98,21 @@ export function getUrlToRule(
     replaceRulePlaceholder(pathRuleDoc, ruleNameWithoutPluginPrefix),
   );
 
-  return (
-    // If the function returned a URL, use it.
-    urlRuleDocFunctionEvaluated ??
-    (typeof urlRuleDoc === 'string'
-      ? // Otherwise, use the URL if it's a string.
-        replaceRulePlaceholder(urlRuleDoc, ruleNameWithoutPluginPrefix)
-      : // Finally, fallback to the relative path.
-        pathToUrl(relative(dirname(pathToFile), pathRuleDocEvaluated)))
-  );
+  // If the function returned a URL, use it (encode relative returns only).
+  if (urlRuleDocFunctionEvaluated !== undefined) {
+    return encodeUrlIfRelative(urlRuleDocFunctionEvaluated);
+  }
+
+  // Otherwise, use the URL if it's a string (encode only the substituted name).
+  if (typeof urlRuleDoc === 'string') {
+    return replaceRulePlaceholder(
+      urlRuleDoc,
+      encodeUrlPath(ruleNameWithoutPluginPrefix),
+    );
+  }
+
+  // Finally, fallback to the relative path.
+  return pathToUrl(relative(dirname(pathToFile), pathRuleDocEvaluated));
 }
 
 export function getMarkdownLink(

--- a/test/lib/generate/__snapshots__/file-paths-test.ts.snap
+++ b/test/lib/generate/__snapshots__/file-paths-test.ts.snap
@@ -138,3 +138,15 @@ exports[`generate (file paths) > multiple rules lists > generates the documentat
 
 <!-- end auto-generated rules list -->"
 `;
+
+exports[`generate (file paths) > rule names with URL-unsafe characters > URL-encodes spaces and parentheses in relative rule doc links 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+| Name                                               | Description                   |
+| :------------------------------------------------- | :---------------------------- |
+| [no foo (bar)](docs/rules/no%20foo%20%28bar%29.md) | Description for no foo (bar). |
+
+<!-- end auto-generated rules list -->
+"
+`;

--- a/test/lib/generate/__snapshots__/option-url-rule-doc-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-url-rule-doc-test.ts.snap
@@ -134,3 +134,39 @@ exports[`generate (--url-rule-doc) > function returns undefined > should fallbac
 <!-- end auto-generated rule header -->
 "
 `;
+
+exports[`generate (--url-rule-doc) > rule names with URL-unsafe characters > URL-encodes relative function return values 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+| Name                                               | Description                   |
+| :------------------------------------------------- | :---------------------------- |
+| [no foo (bar)](docs/rules/no%20foo%20%28bar%29.md) | Description for no foo (bar). |
+
+<!-- end auto-generated rules list -->
+"
+`;
+
+exports[`generate (--url-rule-doc) > rule names with URL-unsafe characters > URL-encodes the substituted rule name in string templates 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+| Name                                                                | Description                   |
+| :------------------------------------------------------------------ | :---------------------------- |
+| [no foo (bar)](https://example.com/rule-docs/no%20foo%20%28bar%29/) | Description for no foo (bar). |
+
+<!-- end auto-generated rules list -->
+"
+`;
+
+exports[`generate (--url-rule-doc) > rule names with URL-unsafe characters > leaves absolute function return values unencoded 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+| Name                                                                | Description                   |
+| :------------------------------------------------------------------ | :---------------------------- |
+| [no foo (bar)](https://example.com/rules/no%20foo%20%28bar%29.html) | Description for no foo (bar). |
+
+<!-- end auto-generated rules list -->
+"
+`;

--- a/test/lib/generate/file-paths-test.ts
+++ b/test/lib/generate/file-paths-test.ts
@@ -276,6 +276,42 @@ describe('generate (file paths)', function () {
     });
   });
 
+  describe('rule names with URL-unsafe characters', function () {
+    let fixture: FixtureContext;
+
+    beforeAll(async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'index.js': `
+              export default {
+                rules: {
+                  'no foo (bar)': {
+                    meta: { docs: { description: 'Description for no foo (bar).' } },
+                    create(context) {}
+                  },
+                },
+              };`,
+          'README.md': '## Rules\n',
+          'docs/rules/no foo (bar).md': '',
+        },
+      });
+    });
+
+    afterAll(async function () {
+      await fixture.cleanup();
+    });
+
+    it('URL-encodes spaces and parentheses in relative rule doc links', async function () {
+      await generate(fixture.path);
+      const readme = await fixture.readFile('README.md');
+      expect(readme).toContain(
+        '[no foo (bar)](docs/rules/no%20foo%20%28bar%29.md)',
+      );
+      expect(readme).toMatchSnapshot();
+    });
+  });
+
   describe('custom path to rule docs using function', function () {
     let fixture: FixtureContext;
 

--- a/test/lib/generate/option-url-rule-doc-test.ts
+++ b/test/lib/generate/option-url-rule-doc-test.ts
@@ -101,6 +101,77 @@ describe('generate (--url-rule-doc)', function () {
     });
   });
 
+  describe('rule names with URL-unsafe characters', function () {
+    let fixture: FixtureContext;
+
+    beforeAll(async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'index.js': `
+          export default {
+            rules: {
+              'no foo (bar)': {
+                meta: {
+                  docs: { description: 'Description for no foo (bar).' }
+                },
+                create(context) {}
+              },
+            },
+          };`,
+          'README.md': '## Rules\n',
+          'docs/rules/no foo (bar).md': '',
+        },
+      });
+    });
+
+    afterAll(async function () {
+      await fixture.cleanup();
+    });
+
+    it('URL-encodes the substituted rule name in string templates', async function () {
+      await generate(fixture.path, {
+        urlRuleDoc: 'https://example.com/rule-docs/{name}/',
+      });
+      const readme = await fixture.readFile('README.md');
+      expect(readme).toContain(
+        '[no foo (bar)](https://example.com/rule-docs/no%20foo%20%28bar%29/)',
+      );
+      // Template prefix/suffix must remain unencoded.
+      expect(readme).toContain('https://example.com/rule-docs/');
+      expect(readme).toMatchSnapshot();
+    });
+
+    it('URL-encodes relative function return values', async function () {
+      await generate(fixture.path, {
+        urlRuleDoc() {
+          return 'docs/rules/no foo (bar).md';
+        },
+      });
+      const readme = await fixture.readFile('README.md');
+      expect(readme).toContain(
+        '[no foo (bar)](docs/rules/no%20foo%20%28bar%29.md)',
+      );
+      expect(readme).not.toContain('(docs/rules/no foo (bar).md)');
+      expect(readme).toMatchSnapshot();
+    });
+
+    it('leaves absolute function return values unencoded', async function () {
+      await generate(fixture.path, {
+        urlRuleDoc() {
+          // Caller owns encoding for absolute URLs.
+          return 'https://example.com/rules/no%20foo%20%28bar%29.html';
+        },
+      });
+      const readme = await fixture.readFile('README.md');
+      expect(readme).toContain(
+        '[no foo (bar)](https://example.com/rules/no%20foo%20%28bar%29.html)',
+      );
+      expect(readme).not.toContain('no%2520foo');
+      expect(readme).toMatchSnapshot();
+    });
+  });
+
   describe('function returns undefined', function () {
     let fixture: FixtureContext;
 


### PR DESCRIPTION
## Summary
- URL-encode each path segment in generated relative rule-doc links (`pathToUrl`), including characters `encodeURIComponent` leaves alone that break CommonMark destinations (`(`, `)`, `!`)
- Encode only the substituted `{name}` portion of string `--url-rule-doc` templates; leave the template itself untouched
- Encode relative `urlRuleDoc` function return values; leave absolute URLs (`://`) as-is so callers own encoding

## Test plan
- [x] `npm run lint`
- [x] `npm test`
- [x] New fixtures with rule name/path `no foo (bar)` assert exact `%20` / `%28` / `%29` in snapshots for relative links, string templates, and relative function returns
- [x] Absolute function return with pre-encoded URL is not double-encoded


Made with [Cursor](https://cursor.com)

## Context

From the post-#987 standards audit: `pathToUrl` handled Windows separator conversion but never URL-encoded, so a rule doc path containing a space or parenthesis produced a broken link — CommonMark terminates a plain link destination at whitespace or an unbalanced `)`. `(`, `)`, and `!` also pass through `encodeURIComponent` untouched, hence the explicit replacements.

Scope guard: only tool-generated relative paths and the substituted `{name}` portion are encoded; user-supplied absolute URLs and template text are left to the caller, so nothing pre-encoded gets double-encoded.
