### PR TITLE
fix: parse frontmatter with a YAML parser

### DIFF
--- a/lib/frontmatter.ts
+++ b/lib/frontmatter.ts
@@ -1,15 +1,93 @@
+import {
+  Document,
+  Pair,
+  Scalar,
+  isMap,
+  isScalar,
+  parseDocument,
+  type YAMLMap,
+} from 'yaml';
 import type { Context } from './context.js';
 import { makeRuleDocTitle } from './rule-doc-title.js';
 
-function formatFrontmatterProperty(key: string, value: string): string {
-  const escaped = value
-    .replaceAll('\\', '\\\\')
-    .replaceAll('"', String.raw`\"`);
-  return `${key}: "${escaped}"`;
+/** Create a double-quoted YAML scalar (matches prior frontmatter quoting style). */
+function quotedScalar(doc: Document, value: string): Scalar {
+  const node = doc.createNode(value);
+  if (isScalar(node)) {
+    node.type = Scalar.QUOTE_DOUBLE;
+    return node;
+  }
+  const scalar = new Scalar(value);
+  scalar.type = Scalar.QUOTE_DOUBLE;
+  return scalar;
+}
+
+function ensureMap(doc: Document): YAMLMap {
+  if (isMap(doc.contents)) {
+    return doc.contents;
+  }
+  const map = doc.createNode({});
+  if (!isMap(map)) {
+    throw new TypeError('Expected YAML map for frontmatter');
+  }
+  // Document.contents is the mutable AST root for round-tripping.
+  // eslint-disable-next-line no-param-reassign -- yaml Document API
+  doc.contents = map;
+  return map;
+}
+
+function keyEquals(pair: Pair, key: string): boolean {
+  return isScalar(pair.key) && pair.key.value === key;
+}
+
+/**
+ * Set a top-level frontmatter string property via the YAML Document API so
+ * unrelated keys/comments keep their existing formatting.
+ */
+function setFrontmatterString(
+  doc: Document,
+  key: 'title' | 'description',
+  value: string,
+): void {
+  const map = ensureMap(doc);
+  const valueNode = quotedScalar(doc, value);
+
+  if (doc.has(key)) {
+    doc.set(key, valueNode);
+    return;
+  }
+
+  const pair = new Pair(doc.createNode(key), valueNode);
+  if (key === 'title') {
+    // Match prior behavior: insert missing title at the top of the map.
+    map.items.unshift(pair);
+    return;
+  }
+
+  const titleIndex = map.items.findIndex((item) => keyEquals(item, 'title'));
+  if (titleIndex === -1) {
+    map.items.unshift(pair);
+  } else {
+    map.items.splice(titleIndex + 1, 0, pair);
+  }
+}
+
+function serializeFrontmatterDocument(
+  doc: Document,
+  openingFence: string,
+  closingFence: string,
+): string {
+  const body = doc.toString({ lineWidth: 0 }).replace(/\n$/u, '');
+  if (body === '') {
+    return `${openingFence}\n${closingFence}`;
+  }
+  return `${openingFence}\n${body}\n${closingFence}`;
 }
 
 /**
  * Generate yml frontmatter for a particular rule.
+ * Only YAML frontmatter (`---` … `---` / `...`) is supported; TOML `+++` and
+ * JSON frontmatter are not.
  * @returns new frontmatter lines (including ---)
  */
 export function generateFrontmatterLines(
@@ -23,57 +101,32 @@ export function generateFrontmatterLines(
   } = context;
   const title = makeRuleDocTitle(context, name, description);
 
-  const oldFrontmatterLines = frontmatterOld ? frontmatterOld.split('\n') : [];
-
   // If the framework is 'none', then just bail out and return the old frontmatter.
   // We don't want to change anything.
   if (framework === 'none') {
-    return oldFrontmatterLines.join('\n');
+    return frontmatterOld ?? '';
   }
 
   // If there is currently no frontmatter, then create a new one with the title and description.
-  if (oldFrontmatterLines.length === 0) {
-    const newFrontmatter = ['---', formatFrontmatterProperty('title', title)];
+  if (!frontmatterOld) {
+    const doc = new Document();
+    ensureMap(doc);
+    setFrontmatterString(doc, 'title', title);
     if (description) {
-      newFrontmatter.push(
-        formatFrontmatterProperty('description', description),
-      );
+      setFrontmatterString(doc, 'description', description);
     }
-    newFrontmatter.push('---');
-    return newFrontmatter.join('\n');
+    return serializeFrontmatterDocument(doc, '---', '---');
   }
 
-  const newFrontmatter = [];
-  let titleSeen = false;
-  let descriptionSeen = false;
-  for (const line of oldFrontmatterLines) {
-    if (line.startsWith('title:')) {
-      newFrontmatter.push(formatFrontmatterProperty('title', title));
-      titleSeen = true;
-    } else if (line.startsWith('description:') && description) {
-      newFrontmatter.push(
-        formatFrontmatterProperty('description', description),
-      );
-      descriptionSeen = true;
-    } else {
-      newFrontmatter.push(line);
-    }
-  }
+  const lines = frontmatterOld.split('\n');
+  const openingFence = lines[0] ?? '---';
+  const closingFence = lines.at(-1) ?? '---';
+  const body = lines.slice(1, -1).join('\n');
 
-  // If the old frontmatter didn't have a 'title', then add it to the beginning of the frontmatter (after the opening ---).
-  if (!titleSeen) {
-    newFrontmatter.splice(1, 0, formatFrontmatterProperty('title', title));
+  const doc = parseDocument(body);
+  setFrontmatterString(doc, 'title', title);
+  if (description) {
+    setFrontmatterString(doc, 'description', description);
   }
-  // If the old frontmatter didn't have a 'description' but we have one, then add it after the title.
-  if (description && !descriptionSeen) {
-    const titleIndex = newFrontmatter.findIndex((line) =>
-      line.startsWith('title:'),
-    );
-    newFrontmatter.splice(
-      titleIndex + 1,
-      0,
-      formatFrontmatterProperty('description', description),
-    );
-  }
-  return newFrontmatter.join('\n');
+  return serializeFrontmatterDocument(doc, openingFence, closingFence);
 }

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -5,19 +5,40 @@
 import { END_RULE_HEADER_MARKER, formatComment } from './comment-markers.js';
 import type { Context } from './context.js';
 
-export function extractFrontmatter(markdown: string) {
-  const lines = markdown.split('\n');
-  const frontMatterStart = lines.indexOf('---');
+/** Opening YAML frontmatter fence (`---` with optional trailing whitespace). */
+const FRONTMATTER_OPENING_FENCE = /^---\s*$/u;
 
-  // Frontmatter must start at the beginning of the file to be considered valid, so if we don't find '---' at the beginning, we want to ignore it.
-  if (frontMatterStart !== 0) {
+/** Closing YAML frontmatter fence (`---` or `...` with optional trailing whitespace). */
+const FRONTMATTER_CLOSING_FENCE = /^(---|\.\.\.)\s*$/u;
+
+/**
+ * Find a YAML frontmatter block at the start of the file.
+ * Only YAML `---` fences are supported (not TOML `+++` or JSON frontmatter).
+ * @returns inclusive start/end line indexes, or undefined if not found
+ */
+function findFrontmatterRange(
+  lines: readonly string[],
+): { start: number; end: number } | undefined {
+  const firstLine = lines[0];
+  if (firstLine === undefined || !FRONTMATTER_OPENING_FENCE.test(firstLine)) {
     return undefined;
   }
-  const frontMatterEnd = lines.indexOf('---', frontMatterStart + 1);
-  if (frontMatterEnd !== -1) {
-    return lines.slice(frontMatterStart, frontMatterEnd + 1).join('\n');
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line !== undefined && FRONTMATTER_CLOSING_FENCE.test(line)) {
+      return { start: 0, end: i };
+    }
   }
   return undefined;
+}
+
+export function extractFrontmatter(markdown: string) {
+  const lines = markdown.split('\n');
+  const range = findFrontmatterRange(lines);
+  if (!range) {
+    return undefined;
+  }
+  return lines.slice(range.start, range.end + 1).join('\n');
 }
 
 /**
@@ -35,16 +56,14 @@ export function replaceOrCreateFrontmatter(
   }
 
   const lines = markdown.split('\n');
+  const range = findFrontmatterRange(lines);
 
-  const frontmatterStartIndex = lines.indexOf('---');
-
-  // If there's no existing frontmatter, just add it to the top.
-  if (frontmatterStartIndex !== 0) {
+  // If there's no valid existing frontmatter, just add it to the top.
+  if (!range) {
     return [newFrontmatter, markdown].join('\n');
   }
 
-  const frontmatterEndIndex = lines.indexOf('---', frontmatterStartIndex + 1);
-  const postFrontmatter = lines.slice(frontmatterEndIndex + 1).join('\n');
+  const postFrontmatter = lines.slice(range.end + 1).join('\n');
   return [newFrontmatter, postFrontmatter].join('\n');
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "markdown-table": "^3.0.3",
         "node-emoji": "^2.2.0",
         "table": "^6.9.0",
-        "type-fest": "^5.3.1"
+        "type-fest": "^5.3.1",
+        "yaml": "^2.9.0"
       },
       "bin": {
         "eslint-doc-generator": "dist/bin/eslint-doc-generator.js"
@@ -8707,6 +8708,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "markdown-table": "^3.0.3",
     "node-emoji": "^2.2.0",
     "table": "^6.9.0",
-    "type-fest": "^5.3.1"
+    "type-fest": "^5.3.1",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.0",

--- a/test/lib/frontmatter-test.ts
+++ b/test/lib/frontmatter-test.ts
@@ -179,6 +179,97 @@ describe('frontmatter', function () {
           ),
         ).toBe(expected);
       });
+
+      it('should replace a block scalar title', function () {
+        const oldFrontmatter = outdent`
+          ---
+          title: |
+            old
+            multiline
+          foo: bar
+          ---
+        `;
+
+        const expected = outdent`
+          ---
+          title: "eslint-doc-generator/no-foo"
+          description: "Description for no-foo."
+          foo: bar
+          ---
+        `;
+        expect(
+          generateFrontmatterLines(context, name, description, oldFrontmatter),
+        ).toBe(expected);
+      });
+
+      it('should escape quotes and newlines in description', function () {
+        const descriptionSpecial = 'Say "hi"\nand bye.';
+
+        const oldFrontmatter = outdent`
+          ---
+          title: "eslint-doc-generator/no-bar"
+          ---
+        `;
+
+        const expected = outdent`
+          ---
+          title: "eslint-doc-generator/no-foo"
+          description: "Say \\"hi\\"\\nand bye."
+          ---
+        `;
+        expect(
+          generateFrontmatterLines(
+            context,
+            name,
+            descriptionSpecial,
+            oldFrontmatter,
+          ),
+        ).toBe(expected);
+      });
+
+      it('should preserve comments and unrelated keys when updating', function () {
+        const oldFrontmatter = outdent`
+          ---
+          # keep this comment
+          foo: bar
+          # title comment stays above title
+          title: "eslint-doc-generator/no-bar"
+          ---
+        `;
+
+        const expected = outdent`
+          ---
+          # keep this comment
+          foo: bar
+          # title comment stays above title
+          title: "eslint-doc-generator/no-foo"
+          description: "Description for no-foo."
+          ---
+        `;
+        expect(
+          generateFrontmatterLines(context, name, description, oldFrontmatter),
+        ).toBe(expected);
+      });
+
+      it('should accept opening fence with trailing space and ... terminator', function () {
+        const oldFrontmatter = [
+          '--- ',
+          'foo: bar',
+          'title: "eslint-doc-generator/no-bar"',
+          '...',
+        ].join('\n');
+
+        const expected = [
+          '--- ',
+          'foo: bar',
+          'title: "eslint-doc-generator/no-foo"',
+          'description: "Description for no-foo."',
+          '...',
+        ].join('\n');
+        expect(
+          generateFrontmatterLines(context, name, description, oldFrontmatter),
+        ).toBe(expected);
+      });
     });
   });
 });

--- a/test/lib/markdown-test.ts
+++ b/test/lib/markdown-test.ts
@@ -71,6 +71,31 @@ describe('markdown', function () {
       expect(context).toBeDefined();
       expect(extractFrontmatter(markdown)).toBeUndefined();
     });
+
+    it('should extract frontmatter when the opening fence has trailing whitespace', function () {
+      const markdown = ['--- ', 'title: Test Rule', '---', '# Test Rule'].join(
+        '\n',
+      );
+
+      expect(extractFrontmatter(markdown)).toBe(
+        ['--- ', 'title: Test Rule', '---'].join('\n'),
+      );
+    });
+
+    it('should extract frontmatter terminated with ...', function () {
+      const markdown = outdent`
+        ---
+        title: Test Rule
+        ...
+        # Test Rule
+      `;
+
+      expect(extractFrontmatter(markdown)).toBe(outdent`
+        ---
+        title: Test Rule
+        ...
+      `);
+    });
   });
 
   describe('findFinalHeaderLevel', function () {
@@ -309,6 +334,24 @@ describe('markdown', function () {
         ---
         title: Old Rule
         ---
+        Rule description.
+      `;
+      const newFrontmatter = outdent`
+        ---
+        title: New Rule
+        ---
+      `;
+
+      expect(replaceOrCreateFrontmatter(markdown, newFrontmatter)).toBe(
+        `${newFrontmatter}\nRule description.`,
+      );
+    });
+
+    it('should replace frontmatter terminated with ...', function () {
+      const markdown = outdent`
+        ---
+        title: Old Rule
+        ...
         Rule description.
       `;
       const newFrontmatter = outdent`


### PR DESCRIPTION
## Summary
- Parse and update rule-doc YAML frontmatter with the `yaml` Document API (`parseDocument` / `doc.set`) so unrelated keys, comments, and formatting round-trip instead of line-based `title:` / `description:` rewrites.
- Accept standard YAML fence variants: opening `/^---\s*$/`, closing `/^(---|\.\.\.)\s*$/` (YAML-only; TOML `+++` / JSON frontmatter remain unsupported).
- Remove hand-rolled `formatFrontmatterProperty`; quoting/escaping is handled by the YAML serializer (double-quoted scalars to match prior simple-frontmatter output).

## Output-churn risk
**Flagged:** this can change bytes for non-simple frontmatter even when title/description values are unchanged in meaning — e.g. replacing block-scalar / oddly quoted `title`/`description` with double-quoted forms, or dropping inline comments on those keys. Untouched keys and comments are preserved via the Document API. Existing simple-frontmatter fixtures remain byte-identical (churn guard in `frontmatter-test.ts`).

## Test plan
- [x] `npm run lint && npm test`
- [x] Existing `frontmatter-test.ts` matrix still byte-identical for simple frontmatter
- [x] New coverage: block scalar title, quotes/newlines in description, comments preserved, `--- ` opening fence, `...` terminator
- [x] `markdown-test.ts` coverage for fence detection / replace with trailing space and `...`


Made with [Cursor](https://cursor.com)

## Context

From the post-#987 standards audit: fences were matched as exactly `'---'` (a trailing space or a `...` terminator defeated detection, silently duplicating frontmatter), `title:`/`description:` were rewritten by line-prefix matching (corrupts block scalars and nested keys), and the hand-rolled escaper handled only `\` and `"` — a newline inside a description emitted invalid YAML. The `yaml` package was chosen for its zero transitive dependencies and its Document API, which round-trips untouched keys/comments instead of reformatting the whole block.
