### PR TITLE
feat: honor EditorConfig insert_final_newline and preserve final-newline state

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,8 @@ Only `lf` and `crlf` are honored from EditorConfig; other values such as `cr` ar
 
 When EditorConfig sets `end_of_line`, files that use a different end of line are converted on the next run (a one-time diff), and `--check` fails until they match. Without an EditorConfig `end_of_line`, existing file endings are preserved and `--check` compares against those.
 
+EditorConfig [`insert_final_newline`](https://editorconfig.org/) is honored the same way when explicitly set for a file path: `true` ensures the file ends with one trailing end of line (existing trailing blank lines are left alone), and `false` strips trailing ends of line. When unset, the final-newline state is left unchanged (byte-identical to previous behavior). `--check` compares post-policy bytes, so a mismatch fails until the next non-check run fixes the file.
+
 ### File Types
 
 This tool supports both regular Markdown (`md`) and Extended Markdown (`mdx`) file types.

--- a/lib/eol.ts
+++ b/lib/eol.ts
@@ -5,9 +5,16 @@ import type { Cache as EditorConfigCache } from 'editorconfig';
 
 type EndOfLine = '\n' | '\r\n';
 
+type EditorConfigLineEndingProps = {
+  endOfLine: EndOfLine | undefined;
+  insertFinalNewline: boolean | undefined;
+};
+
 export type EndOfLineResolver = {
   /** EditorConfig `end_of_line` for the file path, if set. */
   getExplicitEndOfLine: (filePath: string) => Promise<EndOfLine | undefined>;
+  /** EditorConfig `insert_final_newline` for the file path, if set. */
+  getInsertFinalNewline: (filePath: string) => Promise<boolean | undefined>;
   /**
    * Write-time precedence: EditorConfig → detect(contents) → `os.EOL`.
    * New/empty docs pass `contents` as undefined (skip detection).
@@ -30,24 +37,37 @@ export type EndOfLineResolver = {
  * Prettier config is not read — run Prettier via `postprocess` if needed.
  */
 export function createEndOfLineResolver(): EndOfLineResolver {
-  const explicitCache = new Map<string, Promise<EndOfLine | undefined>>();
+  const propsCache = new Map<string, Promise<EditorConfigLineEndingProps>>();
   /** Shared across files so EditorConfig does not re-read the same files. */
   const editorConfigFileCache: EditorConfigCache = new Map();
+
+  function getEditorConfigLineEndingProps(
+    filePath: string,
+  ): Promise<EditorConfigLineEndingProps> {
+    const absolutePath = resolve(filePath);
+    let cached = propsCache.get(absolutePath);
+    if (!cached) {
+      cached = parseEditorConfigLineEndingProps(
+        absolutePath,
+        editorConfigFileCache,
+      );
+      propsCache.set(absolutePath, cached);
+    }
+    return cached;
+  }
 
   async function getExplicitEndOfLine(
     filePath: string,
   ): Promise<EndOfLine | undefined> {
-    const absolutePath = resolve(filePath);
-    let cached = explicitCache.get(absolutePath);
-    if (!cached) {
-      cached = getEndOfLineFromEditorConfig(
-        absolutePath,
-        editorConfigFileCache,
-      );
-      explicitCache.set(absolutePath, cached);
-    }
-    const result = await cached;
-    return result;
+    const props = await getEditorConfigLineEndingProps(filePath);
+    return props.endOfLine;
+  }
+
+  async function getInsertFinalNewline(
+    filePath: string,
+  ): Promise<boolean | undefined> {
+    const props = await getEditorConfigLineEndingProps(filePath);
+    return props.insertFinalNewline;
   }
 
   async function resolveFileEndOfLine(
@@ -63,25 +83,61 @@ export function createEndOfLineResolver(): EndOfLineResolver {
 
   return {
     getExplicitEndOfLine,
+    getInsertFinalNewline,
     resolve: resolveFileEndOfLine,
   };
 }
 
-async function getEndOfLineFromEditorConfig(
+async function parseEditorConfigLineEndingProps(
   filePath: string,
   cache: EditorConfigCache,
-): Promise<EndOfLine | undefined> {
+): Promise<EditorConfigLineEndingProps> {
   const editorConfigProps = await editorconfig.parse(filePath, { cache });
 
+  let endOfLine: EndOfLine | undefined;
   if (editorConfigProps.end_of_line === 'lf') {
-    return '\n';
+    endOfLine = '\n';
+  } else if (editorConfigProps.end_of_line === 'crlf') {
+    endOfLine = '\r\n';
   }
 
-  if (editorConfigProps.end_of_line === 'crlf') {
-    return '\r\n';
+  let insertFinalNewline: boolean | undefined;
+  if (editorConfigProps.insert_final_newline === true) {
+    insertFinalNewline = true;
+  } else if (editorConfigProps.insert_final_newline === false) {
+    insertFinalNewline = false;
   }
 
-  return undefined;
+  return { endOfLine, insertFinalNewline };
+}
+
+/**
+ * Apply EditorConfig `insert_final_newline` at write time.
+ * When unset (`undefined`), returns contents unchanged.
+ */
+export function applyInsertFinalNewline(
+  contents: string,
+  endOfLine: string,
+  insertFinalNewline: boolean | undefined,
+): string {
+  if (insertFinalNewline === undefined) {
+    return contents;
+  }
+
+  if (insertFinalNewline) {
+    // Append one trailing EOL if absent; never trim existing trailing blank lines.
+    if (contents.endsWith(endOfLine)) {
+      return contents;
+    }
+    return contents + endOfLine;
+  }
+
+  // false: strip trailing EOLs so the file does not end with a newline.
+  let result = contents;
+  while (result.endsWith(endOfLine)) {
+    result = result.slice(0, -endOfLine.length);
+  }
+  return result;
 }
 
 /**

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -26,7 +26,11 @@ import { replaceRulePlaceholder } from './rule-link.js';
 import { updateRuleOptionsList } from './rule-options-list.js';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { getContext } from './context.js';
-import { createEndOfLineResolver, normalizeEndOfLine } from './eol.js';
+import {
+  applyInsertFinalNewline,
+  createEndOfLineResolver,
+  normalizeEndOfLine,
+} from './eol.js';
 import { generateSuggestedEmojis } from './suggest-emojis.js';
 import { generateFrontmatterLines } from './frontmatter.js';
 
@@ -166,9 +170,15 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
         pathToDoc,
         undefined,
       );
+      const newDocInsertFinalNewline =
+        await endOfLineResolver.getInsertFinalNewline(pathToDoc);
       await writeFile(
         pathToDoc,
-        normalizeEndOfLine(newRuleDocContents, newDocEndOfLine),
+        applyInsertFinalNewline(
+          normalizeEndOfLine(newRuleDocContents, newDocEndOfLine),
+          newDocEndOfLine,
+          newDocInsertFinalNewline,
+        ),
       );
       initializedRuleDoc = true;
     }
@@ -211,6 +221,11 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     // Convert to the doc's end of line before postprocessing and writing.
     contentsNew = normalizeEndOfLine(contentsNew, endOfLine);
     contentsNew = await postprocess(contentsNew, resolve(pathToDoc));
+    contentsNew = applyInsertFinalNewline(
+      contentsNew,
+      endOfLine,
+      await endOfLineResolver.getInsertFinalNewline(pathToDoc),
+    );
 
     // LF-normalized copy of the final contents for the content checks below.
     const contentsNewNormalized = normalizeEndOfLine(contentsNew, '\n');
@@ -308,12 +323,16 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
       fileContentsNormalized,
       pathToFile,
     );
-    const fileContentsNew = await postprocess(
-      normalizeEndOfLine(
-        updateConfigsList(context, rulesList, isRuleListMdx),
-        endOfLine,
+    const fileContentsNew = applyInsertFinalNewline(
+      await postprocess(
+        normalizeEndOfLine(
+          updateConfigsList(context, rulesList, isRuleListMdx),
+          endOfLine,
+        ),
+        resolve(pathToFile),
       ),
-      resolve(pathToFile),
+      endOfLine,
+      await endOfLineResolver.getInsertFinalNewline(pathToFile),
     );
 
     if (check) {

--- a/test/lib/generate/eol-test.ts
+++ b/test/lib/generate/eol-test.ts
@@ -1,5 +1,6 @@
 import { generate } from '../../../lib/generator.js';
 import {
+  applyInsertFinalNewline,
   createEndOfLineResolver,
   detectEndOfLine,
   getFallbackEndOfLine,
@@ -7,6 +8,7 @@ import {
 } from '../../../lib/eol.js';
 import { EOL } from 'node:os';
 import { join } from 'node:path';
+import { writeFile } from 'node:fs/promises';
 import { setupFixture, type FixtureContext } from '../../helpers/fixture.js';
 
 function assertUniformEndOfLine(contents: string, endOfLine: '\n' | '\r\n') {
@@ -17,6 +19,18 @@ function assertUniformEndOfLine(contents: string, endOfLine: '\n' | '\r\n') {
   } else {
     expect(contents.includes('\r')).toBe(false);
   }
+}
+
+function endsWithEndOfLine(contents: string, endOfLine: '\n' | '\r\n') {
+  return contents.endsWith(endOfLine);
+}
+
+function stripTrailingEndOfLines(contents: string, endOfLine: '\n' | '\r\n') {
+  let result = contents;
+  while (result.endsWith(endOfLine)) {
+    result = result.slice(0, -endOfLine.length);
+  }
+  return result;
 }
 
 describe('detectEndOfLine', function () {
@@ -58,6 +72,43 @@ describe('normalizeEndOfLine', function () {
     expect(normalizeEndOfLine('a\rb\nc\r\n', '\r\n')).toStrictEqual(
       'a\r\nb\r\nc\r\n',
     );
+  });
+});
+
+describe('applyInsertFinalNewline', function () {
+  it('returns contents unchanged when insert_final_newline is unset', function () {
+    expect(applyInsertFinalNewline('a\n', '\n', undefined)).toStrictEqual(
+      'a\n',
+    );
+    expect(applyInsertFinalNewline('a', '\n', undefined)).toStrictEqual('a');
+  });
+
+  it('appends one trailing EOL when true and absent', function () {
+    expect(applyInsertFinalNewline('a', '\n', true)).toStrictEqual('a\n');
+    expect(applyInsertFinalNewline('a', '\r\n', true)).toStrictEqual('a\r\n');
+  });
+
+  it('leaves a single trailing EOL alone when true', function () {
+    expect(applyInsertFinalNewline('a\n', '\n', true)).toStrictEqual('a\n');
+    expect(applyInsertFinalNewline('a\r\n', '\r\n', true)).toStrictEqual(
+      'a\r\n',
+    );
+  });
+
+  it('never trims existing trailing blank lines when true', function () {
+    expect(applyInsertFinalNewline('a\n\n', '\n', true)).toStrictEqual('a\n\n');
+    expect(applyInsertFinalNewline('a\r\n\r\n', '\r\n', true)).toStrictEqual(
+      'a\r\n\r\n',
+    );
+  });
+
+  it('strips all trailing EOLs when false', function () {
+    expect(applyInsertFinalNewline('a\n', '\n', false)).toStrictEqual('a');
+    expect(applyInsertFinalNewline('a\n\n', '\n', false)).toStrictEqual('a');
+    expect(applyInsertFinalNewline('a\r\n\r\n', '\r\n', false)).toStrictEqual(
+      'a',
+    );
+    expect(applyInsertFinalNewline('a', '\n', false)).toStrictEqual('a');
   });
 });
 
@@ -214,6 +265,79 @@ describe('createEndOfLineResolver', function () {
       expect(
         await eol.getExplicitEndOfLine(join(fixture.path, 'README.md')),
       ).toBeUndefined();
+    });
+
+    it('returns true when ".editorconfig" sets insert_final_newline = true', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          '.editorconfig': `
+                  root = true
+
+                  [*]
+                  insert_final_newline = true`,
+        },
+      });
+
+      const eol = createEndOfLineResolver();
+      expect(
+        await eol.getInsertFinalNewline(join(fixture.path, 'README.md')),
+      ).toBe(true);
+    });
+
+    it('returns false when ".editorconfig" sets insert_final_newline = false', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          '.editorconfig': `
+                  root = true
+
+                  [*]
+                  insert_final_newline = false`,
+        },
+      });
+
+      const eol = createEndOfLineResolver();
+      expect(
+        await eol.getInsertFinalNewline(join(fixture.path, 'README.md')),
+      ).toBe(false);
+    });
+
+    it('returns undefined when insert_final_newline is unset', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          '.editorconfig': `
+                  root = true
+
+                  [*]
+                  end_of_line = lf`,
+        },
+      });
+
+      const eol = createEndOfLineResolver();
+      expect(
+        await eol.getInsertFinalNewline(join(fixture.path, 'README.md')),
+      ).toBeUndefined();
+    });
+
+    it('parses end_of_line and insert_final_newline from one EditorConfig read', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          '.editorconfig': `
+                  root = true
+
+                  [*]
+                  end_of_line = crlf
+                  insert_final_newline = true`,
+        },
+      });
+
+      const eol = createEndOfLineResolver();
+      const readmePath = join(fixture.path, 'README.md');
+      expect(await eol.getExplicitEndOfLine(readmePath)).toStrictEqual('\r\n');
+      expect(await eol.getInsertFinalNewline(readmePath)).toBe(true);
     });
   });
 
@@ -783,6 +907,179 @@ describe('generate with end of line', function () {
         await fixture.readFile('docs/rules/no-foo.md'),
         '\r\n',
       );
+    });
+  });
+
+  describe('insert_final_newline', function () {
+    let fixture: FixtureContext;
+
+    afterEach(async function () {
+      await fixture.cleanup();
+    });
+
+    const endOfLineCases = [
+      { label: 'lf', endOfLine: '\n' as const, editorConfigValue: 'lf' },
+      { label: 'crlf', endOfLine: '\r\n' as const, editorConfigValue: 'crlf' },
+    ];
+    const insertFinalNewlineCases: Array<{
+      label: string;
+      value: boolean | undefined;
+      editorConfigLine: string;
+    }> = [
+      {
+        label: 'true',
+        value: true,
+        editorConfigLine: 'insert_final_newline = true',
+      },
+      {
+        label: 'false',
+        value: false,
+        editorConfigLine: 'insert_final_newline = false',
+      },
+      {
+        label: 'unset',
+        value: undefined,
+        editorConfigLine: '',
+      },
+    ];
+    const trailingNewlineCases = [true, false];
+
+    for (const {
+      label: eolLabel,
+      endOfLine,
+      editorConfigValue,
+    } of endOfLineCases) {
+      for (const {
+        label: insertLabel,
+        value: insertFinalNewline,
+        editorConfigLine,
+      } of insertFinalNewlineCases) {
+        for (const hasTrailingNewline of trailingNewlineCases) {
+          it(`honors insert_final_newline=${insertLabel} with ${eolLabel} when file ${hasTrailingNewline ? 'has' : 'lacks'} a trailing newline`, async function () {
+            // Body content controls the natural trailing-newline state for rule
+            // docs (empty body always ends with a header newline).
+            const ruleDocBody = hasTrailingNewline
+              ? 'Some description.\n'
+              : 'Some description.';
+            const ruleDoc = normalizeEndOfLine(
+              `# test/no-foo\n\n<!-- end auto-generated rule header -->\n\n${ruleDocBody}`,
+              endOfLine,
+            );
+            const editorConfigWithoutInsert = [
+              'root = true',
+              '',
+              '[*]',
+              `end_of_line = ${editorConfigValue}`,
+            ].join('\n');
+            const editorConfig = [
+              editorConfigWithoutInsert,
+              ...(editorConfigLine === '' ? [] : [editorConfigLine]),
+            ].join('\n');
+
+            fixture = await setupFixture({
+              fixture: 'esm-base',
+              overrides: {
+                'docs/rules/no-foo.md': ruleDoc,
+                'README.md': normalizeEndOfLine(
+                  '## Rules\n\n<!-- begin auto-generated rules list -->\n<!-- end auto-generated rules list -->\n',
+                  endOfLine,
+                ),
+                '.editorconfig': editorConfigWithoutInsert,
+              },
+            });
+
+            // Baseline without insert_final_newline for the snapshot guard.
+            await generate(fixture.path);
+            const baselineWithoutTrailing = stripTrailingEndOfLines(
+              await fixture.readFile('docs/rules/no-foo.md'),
+              endOfLine,
+            );
+
+            // Restore the body's trailing-newline state, then apply policy.
+            await writeFile(
+              join(fixture.path, 'docs/rules/no-foo.md'),
+              hasTrailingNewline
+                ? baselineWithoutTrailing + endOfLine
+                : baselineWithoutTrailing,
+            );
+            await writeFile(join(fixture.path, '.editorconfig'), editorConfig);
+            await generate(fixture.path);
+
+            const ruleDocAfter = await fixture.readFile('docs/rules/no-foo.md');
+            assertUniformEndOfLine(ruleDocAfter, endOfLine);
+
+            const expectedTrailingNewline =
+              insertFinalNewline === undefined
+                ? hasTrailingNewline
+                : insertFinalNewline;
+            expect(endsWithEndOfLine(ruleDocAfter, endOfLine)).toBe(
+              expectedTrailingNewline,
+            );
+
+            // Snapshot guard: policy must not change non-trailing content.
+            expect(ruleDocAfter).toContain('Some description.');
+            expect(
+              stripTrailingEndOfLines(ruleDocAfter, endOfLine),
+            ).toStrictEqual(baselineWithoutTrailing);
+          });
+        }
+      }
+    }
+
+    it('fails --check when insert_final_newline = true and the file lacks a trailing newline', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'docs/rules/no-foo.md': '',
+          'README.md':
+            '## Rules\n\n<!-- begin auto-generated rules list -->\n<!-- end auto-generated rules list -->\n',
+          '.editorconfig': `
+                root = true
+
+                [*]
+                end_of_line = lf
+                insert_final_newline = true`,
+        },
+      });
+
+      await generate(fixture.path);
+      const readme = await fixture.readFile('README.md');
+      expect(endsWithEndOfLine(readme, '\n')).toBe(true);
+
+      // Remove the trailing newline so --check should fail.
+      await writeFile(
+        join(fixture.path, 'README.md'),
+        stripTrailingEndOfLines(readme, '\n'),
+      );
+
+      process.exitCode = undefined;
+      await generate(fixture.path, { check: true });
+      expect(process.exitCode).toBe(1);
+      process.exitCode = undefined;
+    });
+
+    it('does not trim existing trailing blank lines when insert_final_newline = true', async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'docs/rules/no-foo.md':
+            '# Description of no-foo (`test/no-foo`)\n\n<!-- end auto-generated rule header -->\n\nSome description.\n\n',
+          'README.md':
+            '## Rules\n\n<!-- begin auto-generated rules list -->\n<!-- end auto-generated rules list -->\n',
+          '.editorconfig': `
+                root = true
+
+                [*]
+                end_of_line = lf
+                insert_final_newline = true`,
+        },
+      });
+
+      await generate(fixture.path);
+
+      const ruleDoc = await fixture.readFile('docs/rules/no-foo.md');
+      expect(ruleDoc.endsWith('\n\n')).toBe(true);
+      expect(ruleDoc).toContain('Some description.');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Extend the EditorConfig EOL resolver so one memoized parse yields both `end_of_line` and `insert_final_newline`
- Apply write-time `insert_final_newline` policy after EOL conversion on all three write paths (init rule doc, rule doc, rule list), including `--check` comparisons
- When unset, leave final-newline state unchanged (byte-identical to previous behavior); document the new behavior in the README Line endings section

## Test plan
- [x] `npm run lint`
- [x] `npm test` (includes matrix `{true, false, unset} × {with, without trailing newline} × {LF, CRLF}`, `--check` failure when `insert_final_newline=true` and the file lacks a trailing newline, and a snapshot guard that non-trailing content is unchanged)


Made with [Cursor](https://cursor.com)

## Context

Maintainer decision recorded here for reviewers: this acts **only when EditorConfig explicitly sets `insert_final_newline`**. When unset, no policy code path runs and output is byte-identical to current behavior (verified empirically pre-PR: a doc missing its final newline keeps missing it today, and continues to unless EditorConfig says otherwise).

Heads-up for sequencing: #1002 (UTF-8 BOM handling) is **stacked on this branch** (it composes with the same write pipeline: EOL conversion → final-newline policy → BOM restore), so this PR should merge first.
