### PR TITLE
fix: match section headers per CommonMark ATX rules

### DIFF
--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -86,32 +86,55 @@ export function replaceOrCreateHeader(
 }
 
 /**
+ * CommonMark ATX heading: 0–3 leading spaces, 1–6 `#`, whitespace, text, optional closing hashes.
+ * Operates on LF-normalized lines.
+ */
+const ATX_HEADING_REGEX = /^ {0,3}(#{1,6})[ \t]+(.+?)(?:[ \t]+#+[ \t]*)?$/u;
+
+function parseAtxHeading(
+  line: string,
+): { level: number; text: string } | undefined {
+  const match = ATX_HEADING_REGEX.exec(line);
+  const hashes = match?.[1];
+  const text = match?.[2];
+  if (!hashes || text === undefined) {
+    return undefined;
+  }
+  return { level: hashes.length, text };
+}
+
+/**
  * Find the section most likely to be the top-level section for a given string.
+ * Prefers level-2 ATX headings, then falls back to other levels; among ties, picks the shortest.
  */
 export function findSectionHeader(
   markdown: string,
   str: string,
 ): string | undefined {
-  // Get all the matching strings.
-  const regexp = new RegExp(`## .*${escapeRegExp(str)}.*\n`, 'giu');
-  const sectionPotentialMatches = [...markdown.matchAll(regexp)].map(
-    (match) => match[0],
-  );
+  const lines = markdown.split('\n');
+  const needle = new RegExp(escapeRegExp(str), 'iu');
+  const matches: { header: string; level: number }[] = [];
 
-  if (sectionPotentialMatches.length === 0) {
-    // No section found.
+  for (const [i, line] of lines.entries()) {
+    const heading = parseAtxHeading(line);
+    if (!heading || !needle.test(heading.text)) {
+      continue;
+    }
+    // Preserve whether this line had a trailing newline in the source.
+    const header = i < lines.length - 1 ? `${line}\n` : line;
+    matches.push({ header, level: heading.level });
+  }
+
+  if (matches.length === 0) {
     return undefined;
   }
 
-  if (sectionPotentialMatches.length === 1) {
-    // If there's only one match, we can assume it's the section.
-    return sectionPotentialMatches[0];
-  }
+  const level2Matches = matches.filter(({ level }) => level === 2);
+  const candidates = level2Matches.length > 0 ? level2Matches : matches;
 
   // Otherwise assume the shortest match is the correct one.
-  return sectionPotentialMatches.toSorted(
-    (a: string, b: string) => a.length - b.length,
-  )[0];
+  return candidates.toSorted((a, b) => a.header.length - b.header.length)[0]
+    ?.header;
 }
 
 export function findFinalHeaderLevel(
@@ -123,15 +146,15 @@ export function findFinalHeaderLevel(
   } = context;
 
   const lines = str.split('\n');
-  const finalHeader = lines
-    .toReversed()
-    .find((line) => line.match('^(#+) .+$'));
-
-  if (finalHeader) {
-    return finalHeader.indexOf(' ');
+  for (const line of lines.toReversed()) {
+    const heading = parseAtxHeading(line);
+    if (heading) {
+      return heading.level;
+    }
   }
+
   // If the framework is `starlight` and there's frontmatter at the top, treat that as an H1
-  else if (framework === 'starlight' && extractFrontmatter(str)) {
+  if (framework === 'starlight' && extractFrontmatter(str)) {
     return 1;
   }
 

--- a/test/lib/generate/option-rule-doc-section-test.ts
+++ b/test/lib/generate/option-rule-doc-section-test.ts
@@ -35,6 +35,38 @@ describe('generate (rule doc sections)', function () {
     });
   });
 
+  describe('with `--rule-doc-section-include` matching a level-3 heading', function () {
+    let fixture: FixtureContext;
+
+    beforeAll(async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'index.js': `
+              export default {
+                rules: {
+                  'no-foo': { meta: { docs: { description: 'Description for no-foo.'} }, create(context) {} },
+                },
+              };`,
+          'README.md': '## Rules\n',
+          'docs/rules/no-foo.md': '### Examples\n',
+        },
+      });
+    });
+
+    afterAll(async function () {
+      await fixture.cleanup();
+    });
+
+    it('has no issues', async function () {
+      await expect(
+        generate(fixture.path, {
+          ruleDocSectionInclude: ['Examples'],
+        }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
   describe('with `--rule-doc-section-include` and `--rule-doc-section-exclude` and problems', function () {
     let fixture: FixtureContext;
 

--- a/test/lib/markdown-test.ts
+++ b/test/lib/markdown-test.ts
@@ -114,6 +114,19 @@ describe('markdown', function () {
         expect(findFinalHeaderLevel(context, 'Description')).toBeUndefined();
       });
 
+      it('should detect closed ATX heading level', function () {
+        const markdown = outdent`
+          # Header
+          Some description
+          ## Rules ##
+        `;
+        expect(findFinalHeaderLevel(context, markdown)).toBe(2);
+      });
+
+      it('should detect closed ATX heading with tabs after opening hashes', function () {
+        expect(findFinalHeaderLevel(context, '##\tRules\t##')).toBe(2);
+      });
+
       it('should ignore frontmatter', function () {
         expect(
           findFinalHeaderLevel(
@@ -291,6 +304,40 @@ describe('markdown', function () {
         This one.
       `;
       expect(findSectionHeader(markdown, 'Options .')).toBe('## Options .\n');
+    });
+
+    it('handles closed ATX headings', function () {
+      const title = '## Options ##\n';
+      expect(findSectionHeader(title, 'Options')).toBe(title);
+    });
+
+    it('finds level-3 headings when no level-2 match exists', function () {
+      const markdown = outdent`
+        # Rule
+        ### Examples
+        Examples here.
+      `;
+      expect(findSectionHeader(markdown, 'Examples')).toBe('### Examples\n');
+    });
+
+    it('prefers level-2 over other heading levels', function () {
+      const markdown = outdent`
+        # Examples overview
+        ### Examples details
+        ## Examples
+        Body.
+      `;
+      expect(findSectionHeader(markdown, 'Examples')).toBe('## Examples\n');
+    });
+
+    it('handles heading as the last line without a trailing newline', function () {
+      expect(findSectionHeader('## Options', 'Options')).toBe('## Options');
+    });
+
+    it('handles closed ATX heading as the last line without a trailing newline', function () {
+      expect(findSectionHeader('## Options ##', 'Options')).toBe(
+        '## Options ##',
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- Parse ATX headings line-by-line with CommonMark rules (levels 1–6, optional closing hashes, optional trailing newline) in `findSectionHeader` / `findFinalHeaderLevel`.
- Keep level-2 preference with fallback to other levels; reuse `escapeRegExp` for the section needle (no remark dependency).
- Stacked on #995 (`fix/section-header-regex-escape`). **Retarget base to `main` once #995 merges.** Lowest priority of the standardization wave.

## Test plan
- [x] `npm run lint && npm test`
- [x] Unit tests: closed ATX, `###` fallback, heading as last line without newline, `findFinalHeaderLevel` on closed ATX
- [x] Generate test: `--rule-doc-section-include` finds `### Examples`


Made with [Cursor](https://cursor.com)

## Context

From the post-#987 standards audit: only exact `## `-prefixed level-2 headings with a trailing `\n` were found — closed ATX (`## Options ##`), other levels, and a heading on the file's last line were all missed — and `findFinalHeaderLevel` derived the level from `indexOf(' ')`, which breaks on closed ATX. Kept hand-rolled and line-based on LF-normalized content (the #987 invariant) rather than adding a remark dependency.
