### PR TITLE
fix: prevent container-breaking characters in generated MDX and headings

### DIFF
--- a/lib/config-list.ts
+++ b/lib/config-list.ts
@@ -30,7 +30,7 @@ function configToDescription(config: Config): string | undefined {
   );
 }
 
-function generateConfigListMarkdown(context: Context): string {
+function generateConfigListMarkdown(context: Context, isMdx: boolean): string {
   const { configsToRules, options, plugin } = context;
   const { configEmojis, ignoreConfig } = options;
 
@@ -60,7 +60,7 @@ function generateConfigListMarkdown(context: Context): string {
   ];
 
   return markdownTable(
-    sanitizeMarkdownTable(rows),
+    sanitizeMarkdownTable(rows, isMdx),
     { align: 'l' }, // Left-align headers.
   );
 }
@@ -106,7 +106,7 @@ export function updateConfigsList(
   const postList = markdown.slice(Math.max(0, listEndIndex));
 
   // New config list.
-  const list = generateConfigListMarkdown(context);
+  const list = generateConfigListMarkdown(context, isMdx);
 
   return `${preList}${formattedConfigListMarkerBegin}\n\n${list}\n\n${formattedConfigListMarkerEnd}${postList}`;
 }

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -29,6 +29,7 @@ import { getContext } from './context.js';
 import { createEndOfLineResolver, normalizeEndOfLine } from './eol.js';
 import { generateSuggestedEmojis } from './suggest-emojis.js';
 import { generateFrontmatterLines } from './frontmatter.js';
+import { sanitizeMarkdownHeading } from './string.js';
 
 function isMdx(path: string): boolean {
   return extname(path).toLowerCase() === '.mdx';
@@ -79,9 +80,14 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     pathRuleList,
     postprocess,
     ruleDocSectionExclude,
-    ruleDocSectionInclude,
+    ruleDocSectionInclude: ruleDocSectionIncludeRaw,
     ruleDocSectionOptions,
   } = options;
+
+  // Strip embedded newlines so init headings and section checks stay aligned.
+  const ruleDocSectionInclude = ruleDocSectionIncludeRaw.map((title) =>
+    sanitizeMarkdownHeading(title),
+  );
 
   if (suggestEmojis) {
     await generateSuggestedEmojis(context);

--- a/lib/rule-list.ts
+++ b/lib/rule-list.ts
@@ -22,7 +22,11 @@ import { markdownTable } from 'markdown-table';
 import { EMOJIS_TYPE } from './rule-type.js';
 import { hasOptions } from './rule-options.js';
 import { getLinkToRule } from './rule-link.js';
-import { capitalizeOnlyFirstLetter, sanitizeMarkdownTable } from './string.js';
+import {
+  capitalizeOnlyFirstLetter,
+  sanitizeMarkdownHeading,
+  sanitizeMarkdownTable,
+} from './string.js';
 import { noCase } from 'change-case';
 import { getProperty } from 'dot-prop';
 import { boolean, isBooleanable } from './boolean.js';
@@ -146,6 +150,7 @@ function generateRulesListMarkdown(
   ruleNamesAndRules: RuleNamesAndRules,
   columns: Record<COLUMN_TYPE, boolean>,
   pathToFile: string,
+  isMdx: boolean,
 ): string {
   const listHeaderRow = (
     Object.entries(columns) as readonly [COLUMN_TYPE, boolean][]
@@ -162,12 +167,15 @@ function generateRulesListMarkdown(
   });
 
   return markdownTable(
-    sanitizeMarkdownTable([
-      listHeaderRow,
-      ...ruleNamesAndRules.map(([name, rule]) =>
-        buildRuleRow(context, name, rule, columns, pathToFile),
-      ),
-    ]),
+    sanitizeMarkdownTable(
+      [
+        listHeaderRow,
+        ...ruleNamesAndRules.map(([name, rule]) =>
+          buildRuleRow(context, name, rule, columns, pathToFile),
+        ),
+      ],
+      isMdx,
+    ),
     { align: 'l' }, // Left-align headers.
   );
 }
@@ -185,17 +193,22 @@ function generateRuleListMarkdownForRulesAndHeaders(
   headerLevel: number,
   columns: Record<COLUMN_TYPE, boolean>,
   pathToFile: string,
+  isMdx: boolean,
 ): string {
   const parts: string[] = [];
 
   for (const { title, rules, description } of rulesAndHeaders) {
     if (title) {
-      parts.push(`${'#'.repeat(headerLevel)} ${title}`);
+      parts.push(
+        `${'#'.repeat(headerLevel)} ${sanitizeMarkdownHeading(title)}`,
+      );
     }
     if (description) {
       parts.push(description);
     }
-    parts.push(generateRulesListMarkdown(context, rules, columns, pathToFile));
+    parts.push(
+      generateRulesListMarkdown(context, rules, columns, pathToFile, isMdx),
+    );
   }
 
   return parts.join('\n\n');
@@ -435,6 +448,7 @@ export function updateRulesList(
     ruleListSplitHeaderLevel,
     columns,
     pathToFile,
+    isMdx,
   );
 
   const newContent = `${legend ? `${legend}\n\n` : ''}${list}`;

--- a/lib/rule-options-list.ts
+++ b/lib/rule-options-list.ts
@@ -112,7 +112,10 @@ function ruleOptionsToColumnsToDisplay(ruleOptions: readonly RuleOption[]): {
   return columnsToDisplay;
 }
 
-function generateRuleOptionsListMarkdown(rule: RuleModule): string {
+function generateRuleOptionsListMarkdown(
+  rule: RuleModule,
+  isMdx: boolean,
+): string {
   const ruleOptions = getAllNamedOptions(
     rule.meta?.schema,
     rule.meta?.defaultOptions,
@@ -141,7 +144,7 @@ function generateRuleOptionsListMarkdown(rule: RuleModule): string {
     });
 
   return markdownTable(
-    sanitizeMarkdownTable([listHeaderRow, ...rows]),
+    sanitizeMarkdownTable([listHeaderRow, ...rows], isMdx),
     { align: 'l' }, // Left-align headers.
   );
 }
@@ -175,7 +178,7 @@ export function updateRuleOptionsList(
   const postList = markdown.slice(Math.max(0, listEndIndex));
 
   // New rule options list.
-  const list = generateRuleOptionsListMarkdown(rule);
+  const list = generateRuleOptionsListMarkdown(rule, isMdx);
 
   return `${preList}${formattedRuleOptionsListMarkerBegin}\n\n${list}\n\n${formattedRuleOptionsListMarkerEnd}${postList}`;
 }

--- a/lib/string.ts
+++ b/lib/string.ts
@@ -23,13 +23,38 @@ export function capitalizeOnlyFirstLetter(str: string) {
   return upperFirst(str.toLowerCase());
 }
 
-function sanitizeMarkdownTableCell(text: string): string {
+/**
+ * Neutralize characters that would be parsed as JSX / expressions in MDX.
+ * `{` must be replaced before `<` so the braces introduced for `<` are not
+ * re-escaped.
+ */
+function sanitizeMdxText(text: string): string {
+  return text.replaceAll('{', "{'{'}").replaceAll('<', "{'<'}");
+}
+
+/**
+ * Strip embedded newlines so an interpolated value cannot fork an ATX heading.
+ */
+export function sanitizeMarkdownHeading(text: string): string {
+  return text.replaceAll(/\r?\n/gu, '');
+}
+
+function sanitizeMarkdownTableCell(text: string, isMdx: boolean): string {
   // Handle CRLF line endings too since cell text can come from rule metadata.
-  return text.replaceAll('|', String.raw`\|`).replaceAll(/\r?\n/gu, '<br/>');
+  // Escape MDX-sensitive characters before inserting `<br/>` so the break tag
+  // itself is not neutralized.
+  let result = text.replaceAll('|', String.raw`\|`);
+  if (isMdx) {
+    result = sanitizeMdxText(result);
+  }
+  return result.replaceAll(/\r?\n/gu, '<br/>');
 }
 
 export function sanitizeMarkdownTable(
   text: readonly (readonly string[])[],
+  isMdx = false,
 ): readonly (readonly string[])[] {
-  return text.map((row) => row.map((col) => sanitizeMarkdownTableCell(col)));
+  return text.map((row) =>
+    row.map((col) => sanitizeMarkdownTableCell(col, isMdx)),
+  );
 }

--- a/test/lib/generate/__snapshots__/file-paths-test.ts.snap
+++ b/test/lib/generate/__snapshots__/file-paths-test.ts.snap
@@ -83,6 +83,15 @@ exports[`generate (file paths) > missing rule doc with initRuleDocs > when initR
 "
 `;
 
+exports[`generate (file paths) > missing rule doc, initRuleDocs is true, and ruleDocSectionInclude title contains a newline > creates the rule doc with a single intact heading line 1`] = `
+"# test/no-bar
+
+<!-- end auto-generated rule header -->
+
+## Examples
+"
+`;
+
 exports[`generate (file paths) > missing rule doc, initRuleDocs is true, and with ruleDocSectionInclude > creates the rule doc including the mandatory section 1`] = `
 "# test/no-foo
 

--- a/test/lib/generate/__snapshots__/option-rule-list-split-test.ts.snap
+++ b/test/lib/generate/__snapshots__/option-rule-list-split-test.ts.snap
@@ -74,6 +74,28 @@ This is the "no-baz" rule.
 "
 `;
 
+exports[`generate (--rule-list-split) > as a function with title containing a newline > keeps the heading on a single line 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+❌ Deprecated.
+
+### Deprecatedrules
+
+| Name                           | ❌  |
+| :----------------------------- | :- |
+| [no-foo](docs/rules/no-foo.md) | ❌  |
+
+### Otherrules
+
+| Name                           | ❌  |
+| :----------------------------- | :- |
+| [no-bar](docs/rules/no-bar.md) |    |
+
+<!-- end auto-generated rules list -->
+"
+`;
+
 exports[`generate (--rule-list-split) > by nested property meta.docs.category > splits the list 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->

--- a/test/lib/generate/__snapshots__/rule-description-test.ts.snap
+++ b/test/lib/generate/__snapshots__/rule-description-test.ts.snap
@@ -99,6 +99,29 @@ exports[`generate (rule descriptions) > rule with long-enough description to req
 "
 `;
 
+exports[`generate (rule descriptions) > with rule description containing MDX container characters > for md files > leaves angle brackets and braces unescaped 1`] = `
+"## Rules
+<!-- begin auto-generated rules list -->
+
+| Name                           | Description               |
+| :----------------------------- | :------------------------ |
+| [no-foo](docs/rules/no-foo.md) | Disallow <Foo> and {bar}. |
+
+<!-- end auto-generated rules list -->
+"
+`;
+
+exports[`generate (rule descriptions) > with rule description containing MDX container characters > for mdx files > neutralizes angle brackets and braces for MDX 1`] = `
+"## Rules
+{/* begin auto-generated rules list */}
+
+| Name                           | Description                       |
+| :----------------------------- | :-------------------------------- |
+| [no-foo](docs/rules/no-foo.md) | Disallow {'<'}Foo> and {'{'}bar}. |
+
+{/* end auto-generated rules list */}"
+`;
+
 exports[`generate (rule descriptions) > with rule description that needs to be escaped in table > generates the documentation 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->

--- a/test/lib/generate/__snapshots__/rule-options-list-test.ts.snap
+++ b/test/lib/generate/__snapshots__/rule-options-list-test.ts.snap
@@ -110,6 +110,20 @@ exports[`generate (rule options list) > for mdx files > displays default column 
 {/* end auto-generated rule options list */}"
 `;
 
+exports[`generate (rule options list) > for mdx files > with description containing MDX container characters > neutralizes angle brackets and braces for MDX 1`] = `
+"# test/no-foo
+
+{/* end auto-generated rule header */}
+## Options
+{/* begin auto-generated rule options list */}
+
+| Name  | Description                       | Type    |
+| :---- | :-------------------------------- | :------ |
+| \`foo\` | Disallow {'<'}Foo> and {'{'}bar}. | Boolean |
+
+{/* end auto-generated rule options list */}"
+`;
+
 exports[`generate (rule options list) > for mdx files > with no marker comments > generates the documentation 1`] = `
 "# test/no-foo
 

--- a/test/lib/generate/file-paths-test.ts
+++ b/test/lib/generate/file-paths-test.ts
@@ -130,6 +130,45 @@ describe('generate (file paths)', function () {
     });
   });
 
+  describe('missing rule doc, initRuleDocs is true, and ruleDocSectionInclude title contains a newline', function () {
+    let fixture: FixtureContext;
+
+    beforeAll(async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'index.js': `
+          export default {
+            rules: {
+              // Use a rule name without a pre-existing doc in the esm-base fixture.
+              'no-bar': {
+                meta: { },
+                create(context) {}
+              },
+            },
+          };`,
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
+        },
+      });
+    });
+
+    afterAll(async function () {
+      await fixture.cleanup();
+    });
+
+    it('creates the rule doc with a single intact heading line', async function () {
+      await generate(fixture.path, {
+        initRuleDocs: true,
+        ruleDocSectionInclude: ['Exam\nples'],
+      });
+      const doc = await fixture.readFile('docs/rules/no-bar.md');
+      expect(doc).toContain('## Examples');
+      expect(doc).not.toMatch(/^## Exam$/mu);
+      expect(doc).toMatchSnapshot();
+    });
+  });
+
   describe('no missing rule doc but --init-rule-docs enabled', function () {
     let fixture: FixtureContext;
 

--- a/test/lib/generate/option-rule-list-split-test.ts
+++ b/test/lib/generate/option-rule-list-split-test.ts
@@ -691,6 +691,52 @@ describe('generate (--rule-list-split)', function () {
     });
   });
 
+  describe('as a function with title containing a newline', function () {
+    let fixture: FixtureContext;
+
+    beforeAll(async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'index.js': `
+          export default {
+            rules: {
+              'no-foo': { meta: { deprecated: true, }, create(context) {} },
+              'no-bar': { meta: { deprecated: false, }, create(context) {} },
+            },
+          };`,
+          'README.md': '## Rules\n',
+          'docs/rules/no-foo.md': '',
+          'docs/rules/no-bar.md': '',
+        },
+      });
+    });
+
+    afterAll(async function () {
+      await fixture.cleanup();
+    });
+
+    it('keeps the heading on a single line', async function () {
+      await generate(fixture.path, {
+        ruleListSplit: (rules) => [
+          {
+            title: 'Deprecated\nrules',
+            rules: rules.filter(([, rule]) => rule.meta.deprecated),
+          },
+          {
+            title: 'Other\r\nrules',
+            rules: rules.filter(([, rule]) => !rule.meta.deprecated),
+          },
+        ],
+      });
+      const readme = await fixture.readFile('README.md');
+      expect(readme).toContain('### Deprecatedrules');
+      expect(readme).toContain('### Otherrules');
+      expect(readme).not.toMatch(/^### Deprecated$/mu);
+      expect(readme).toMatchSnapshot();
+    });
+  });
+
   describe('as a function but invalid return value', function () {
     let fixture: FixtureContext;
 

--- a/test/lib/generate/rule-description-test.ts
+++ b/test/lib/generate/rule-description-test.ts
@@ -199,4 +199,80 @@ describe('generate (rule descriptions)', () => {
       expect(await fixture.readFile('README.md')).toMatchSnapshot();
     });
   });
+
+  describe('with rule description containing MDX container characters', () => {
+    describe('for md files', () => {
+      let fixture: FixtureContext;
+
+      beforeAll(async () => {
+        fixture = await setupFixture({
+          fixture: 'esm-base',
+          overrides: {
+            'index.js': `
+            export default {
+              rules: {
+                'no-foo': {
+                  meta: { docs: { description: 'Disallow <Foo> and {bar}.'} },
+                  create(context) {},
+                },
+              },
+            };`,
+            'README.md': '## Rules\n',
+            'docs/rules/no-foo.md': '',
+          },
+        });
+      });
+
+      afterAll(async () => {
+        await fixture.cleanup();
+      });
+
+      it('leaves angle brackets and braces unescaped', async () => {
+        await generate(fixture.path);
+        const readme = await fixture.readFile('README.md');
+        expect(readme).toContain('Disallow <Foo> and {bar}.');
+        expect(readme).not.toContain("{'<'}");
+        expect(readme).not.toContain("{'{'}");
+        expect(readme).toMatchSnapshot();
+      });
+    });
+
+    describe('for mdx files', () => {
+      let fixture: FixtureContext;
+
+      beforeAll(async () => {
+        fixture = await setupFixture({
+          fixture: 'esm-base-mdx',
+          overrides: {
+            'index.js': `
+            export default {
+              rules: {
+                'no-foo': {
+                  meta: { docs: { description: 'Disallow <Foo> and {bar}.'} },
+                  create(context) {},
+                },
+              },
+            };`,
+            'README.mdx': `## Rules
+{/* begin auto-generated rules list */}
+{/* end auto-generated rules list */}`,
+            'docs/rules/no-foo.mdx': '',
+          },
+        });
+      });
+
+      afterAll(async () => {
+        await fixture.cleanup();
+      });
+
+      it('neutralizes angle brackets and braces for MDX', async () => {
+        await generate(fixture.path, { pathRuleList: 'README.mdx' });
+        const readme = await fixture.readFile('README.mdx');
+        expect(readme).toContain("Disallow {'<'}Foo> and {'{'}bar}.");
+        expect(readme).not.toContain('<Foo>');
+        expect(readme).not.toContain('{bar}');
+        expect(readme).toMatchSnapshot();
+      });
+    });
+  });
 });

--- a/test/lib/generate/rule-options-list-test.ts
+++ b/test/lib/generate/rule-options-list-test.ts
@@ -676,5 +676,50 @@ describe('generate (rule options list)', function () {
         ).toMatchSnapshot();
       });
     });
+
+    describe('with description containing MDX container characters', function () {
+      let fixture: FixtureContext;
+
+      beforeAll(async function () {
+        fixture = await setupFixture({
+          fixture: 'esm-base-mdx',
+          overrides: {
+            'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: {
+                  schema: [{ type: "object", properties: { foo: { description: 'Disallow <Foo> and {bar}.', type: 'boolean' } } }]
+                },
+                create(context) {}
+              },
+            },
+          };`,
+            'README.md': '## Rules\n',
+            'docs/rules/no-foo.mdx': `## Options
+{/* begin auto-generated rule options list */}
+{/* end auto-generated rule options list */}`,
+          },
+        });
+      });
+
+      afterAll(async function () {
+        await fixture.cleanup();
+      });
+
+      it('neutralizes angle brackets and braces for MDX', async function () {
+        const consoleErrorStub = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {});
+        await generate(fixture.path);
+        expect(consoleErrorStub.mock.calls.length).toBe(0);
+        consoleErrorStub.mockRestore();
+        const doc = await fixture.readFile('docs/rules/no-foo.mdx');
+        expect(doc).toContain("Disallow {'<'}Foo> and {'{'}bar}.");
+        expect(doc).not.toContain('<Foo>');
+        expect(doc).not.toContain('{bar}');
+        expect(doc).toMatchSnapshot();
+      });
+    });
   });
 });

--- a/test/lib/string-test.ts
+++ b/test/lib/string-test.ts
@@ -1,6 +1,8 @@
 import {
   addTrailingPeriod,
   removeTrailingPeriod,
+  sanitizeMarkdownHeading,
+  sanitizeMarkdownTable,
   toSentenceCase,
 } from '../../lib/string.js';
 
@@ -32,6 +34,38 @@ describe('strings', function () {
 
     it('handles when uppercase first letter', function () {
       expect(toSentenceCase('Hello World')).toStrictEqual('Hello World');
+    });
+  });
+
+  describe('#sanitizeMarkdownHeading', function () {
+    it('strips embedded newlines', function () {
+      expect(sanitizeMarkdownHeading('Foo\nBar')).toStrictEqual('FooBar');
+      expect(sanitizeMarkdownHeading('Foo\r\nBar')).toStrictEqual('FooBar');
+    });
+  });
+
+  describe('#sanitizeMarkdownTable', function () {
+    it('escapes pipes and converts newlines for plain markdown', function () {
+      expect(sanitizeMarkdownTable([['a|b', 'line1\nline2']])).toStrictEqual([
+        [String.raw`a\|b`, 'line1<br/>line2'],
+      ]);
+    });
+
+    it('neutralizes MDX container characters without breaking br tags', function () {
+      expect(
+        sanitizeMarkdownTable(
+          [['Disallow <Foo> and {bar}', 'line1\nline2']],
+          true,
+        ),
+      ).toStrictEqual([
+        ["Disallow {'<'}Foo> and {'{'}bar}", 'line1<br/>line2'],
+      ]);
+    });
+
+    it('leaves MDX characters alone for plain markdown', function () {
+      expect(
+        sanitizeMarkdownTable([['Disallow <Foo> and {bar}']]),
+      ).toStrictEqual([['Disallow <Foo> and {bar}']]);
     });
   });
 });


### PR DESCRIPTION
## Summary
- In `.mdx` outputs only, neutralize `<` → `{'<'}` and `{` → `{'{'}` in table cell metadata (descriptions, option fields, config fields) so JSX/expression parsing cannot break consumer docs builds
- Strip embedded newlines from values interpolated into ATX headings (split-list titles and `--init-rule-docs` section titles) so a heading cannot fork the document
- Plain `.md` table output stays byte-identical for these characters; intentional `<br/>` line breaks in cells are preserved

## Test plan
- [x] `npm run lint`
- [x] `npm test`
- [x] MDX rule-list + rule-options fixtures with `<Foo>` / `{bar}` emit neutralized forms
- [x] `.md` fixtures with the same characters remain unescaped
- [x] Split-list / init section titles containing `\n` produce a single intact heading line


Made with [Cursor](https://cursor.com)

## Context

Scope decision recorded here for reviewers — **container protection only**, the same rationale as the existing `|` escaping: in `.mdx`, ordinary prose like "Disallow `<marquee>` elements" is parsed as JSX and hard-fails the consumer's docs build, and a newline in a heading value forks the document the way it would fork a table row.

Deliberately **out of scope** (please don't expand in review): escaping backticks/emphasis/links/raw HTML in `.md`, leading-`#` guards, and notice/deprecation-message text — inline markdown in rule metadata is a supported feature that plugins rely on, and a general escaper would regress rendered docs across the ecosystem.
