### PR TITLE
fix: preserve UTF-8 BOM and parse BOM-prefixed markdown correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,8 @@ When EditorConfig sets `end_of_line`, files that use a different end of line are
 
 EditorConfig [`insert_final_newline`](https://editorconfig.org/) is honored the same way when explicitly set for a file path: `true` ensures the file ends with one trailing end of line (existing trailing blank lines are left alone), and `false` strips trailing ends of line. When unset, the final-newline state is left unchanged (byte-identical to previous behavior). `--check` compares post-policy bytes, so a mismatch fails until the next non-check run fixes the file.
 
+A leading UTF-8 BOM (`U+FEFF`) is stripped for markdown processing and re-prepended on write when the original file had one, so title/frontmatter parsing and `--check` stay BOM-faithful. EditorConfig `charset = utf-8-bom` is not used to *add* a BOM to files that lack one.
+
 ### File Types
 
 This tool supports both regular Markdown (`md`) and Extended Markdown (`mdx`) file types.

--- a/lib/eol.ts
+++ b/lib/eol.ts
@@ -111,6 +111,30 @@ async function parseEditorConfigLineEndingProps(
   return { endOfLine, insertFinalNewline };
 }
 
+const UTF8_BOM = '\uFEFF';
+
+/**
+ * Detect and strip a leading UTF-8 BOM for processing.
+ * Markdown is processed BOM-free; restore with {@link restoreBom} at write time.
+ */
+export function stripBom(contents: string): {
+  hasBom: boolean;
+  contents: string;
+} {
+  if (contents.startsWith(UTF8_BOM)) {
+    return { hasBom: true, contents: contents.slice(UTF8_BOM.length) };
+  }
+  return { hasBom: false, contents };
+}
+
+/**
+ * Re-prepend a UTF-8 BOM when the original file had one.
+ * Call after EOL normalization and `insert_final_newline` policy.
+ */
+export function restoreBom(contents: string, hasBom: boolean): string {
+  return hasBom ? `${UTF8_BOM}${contents}` : contents;
+}
+
 /**
  * Apply EditorConfig `insert_final_newline` at write time.
  * When unset (`undefined`), returns contents unchanged.

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -30,6 +30,8 @@ import {
   applyInsertFinalNewline,
   createEndOfLineResolver,
   normalizeEndOfLine,
+  restoreBom,
+  stripBom,
 } from './eol.js';
 import { generateSuggestedEmojis } from './suggest-emojis.js';
 import { generateFrontmatterLines } from './frontmatter.js';
@@ -184,7 +186,10 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     }
 
     const isRuleDocMdx = isMdx(pathToDoc);
-    const contentsOld = await readFile(pathToDoc, 'utf8');
+    const contentsOldRaw = await readFile(pathToDoc, 'utf8');
+    // Strip BOM for processing; restore before write/check so title/frontmatter
+    // parsing sees line 0 correctly and existing BOMs are preserved.
+    const { hasBom, contents: contentsOld } = stripBom(contentsOldRaw);
 
     // Normalize to LF for processing; restore this file's end of line before write.
     const endOfLine = await endOfLineResolver.resolve(pathToDoc, contentsOld);
@@ -226,20 +231,24 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
       endOfLine,
       await endOfLineResolver.getInsertFinalNewline(pathToDoc),
     );
+    contentsNew = restoreBom(contentsNew, hasBom);
 
-    // LF-normalized copy of the final contents for the content checks below.
-    const contentsNewNormalized = normalizeEndOfLine(contentsNew, '\n');
+    // LF-normalized, BOM-free copy of the final contents for the content checks below.
+    const contentsNewNormalized = normalizeEndOfLine(
+      stripBom(contentsNew).contents,
+      '\n',
+    );
 
     if (check) {
       /* istanbul ignore next -- V8 branch coverage doesn't detect this branch is tested */
-      if (contentsNew !== contentsOld) {
+      if (contentsNew !== contentsOldRaw) {
         console.error(
           `Please run eslint-doc-generator. A rule doc is out-of-date: ${relative(
             getPluginRoot(path),
             pathToDoc,
           )}`,
         );
-        console.error(diff(contentsNew, contentsOld, { expand: false }));
+        console.error(diff(contentsNew, contentsOldRaw, { expand: false }));
         process.exitCode = 1;
       }
     } else {
@@ -311,7 +320,8 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
     const isRuleListMdx = isMdx(pathToFile);
 
     // Update the rules list in this file.
-    const fileContents = await readFile(pathToFile, 'utf8');
+    const fileContentsRaw = await readFile(pathToFile, 'utf8');
+    const { hasBom, contents: fileContents } = stripBom(fileContentsRaw);
 
     // Normalize to LF for processing; restore this file's end of line before write.
     const endOfLine = await endOfLineResolver.resolve(pathToFile, fileContents);
@@ -323,28 +333,33 @@ export async function generate(path: string, userOptions?: GenerateOptions) {
       fileContentsNormalized,
       pathToFile,
     );
-    const fileContentsNew = applyInsertFinalNewline(
-      await postprocess(
-        normalizeEndOfLine(
-          updateConfigsList(context, rulesList, isRuleListMdx),
-          endOfLine,
+    const fileContentsNew = restoreBom(
+      applyInsertFinalNewline(
+        await postprocess(
+          normalizeEndOfLine(
+            updateConfigsList(context, rulesList, isRuleListMdx),
+            endOfLine,
+          ),
+          resolve(pathToFile),
         ),
-        resolve(pathToFile),
+        endOfLine,
+        await endOfLineResolver.getInsertFinalNewline(pathToFile),
       ),
-      endOfLine,
-      await endOfLineResolver.getInsertFinalNewline(pathToFile),
+      hasBom,
     );
 
     if (check) {
       /* istanbul ignore next -- V8 branch coverage doesn't detect this branch is tested */
-      if (fileContentsNew !== fileContents) {
+      if (fileContentsNew !== fileContentsRaw) {
         console.error(
           `Please run eslint-doc-generator. The rules table in ${relative(
             getPluginRoot(path),
             pathToFile,
           )} is out-of-date.`,
         );
-        console.error(diff(fileContentsNew, fileContents, { expand: false }));
+        console.error(
+          diff(fileContentsNew, fileContentsRaw, { expand: false }),
+        );
         process.exitCode = 1;
       }
     } else {

--- a/test/lib/generate/bom-test.ts
+++ b/test/lib/generate/bom-test.ts
@@ -1,0 +1,249 @@
+import { generate } from '../../../lib/generator.js';
+import { restoreBom, stripBom } from '../../../lib/eol.js';
+import { setupFixture, type FixtureContext } from '../../helpers/fixture.js';
+
+const BOM = '\uFEFF';
+
+function countBom(contents: string): number {
+  return contents.split(BOM).length - 1;
+}
+
+function countFrontmatterFences(contents: string): number {
+  return stripBom(contents)
+    .contents.split('\n')
+    .filter((line) => line === '---').length;
+}
+
+describe('stripBom / restoreBom', function () {
+  it('detects and strips a leading UTF-8 BOM', function () {
+    expect(stripBom(`${BOM}# Title\n`)).toStrictEqual({
+      hasBom: true,
+      contents: '# Title\n',
+    });
+  });
+
+  it('leaves BOM-free contents unchanged', function () {
+    expect(stripBom('# Title\n')).toStrictEqual({
+      hasBom: false,
+      contents: '# Title\n',
+    });
+  });
+
+  it('restores a BOM only when requested', function () {
+    expect(restoreBom('# Title\n', true)).toStrictEqual(`${BOM}# Title\n`);
+    expect(restoreBom('# Title\n', false)).toStrictEqual('# Title\n');
+  });
+});
+
+describe('generate (UTF-8 BOM)', function () {
+  describe('BOM + title', function () {
+    let fixture: FixtureContext;
+
+    beforeAll(async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'index.js': `
+            export default {
+              rules: {
+                'no-foo': { meta: { docs: { description: 'Description for no-foo.'} }, create(context) {} },
+              },
+            };`,
+          'README.md': '## Rules\n',
+          'docs/rules/no-foo.md': `${BOM}# stale title
+<!-- end auto-generated rule header -->
+## Rule details
+Details.
+`,
+        },
+      });
+    });
+
+    afterAll(async function () {
+      await fixture.cleanup();
+    });
+
+    it('preserves the BOM and regenerates a single header', async function () {
+      await generate(fixture.path, { ruleDocTitleFormat: 'name' });
+
+      const ruleDoc = await fixture.readFile('docs/rules/no-foo.md');
+      expect(ruleDoc.startsWith(BOM)).toBe(true);
+      expect(countBom(ruleDoc)).toBe(1);
+      const ruleDocWithoutBom = stripBom(ruleDoc).contents;
+      expect(ruleDocWithoutBom).toContain('# no-foo');
+      expect(ruleDocWithoutBom).not.toContain('stale title');
+      expect(ruleDocWithoutBom.match(/^# /gmu)?.length).toBe(1);
+    });
+  });
+
+  describe('BOM + frontmatter + title', function () {
+    let fixture: FixtureContext;
+
+    beforeAll(async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'index.js': `
+            export default {
+              rules: {
+                'no-foo': { meta: { docs: { description: 'Description for no-foo.'} }, create(context) {} },
+              },
+            };`,
+          'README.md': '## Rules\n',
+          'docs/rules/no-foo.md': `${BOM}---
+title: No Foo
+description: Description for no-foo.
+---
+# stale title
+<!-- end auto-generated rule header -->
+## Rule details
+Details.
+`,
+        },
+      });
+    });
+
+    afterAll(async function () {
+      await fixture.cleanup();
+    });
+
+    it('preserves BOM and existing frontmatter with a single header', async function () {
+      await generate(fixture.path, {
+        framework: 'none',
+        ruleDocTitleFormat: 'name',
+      });
+
+      const ruleDoc = await fixture.readFile('docs/rules/no-foo.md');
+      expect(ruleDoc.startsWith(BOM)).toBe(true);
+      expect(countBom(ruleDoc)).toBe(1);
+      expect(countFrontmatterFences(ruleDoc)).toBe(2);
+      expect(ruleDoc).toContain('title: No Foo');
+      expect(ruleDoc).toContain('# no-foo');
+      expect(ruleDoc).not.toContain('stale title');
+    });
+  });
+
+  describe('BOM + framework frontmatter', function () {
+    let fixture: FixtureContext;
+
+    beforeAll(async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'index.js': `
+            export default {
+              rules: {
+                'no-foo': { meta: { docs: { description: 'Description for no-foo.'} }, create(context) {} },
+              },
+            };`,
+          'README.md': '## Rules\n',
+          // starlight generates/updates frontmatter; without BOM stripping, line 0 is
+          // "\uFEFF---" so existing frontmatter is missed and a duplicate block is prepended.
+          'docs/rules/no-foo.md': `${BOM}---
+title: "stale"
+description: "stale description"
+---
+## Rule details
+Details.
+`,
+        },
+      });
+    });
+
+    afterAll(async function () {
+      await fixture.cleanup();
+    });
+
+    it('updates existing frontmatter without duplicating it', async function () {
+      await generate(fixture.path, {
+        framework: 'starlight',
+        ruleDocTitleFormat: 'name',
+      });
+
+      const ruleDoc = await fixture.readFile('docs/rules/no-foo.md');
+      expect(ruleDoc.startsWith(BOM)).toBe(true);
+      expect(countBom(ruleDoc)).toBe(1);
+      expect(countFrontmatterFences(ruleDoc)).toBe(2);
+      expect(ruleDoc).toContain('title: "no-foo"');
+      expect(ruleDoc).toContain('description: "Description for no-foo."');
+      expect(ruleDoc).not.toContain('stale');
+    });
+  });
+
+  describe('BOM in README rules-list file', function () {
+    let fixture: FixtureContext;
+
+    beforeAll(async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'index.js': `
+            export default {
+              rules: {
+                'no-foo': { meta: { docs: { description: 'Description for no-foo.'} }, create(context) {} },
+              },
+            };`,
+          'README.md': `${BOM}## Rules
+`,
+          'docs/rules/no-foo.md': '# no-foo\n',
+        },
+      });
+    });
+
+    afterAll(async function () {
+      await fixture.cleanup();
+    });
+
+    it('preserves the README BOM when updating the rules list', async function () {
+      await generate(fixture.path, { ruleDocTitleFormat: 'name' });
+
+      const readme = await fixture.readFile('README.md');
+      expect(readme.startsWith(BOM)).toBe(true);
+      expect(countBom(readme)).toBe(1);
+      expect(readme).toContain('begin auto-generated rules list');
+      expect(readme).toContain('no-foo');
+    });
+  });
+
+  describe('--check with up-to-date BOM files', function () {
+    let fixture: FixtureContext;
+
+    beforeAll(async function () {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'index.js': `
+            export default {
+              rules: {
+                'no-foo': { meta: { docs: { description: 'Description for no-foo.'} }, create(context) {} },
+              },
+            };`,
+          'README.md': `${BOM}## Rules
+`,
+          'docs/rules/no-foo.md': `${BOM}# stale
+`,
+        },
+      });
+    });
+
+    afterAll(async function () {
+      await fixture.cleanup();
+    });
+
+    it('passes when BOM-prefixed files are already up-to-date', async function () {
+      await generate(fixture.path, { ruleDocTitleFormat: 'name' });
+
+      const ruleDoc = await fixture.readFile('docs/rules/no-foo.md');
+      const readme = await fixture.readFile('README.md');
+      expect(ruleDoc.startsWith(BOM)).toBe(true);
+      expect(readme.startsWith(BOM)).toBe(true);
+
+      process.exitCode = undefined;
+      await generate(fixture.path, {
+        check: true,
+        ruleDocTitleFormat: 'name',
+      });
+      expect(process.exitCode).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Depends on #998 (`feat/insert-final-newline`). **Retarget this PR to `main` once #998 merges.**
- Strip a leading UTF-8 BOM on read (rule docs and rules-list files), process markdown BOM-free, then re-prepend the BOM after EOL / `insert_final_newline` policy so existing BOMs are preserved and `--check` compares BOM-faithful bytes.
- Fixes title regex misses when line 0 is `BOM# Title`, and duplicate frontmatter when line 0 is `BOM---` under framework frontmatter generation (starlight).

## Out of scope
- Honoring EditorConfig `charset = utf-8-bom` to *add* a BOM to files that lack one. This PR only preserves BOMs that already exist.

## Test plan
- [x] `npm run lint && npm test`
- [x] New `test/lib/generate/bom-test.ts`: BOM + title; BOM + frontmatter + title; BOM + starlight frontmatter (no duplicate); BOM in README rules list; `--check` passes on up-to-date BOM'd files


Made with [Cursor](https://cursor.com)